### PR TITLE
fix(graph): wire RMSNorm fusion into Compile path for ONNX models

### DIFF
--- a/graph/compile.go
+++ b/graph/compile.go
@@ -548,6 +548,9 @@ func (g *Graph[T]) Compile(ctx context.Context, inputs ...*tensor.TensorNumeric[
 		})
 	}
 
+	// Step 6: Apply graph fusion passes.
+	instructions, frozenIdx, slots, slotShapes = FuseRMSNorm(instructions, frozenIdx, slots, slotShapes)
+
 	return &ExecutionPlan[T]{
 		instructions: instructions,
 		slots:        slots,


### PR DESCRIPTION
## Summary
FuseRMSNorm was only called in CompileTraced, but ONNX models use the regular Compile path. This one-line fix adds the fusion step to Compile so decomposed RMSNorm ops are replaced for all model types.

Expected impact: Llama 3 instruction count drops from 1610 to ~1290 (64 fusions x 5 ops eliminated).

## Test plan
- [x] go build ./... passes
- [x] go test ./graph/... -race passes