### PR TITLE
fix(ci): add zmf checkout to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.release-please.outputs.tag_name }}
+      - uses: actions/checkout@v4
+        with:
+          repository: zerfoo/zmf
+          path: zmf-checkout
+      - name: Link zmf as sibling directory
+        run: ln -s "$GITHUB_WORKSPACE/zmf-checkout" "$GITHUB_WORKSPACE/../zmf"
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
GoReleaser failed on v1.0.0 release because go.mod has `replace github.com/zerfoo/zmf => ../zmf`. Same fix as PR #56 for ci.yml and benchmark.yml — checkout zmf and symlink as sibling.