### PR TITLE
test(layers): verify fused SwiGLU and ScaledSoftmax kernel dispatch

### DIFF
--- a/layers/attention/fused_dispatch_test.go
+++ b/layers/attention/fused_dispatch_test.go
@@ -1,0 +1,169 @@
+package attention
+
+import (
+	"context"
+	"math"
+	"sync/atomic"
+	"testing"
+
+	"github.com/zerfoo/zerfoo/compute"
+	"github.com/zerfoo/zerfoo/numeric"
+	"github.com/zerfoo/zerfoo/tensor"
+)
+
+// fusedScaledSoftmaxEngine wraps a CPUEngine and implements FusedScaledSoftmaxProvider.
+// It records whether GPUScaledSoftmax was called so tests can verify dispatch.
+type fusedScaledSoftmaxEngine struct {
+	compute.Engine[float32]
+	calls atomic.Int64
+}
+
+func (e *fusedScaledSoftmaxEngine) GPUScaledSoftmax(input *tensor.TensorNumeric[float32], scale float32, axis int) (*tensor.TensorNumeric[float32], error) {
+	e.calls.Add(1)
+	// Compute scaled softmax on CPU: softmax(input * scale)
+	data := input.Data()
+	shape := input.Shape()
+	out := make([]float32, len(data))
+	copy(out, data)
+
+	// Scale
+	for i := range out {
+		out[i] *= scale
+	}
+
+	// Softmax along last axis
+	lastDim := shape[len(shape)-1]
+	batches := len(out) / lastDim
+
+	for b := 0; b < batches; b++ {
+		off := b * lastDim
+		row := out[off : off+lastDim]
+
+		maxVal := row[0]
+		for _, v := range row[1:] {
+			if v > maxVal {
+				maxVal = v
+			}
+		}
+		sum := float32(0)
+		for i := range row {
+			row[i] = float32(math.Exp(float64(row[i] - maxVal)))
+			sum += row[i]
+		}
+		for i := range row {
+			row[i] /= sum
+		}
+	}
+
+	return tensor.New(shape, out)
+}
+
+func TestSDPA_FusedScaledSoftmax_Dispatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		batch   int
+		seqLen  int
+		headDim int
+	}{
+		{"small", 1, 1, 4},
+		{"medium", 2, 1, 8},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+			engine := &fusedScaledSoftmaxEngine{Engine: base}
+
+			sdpa := NewScaledDotProductAttention[float32](engine, tc.headDim)
+
+			q, err := tensor.New[float32]([]int{tc.batch, tc.seqLen, tc.headDim}, nil)
+			if err != nil {
+				t.Fatalf("tensor.New Q: %v", err)
+			}
+			k, err := tensor.New[float32]([]int{tc.batch, tc.seqLen, tc.headDim}, nil)
+			if err != nil {
+				t.Fatalf("tensor.New K: %v", err)
+			}
+			v, err := tensor.New[float32]([]int{tc.batch, tc.seqLen, tc.headDim}, nil)
+			if err != nil {
+				t.Fatalf("tensor.New V: %v", err)
+			}
+
+			before := engine.calls.Load()
+			_, err = sdpa.Forward(context.Background(), q, k, v, nil)
+			if err != nil {
+				t.Fatalf("Forward: %v", err)
+			}
+
+			after := engine.calls.Load()
+			if after <= before {
+				t.Errorf("GPUScaledSoftmax was not dispatched: calls before=%d after=%d", before, after)
+			}
+		})
+	}
+}
+
+func TestSDPA_FusedScaledSoftmax_DispatchViaProxy(t *testing.T) {
+	base := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	fused := &fusedScaledSoftmaxEngine{Engine: base}
+	proxy := compute.NewEngineProxy[float32](fused)
+
+	sdpa := NewScaledDotProductAttention[float32](proxy, 4)
+
+	q, _ := tensor.New[float32]([]int{1, 1, 4}, nil)
+	k, _ := tensor.New[float32]([]int{1, 1, 4}, nil)
+	v, _ := tensor.New[float32]([]int{1, 1, 4}, nil)
+
+	before := fused.calls.Load()
+	_, err := sdpa.Forward(context.Background(), q, k, v, nil)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+
+	after := fused.calls.Load()
+	if after <= before {
+		t.Errorf("GPUScaledSoftmax was not dispatched through EngineProxy: calls before=%d after=%d", before, after)
+	}
+}
+
+func TestSDPA_FusedScaledSoftmax_SkippedWithMask(t *testing.T) {
+	base := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	engine := &fusedScaledSoftmaxEngine{Engine: base}
+
+	sdpa := NewScaledDotProductAttention[float32](engine, 4)
+
+	q, _ := tensor.New[float32]([]int{1, 2, 4}, nil)
+	k, _ := tensor.New[float32]([]int{1, 2, 4}, nil)
+	v, _ := tensor.New[float32]([]int{1, 2, 4}, nil)
+	mask, _ := tensor.New[float32]([]int{1, 1, 2, 2}, nil)
+
+	before := engine.calls.Load()
+	_, err := sdpa.Forward(context.Background(), q, k, v, mask)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+
+	after := engine.calls.Load()
+	if after != before {
+		t.Errorf("GPUScaledSoftmax should not be dispatched when mask is present: calls before=%d after=%d", before, after)
+	}
+}
+
+func TestSDPA_FusedScaledSoftmax_FallbackWhenNotAvailable(t *testing.T) {
+	// Plain CPUEngine does not implement FusedScaledSoftmaxProvider.
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	sdpa := NewScaledDotProductAttention[float32](engine, 4)
+
+	q, _ := tensor.New[float32]([]int{1, 1, 4}, nil)
+	k, _ := tensor.New[float32]([]int{1, 1, 4}, nil)
+	v, _ := tensor.New[float32]([]int{1, 1, 4}, nil)
+
+	out, err := sdpa.Forward(context.Background(), q, k, v, nil)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if out == nil {
+		t.Fatal("output is nil")
+	}
+}

--- a/layers/core/fused_dispatch_test.go
+++ b/layers/core/fused_dispatch_test.go
@@ -1,0 +1,131 @@
+package core
+
+import (
+	"context"
+	"math"
+	"sync/atomic"
+	"testing"
+
+	"github.com/zerfoo/zerfoo/compute"
+	"github.com/zerfoo/zerfoo/numeric"
+	"github.com/zerfoo/zerfoo/tensor"
+)
+
+// fusedSwiGLUEngine wraps a CPUEngine and implements FusedSwiGLUProvider.
+// It records whether GPUFusedSwiGLU was called so tests can verify dispatch.
+type fusedSwiGLUEngine struct {
+	compute.Engine[float32]
+	calls atomic.Int64
+}
+
+func (e *fusedSwiGLUEngine) GPUFusedSwiGLU(w1, w3 *tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error) {
+	e.calls.Add(1)
+	// Compute SwiGLU on CPU: output[i] = w1[i] * sigmoid(w1[i]) * w3[i]
+	d1 := w1.Data()
+	d3 := w3.Data()
+	out := make([]float32, len(d1))
+	for i := range d1 {
+		sig := float32(1.0 / (1.0 + math.Exp(-float64(d1[i]))))
+		out[i] = d1[i] * sig * d3[i]
+	}
+	return tensor.New(w1.Shape(), out)
+}
+
+func TestFFN_FusedSwiGLU_Dispatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputDim  int
+		hiddenDim int
+		outputDim int
+		batchSize int
+	}{
+		{"small", 4, 8, 4, 1},
+		{"medium", 8, 16, 8, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+			engine := &fusedSwiGLUEngine{Engine: base}
+
+			ffn, err := NewFFN[float32]("test", engine, &numeric.Float32Ops{},
+				tc.inputDim, tc.hiddenDim, tc.outputDim,
+				WithFFNNoBias[float32](),
+			)
+			if err != nil {
+				t.Fatalf("NewFFN: %v", err)
+			}
+
+			input, err := tensor.New[float32]([]int{tc.batchSize, tc.inputDim}, nil)
+			if err != nil {
+				t.Fatalf("tensor.New: %v", err)
+			}
+
+			before := engine.calls.Load()
+			_, err = ffn.Forward(context.Background(), input)
+			if err != nil {
+				t.Fatalf("Forward: %v", err)
+			}
+
+			after := engine.calls.Load()
+			if after <= before {
+				t.Errorf("GPUFusedSwiGLU was not dispatched: calls before=%d after=%d", before, after)
+			}
+		})
+	}
+}
+
+func TestFFN_FusedSwiGLU_DispatchViaProxy(t *testing.T) {
+	base := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	fused := &fusedSwiGLUEngine{Engine: base}
+	proxy := compute.NewEngineProxy[float32](fused)
+
+	ffn, err := NewFFN[float32]("test", proxy, &numeric.Float32Ops{}, 4, 8, 4,
+		WithFFNNoBias[float32](),
+	)
+	if err != nil {
+		t.Fatalf("NewFFN: %v", err)
+	}
+
+	input, err := tensor.New[float32]([]int{1, 4}, nil)
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+
+	before := fused.calls.Load()
+	_, err = ffn.Forward(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+
+	after := fused.calls.Load()
+	if after <= before {
+		t.Errorf("GPUFusedSwiGLU was not dispatched through EngineProxy: calls before=%d after=%d", before, after)
+	}
+}
+
+func TestFFN_FusedSwiGLU_FallbackWhenNotAvailable(t *testing.T) {
+	// Plain CPUEngine does not implement FusedSwiGLUProvider.
+	// FFN should still work via the unfused path.
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	ffn, err := NewFFN[float32]("test", engine, &numeric.Float32Ops{}, 4, 8, 4,
+		WithFFNNoBias[float32](),
+	)
+	if err != nil {
+		t.Fatalf("NewFFN: %v", err)
+	}
+
+	input, err := tensor.New[float32]([]int{1, 4}, nil)
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+
+	out, err := ffn.Forward(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if out == nil {
+		t.Fatal("output is nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds tests for **SwiGLU fused kernel dispatch** in `layers/core`: verifies that `FFN.Forward` dispatches to `GPUFusedSwiGLU` when the engine implements `FusedSwiGLUProvider`, including through an `EngineProxy`, and falls back to the unfused path when the provider is absent.
- Adds tests for **ScaledSoftmax fused kernel dispatch** in `layers/attention`: verifies that `SDPA.Forward` dispatches to `GPUScaledSoftmax` when available, works through `EngineProxy`, correctly **skips** the fused path when an attention mask is present, and falls back gracefully when the provider is not implemented.

## Test plan

- [x] `go test ./layers/core/... -run FusedSwiGLU`
- [x] `go test ./layers/attention/... -run FusedScaledSoftmax`