### PR TITLE
docs(api): godoc and stability markers on zerfoo public API

### DIFF
--- a/api.go
+++ b/api.go
@@ -16,7 +16,13 @@ import (
 	"github.com/zerfoo/zerfoo/serve"
 )
 
-// Model is a loaded model ready for inference.
+// Model is a loaded language model ready for inference.
+//
+// A Model is created via [Load] and used for text generation, embedding,
+// and tool-call detection. [Model.Close] must be called when the model is no
+// longer needed to release GPU and CPU resources.
+//
+// Stable.
 type Model struct {
 	inner *inference.Model
 
@@ -29,10 +35,13 @@ type Model struct {
 const defaultQuant = "Q4_K_M"
 
 // Load loads a model from a file path or HuggingFace model ID.
+//
 // Paths starting with "/", "./" or "../" are treated as local GGUF files.
 // All other strings are treated as HuggingFace model IDs (e.g. "google/gemma-3-4b"
 // or "google/gemma-3-4b/Q8_0"). If the model is not cached locally it will be
 // downloaded from HuggingFace.
+//
+// Stable.
 func Load(pathOrID string) (*Model, error) {
 	if isLocalPath(pathOrID) {
 		m, err := inference.LoadFile(pathOrID)
@@ -124,6 +133,8 @@ func isLocalPath(s string) bool {
 }
 
 // Chat runs a simple one-shot generation and returns the generated text.
+//
+// Stable.
 func (m *Model) Chat(prompt string) (string, error) {
 	result, err := m.Generate(context.Background(), prompt)
 	if err != nil {
@@ -132,7 +143,9 @@ func (m *Model) Chat(prompt string) (string, error) {
 	return result.Text, nil
 }
 
-// Generate runs generation with options.
+// Generate runs text generation with the given prompt and options.
+//
+// Stable.
 func (m *Model) Generate(ctx context.Context, prompt string, opts ...GenerateOption) (*GenerateResult, error) {
 	var gopts generateOptions
 	for _, o := range opts {
@@ -205,9 +218,12 @@ func (m *Model) Generate(ctx context.Context, prompt string, opts ...GenerateOpt
 	return result, nil
 }
 
-// Embed returns embeddings for the given texts. Each input string is tokenized,
-// its token embeddings are looked up from the model's embedding table,
-// mean-pooled, and L2-normalized.
+// Embed returns embeddings for the given texts.
+//
+// Each input string is tokenized, its token embeddings are looked up from the
+// model's embedding table, mean-pooled, and L2-normalized.
+//
+// Stable.
 func (m *Model) Embed(texts []string) ([]Embedding, error) {
 	if len(texts) == 0 {
 		return nil, nil
@@ -224,11 +240,15 @@ func (m *Model) Embed(texts []string) ([]Embedding, error) {
 }
 
 // Close releases model resources.
+//
+// Stable.
 func (m *Model) Close() error {
 	return m.inner.Close()
 }
 
-// GenerateResult holds the result of a generation.
+// GenerateResult holds the result of a text generation call.
+//
+// Stable.
 type GenerateResult struct {
 	Text       string
 	TokenCount int
@@ -237,11 +257,15 @@ type GenerateResult struct {
 }
 
 // Embedding holds a text embedding vector.
+//
+// Stable.
 type Embedding struct {
 	Vector []float32
 }
 
-// CosineSimilarity computes cosine similarity with another embedding.
+// CosineSimilarity computes the cosine similarity between two embeddings.
+//
+// Stable.
 func (e Embedding) CosineSimilarity(other Embedding) float32 {
 	if len(e.Vector) == 0 || len(e.Vector) != len(other.Vector) {
 		return 0
@@ -271,10 +295,14 @@ type generateOptions struct {
 	schema      *grammar.JSONSchema
 }
 
-// GenerateOption is an option for Generate.
+// GenerateOption configures the behavior of [Model.Generate].
+//
+// Stable.
 type GenerateOption func(*generateOptions)
 
 // WithGenMaxTokens sets the maximum number of tokens to generate.
+//
+// Stable.
 func WithGenMaxTokens(n int) GenerateOption {
 	return func(o *generateOptions) {
 		o.maxTokens = n
@@ -282,13 +310,17 @@ func WithGenMaxTokens(n int) GenerateOption {
 }
 
 // WithGenTemperature sets the sampling temperature.
+//
+// Stable.
 func WithGenTemperature(t float32) GenerateOption {
 	return func(o *generateOptions) {
 		o.temperature = t
 	}
 }
 
-// WithGenTopP sets the top-p sampling parameter.
+// WithGenTopP sets the top-p (nucleus) sampling parameter.
+//
+// Stable.
 func WithGenTopP(p float32) GenerateOption {
 	return func(o *generateOptions) {
 		o.topP = p
@@ -296,15 +328,19 @@ func WithGenTopP(p float32) GenerateOption {
 }
 
 // StreamToken represents a token received during streaming generation.
+//
+// Stable.
 type StreamToken struct {
 	Text string
 	Done bool
 }
 
 // ChatStream starts streaming generation and returns a receive-only channel
-// that yields token strings as they are generated. The channel is closed when
-// generation completes or ctx is cancelled. The error return is non-nil only
-// if startup fails (e.g. the model is not loaded).
+// that yields [StreamToken] values as they are generated. The channel is closed
+// when generation completes or ctx is canceled. The error return is non-nil
+// only if startup fails (e.g. the model is not loaded).
+//
+// Stable.
 func (m *Model) ChatStream(ctx context.Context, prompt string, opts ...GenerateOption) (<-chan StreamToken, error) {
 	if m.inner == nil && m.generateFunc == nil {
 		return nil, fmt.Errorf("model not loaded")
@@ -350,12 +386,11 @@ func (m *Model) ChatStream(ctx context.Context, prompt string, opts ...GenerateO
 			if ctx.Err() != nil {
 				return
 			}
-			tok := word
 			if i < len(words)-1 {
-				tok += " "
+				word += " "
 			}
 			select {
-			case ch <- StreamToken{Text: tok}:
+			case ch <- StreamToken{Text: word}:
 			case <-ctx.Done():
 				return
 			}
@@ -371,6 +406,8 @@ func (m *Model) ChatStream(ctx context.Context, prompt string, opts ...GenerateO
 }
 
 // ToolCall represents a tool invocation detected in model output.
+//
+// Experimental.
 type ToolCall struct {
 	ID           string
 	FunctionName string
@@ -378,8 +415,11 @@ type ToolCall struct {
 }
 
 // WithTools configures the tools available for tool call detection.
-// When tools are provided, Generate will attempt to detect tool calls
-// in the model output and populate GenerateResult.ToolCalls.
+//
+// When tools are provided, [Model.Generate] will attempt to detect tool calls
+// in the model output and populate [GenerateResult.ToolCalls].
+//
+// Experimental.
 func WithTools(tools ...serve.Tool) GenerateOption {
 	return func(o *generateOptions) {
 		o.tools = tools
@@ -387,14 +427,19 @@ func WithTools(tools ...serve.Tool) GenerateOption {
 }
 
 // WithToolChoice sets the tool choice mode for tool call detection.
+//
+// Experimental.
 func WithToolChoice(choice serve.ToolChoice) GenerateOption {
 	return func(o *generateOptions) {
 		o.toolChoice = &choice
 	}
 }
 
-// WithSchema enables grammar-guided decoding. The model's output will be
-// constrained to valid JSON matching the given schema.
+// WithSchema enables grammar-guided decoding.
+//
+// The model's output will be constrained to valid JSON matching the given schema.
+//
+// Experimental.
 func WithSchema(schema grammar.JSONSchema) GenerateOption {
 	return func(o *generateOptions) {
 		o.schema = &schema

--- a/api_tool_call_test.go
+++ b/api_tool_call_test.go
@@ -95,10 +95,8 @@ func TestGenerate_ToolCallDetection(t *testing.T) {
 				if len(result.ToolCalls[0].Arguments) == 0 {
 					t.Error("ToolCalls[0].Arguments should not be empty")
 				}
-			} else {
-				if len(result.ToolCalls) != 0 {
-					t.Errorf("expected no ToolCalls, got %d: %+v", len(result.ToolCalls), result.ToolCalls)
-				}
+			} else if len(result.ToolCalls) != 0 {
+				t.Errorf("expected no ToolCalls, got %d: %+v", len(result.ToolCalls), result.ToolCalls)
 			}
 
 			// Text should always be set regardless of tool call detection.

--- a/zerfoo.go
+++ b/zerfoo.go
@@ -17,38 +17,52 @@ import (
 )
 
 // Prelude of commonly used types for building models.
-// This allows developers to use `zerfoo.Graph` instead of `graph.Graph`,
+// This allows developers to use zerfoo.Graph instead of graph.Graph,
 // improving discoverability and developer experience.
 type (
 	// Graph represents a computation graph.
+	//
+	// Stable.
 	Graph[T tensor.Numeric] struct {
 		*graph.Graph[T]
 	}
 
 	// Node represents a node in the computation graph.
+	//
+	// Stable.
 	Node[T tensor.Numeric] interface {
 		graph.Node[T]
 	}
 
 	// Parameter represents a trainable parameter in the model.
+	//
+	// Stable.
 	Parameter[T tensor.Numeric] struct {
 		*graph.Parameter[T]
 	}
 
-	// Engine represents a computation engine (e.g., CPU).
+	// Engine represents a computation engine (e.g., CPU or GPU).
+	//
+	// Stable.
 	Engine[T tensor.Numeric] interface {
 		compute.Engine[T]
 	}
 
 	// Tensor represents a multi-dimensional array.
+	//
+	// Stable.
 	Tensor[T tensor.Numeric] struct {
 		*tensor.TensorNumeric[T]
 	}
 
-	// Numeric represents a numeric type constraint.
+	// Numeric represents a numeric type constraint for tensor elements.
+	//
+	// Stable.
 	Numeric tensor.Numeric
 
-	// LayerBuilder is a function that builds a layer.
+	// LayerBuilder is a function that builds a computation graph layer.
+	//
+	// Stable.
 	LayerBuilder[T tensor.Numeric] func(
 		engine compute.Engine[T],
 		ops numeric.Arithmetic[T],
@@ -58,22 +72,30 @@ type (
 	) (graph.Node[T], error)
 )
 
-// NewGraph creates a new computation graph.
+// NewGraph creates a new computation graph builder for the given engine.
+//
+// Stable.
 func NewGraph[T tensor.Numeric](engine compute.Engine[T]) *graph.Builder[T] {
 	return graph.NewBuilder[T](engine)
 }
 
-// RegisterLayer registers a new layer builder.
+// RegisterLayer registers a new layer builder for the given operation type.
+//
+// Stable.
 func RegisterLayer[T tensor.Numeric](opType string, builder model.LayerBuilder[T]) {
 	model.RegisterLayer[T](opType, builder)
 }
 
-// UnregisterLayer unregisters a layer builder.
+// UnregisterLayer unregisters the layer builder for the given operation type.
+//
+// Stable.
 func UnregisterLayer(opType string) {
 	model.UnregisterLayer(opType)
 }
 
-// NewCPUEngine creates a new CPU engine for the given numeric type.
+// NewCPUEngine creates a new CPU computation engine for the given numeric type.
+//
+// Stable.
 func NewCPUEngine[T tensor.Numeric]() compute.Engine[T] {
 	var ops numeric.Arithmetic[T]
 	switch any(ops).(type) {
@@ -88,16 +110,22 @@ func NewCPUEngine[T tensor.Numeric]() compute.Engine[T] {
 }
 
 // NewFloat32Ops returns the float32 arithmetic operations.
+//
+// Stable.
 func NewFloat32Ops() numeric.Arithmetic[float32] {
 	return numeric.Float32Ops{}
 }
 
 // NewTensor creates a new tensor with the given shape and data.
+//
+// Stable.
 func NewTensor[T tensor.Numeric](shape []int, data []T) (*tensor.TensorNumeric[T], error) {
 	return tensor.New[T](shape, data)
 }
 
 // NewMSE creates a new Mean Squared Error loss function.
+//
+// Stable.
 func NewMSE[T tensor.Numeric](engine compute.Engine[T]) *loss.MSE[T] {
 	var ops numeric.Arithmetic[T]
 	switch any(ops).(type) {
@@ -111,7 +139,9 @@ func NewMSE[T tensor.Numeric](engine compute.Engine[T]) *loss.MSE[T] {
 	return loss.NewMSE[T](engine, ops)
 }
 
-// NewAdamW creates a new AdamW optimizer.
+// NewAdamW creates a new AdamW optimizer with the given hyperparameters.
+//
+// Stable.
 func NewAdamW[T tensor.Numeric](learningRate, beta1, beta2, epsilon, weightDecay T) *optimizer.AdamW[T] {
 	var ops numeric.Arithmetic[T]
 	switch any(ops).(type) {
@@ -126,7 +156,9 @@ func NewAdamW[T tensor.Numeric](learningRate, beta1, beta2, epsilon, weightDecay
 	return optimizer.NewAdamW[T](engine, learningRate, beta1, beta2, epsilon, weightDecay)
 }
 
-// NewDefaultTrainer creates a new default trainer.
+// NewDefaultTrainer creates a new default trainer for the given graph, loss, optimizer, and gradient strategy.
+//
+// Stable.
 func NewDefaultTrainer[T tensor.Numeric](
 	g *graph.Graph[T],
 	lossNode graph.Node[T],
@@ -136,13 +168,17 @@ func NewDefaultTrainer[T tensor.Numeric](
 	return training.NewDefaultTrainer[T](g, lossNode, opt, strategy)
 }
 
-// Batch represents a training batch.
+// Batch represents a training batch of inputs and targets.
+//
+// Stable.
 type Batch[T tensor.Numeric] struct {
 	Inputs  map[graph.Node[T]]*tensor.TensorNumeric[T]
 	Targets *tensor.TensorNumeric[T]
 }
 
-// NewRMSNorm is a factory function for creating RMSNorm layers.
+// NewRMSNorm creates a new RMSNorm normalization layer with the given configuration.
+//
+// Stable.
 func NewRMSNorm[T tensor.Numeric](name string, engine compute.Engine[T], ops numeric.Arithmetic[T], modelDim int, options ...normalization.RMSNormOption[T]) (*normalization.RMSNorm[T], error) {
 	return normalization.NewRMSNorm[T](name, engine, ops, modelDim, options...)
 }


### PR DESCRIPTION
## Summary
- Added godoc comments and stability markers to all exported symbols in the top-level zerfoo package (api.go and zerfoo.go)
- Marked stable: Model, Load, Chat, Generate, Embed, Close, GenerateResult, Embedding, CosineSimilarity, GenerateOption, WithGenMaxTokens, WithGenTemperature, WithGenTopP, ChatStream, StreamToken, and all prelude types/functions
- Marked experimental: ToolCall, WithTools, WithToolChoice, WithSchema
- Fixed copyloopvar, misspell, and gocritic lint findings

## Test plan
- [x] `go vet .` passes with zero warnings
- [x] `golangci-lint run .` passes with zero issues
- [x] Full test suite passes (`go test ./... -race`)