### PR TITLE
fix(security): Wave 42 -- T108.10 marketplace metering retry

### DIFF
--- a/marketplace/aws/aws_test.go
+++ b/marketplace/aws/aws_test.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/zerfoo/zerfoo/marketplace"
 )
 
 // mockMeteringAPI is a test double for MeteringAPI.
@@ -126,6 +129,87 @@ func TestMeteringClient_MeterUsage(t *testing.T) {
 	}
 	if out.MeteringRecordID != "rec-789" {
 		t.Errorf("got record ID %q, want %q", out.MeteringRecordID, "rec-789")
+	}
+}
+
+func TestMeteringClient_BatchMeterUsage_RetryOn429(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte("throttled"))
+			return
+		}
+		var input BatchMeterUsageInput
+		json.NewDecoder(r.Body).Decode(&input)
+		var results []UsageRecordResult
+		for _, rec := range input.UsageRecords {
+			results = append(results, UsageRecordResult{
+				UsageRecord:    rec,
+				MeteringStatus: "Success",
+			})
+		}
+		json.NewEncoder(w).Encode(BatchMeterUsageOutput{Results: results})
+	}))
+	defer srv.Close()
+
+	client := NewMeteringClient(srv.URL, nil)
+	client.Retry = marketplace.RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Millisecond,
+		MaxJitter:   1 * time.Millisecond,
+	}
+
+	out, err := client.BatchMeterUsage(context.Background(), &BatchMeterUsageInput{
+		ProductCode:  "prod-xyz",
+		UsageRecords: []UsageRecord{{CustomerIdentifier: "cust-1", Dimension: "tokens_1m", Quantity: 5, Timestamp: time.Now()}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(out.Results))
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("got %d attempts, want 3", got)
+	}
+}
+
+func TestMeteringClient_MeterUsage_RetryOn429(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte("throttled"))
+			return
+		}
+		json.NewEncoder(w).Encode(MeterUsageOutput{MeteringRecordID: "rec-retry"})
+	}))
+	defer srv.Close()
+
+	client := NewMeteringClient(srv.URL, nil)
+	client.Retry = marketplace.RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Millisecond,
+		MaxJitter:   1 * time.Millisecond,
+	}
+
+	out, err := client.MeterUsage(context.Background(), &MeterUsageInput{
+		ProductCode: "prod-xyz",
+		Dimension:   "tokens_1m",
+		Quantity:    10,
+		Timestamp:   time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.MeteringRecordID != "rec-retry" {
+		t.Errorf("got record ID %q, want %q", out.MeteringRecordID, "rec-retry")
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Errorf("got %d attempts, want 2", got)
 	}
 }
 

--- a/marketplace/aws/metering.go
+++ b/marketplace/aws/metering.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/zerfoo/zerfoo/marketplace"
 )
 
 // MeteringAPI abstracts AWS Marketplace Metering Service API calls.
@@ -60,11 +62,11 @@ type BatchMeterUsageOutput struct {
 
 // MeterUsageInput is the input for MeterUsage.
 type MeterUsageInput struct {
-	ProductCode        string    `json:"productCode"`
-	Dimension          string    `json:"dimension"`
-	Quantity           int       `json:"quantity"`
-	Timestamp          time.Time `json:"timestamp"`
-	UsageAllocations   []UsageAllocation `json:"usageAllocations,omitempty"`
+	ProductCode      string            `json:"productCode"`
+	Dimension        string            `json:"dimension"`
+	Quantity         int               `json:"quantity"`
+	Timestamp        time.Time         `json:"timestamp"`
+	UsageAllocations []UsageAllocation `json:"usageAllocations,omitempty"`
 }
 
 // UsageAllocation allows tagging usage with allocation metadata.
@@ -88,6 +90,9 @@ type MeteringClient struct {
 	Signer RequestSigner
 	// HTTPClient is the HTTP client used for API calls.
 	HTTPClient *http.Client
+	// Retry configures exponential backoff for metering calls.
+	// Zero value disables retry.
+	Retry marketplace.RetryConfig
 
 	mu sync.Mutex
 }
@@ -103,6 +108,7 @@ func NewMeteringClient(endpoint string, signer RequestSigner) *MeteringClient {
 		Endpoint:   endpoint,
 		Signer:     signer,
 		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		Retry:      marketplace.DefaultRetryConfig(),
 	}
 }
 
@@ -133,7 +139,12 @@ func (c *MeteringClient) BatchMeterUsage(ctx context.Context, input *BatchMeterU
 		return nil, fmt.Errorf("marshal batch meter usage request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, "AWSMPMeteringService.BatchMeterUsage", data)
+	var resp []byte
+	err = marketplace.RetryFunc(ctx, c.Retry, "aws.BatchMeterUsage", func() error {
+		var reqErr error
+		resp, reqErr = c.doRequest(ctx, "AWSMPMeteringService.BatchMeterUsage", data)
+		return reqErr
+	})
 	if err != nil {
 		return nil, fmt.Errorf("batch meter usage: %w", err)
 	}
@@ -152,7 +163,12 @@ func (c *MeteringClient) MeterUsage(ctx context.Context, input *MeterUsageInput)
 		return nil, fmt.Errorf("marshal meter usage request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, "AWSMPMeteringService.MeterUsage", data)
+	var resp []byte
+	err = marketplace.RetryFunc(ctx, c.Retry, "aws.MeterUsage", func() error {
+		var reqErr error
+		resp, reqErr = c.doRequest(ctx, "AWSMPMeteringService.MeterUsage", data)
+		return reqErr
+	})
 	if err != nil {
 		return nil, fmt.Errorf("meter usage: %w", err)
 	}

--- a/marketplace/azure/azure_test.go
+++ b/marketplace/azure/azure_test.go
@@ -9,8 +9,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/zerfoo/zerfoo/marketplace"
 )
 
 // mockFulfillmentAPI is a test double for FulfillmentAPI.
@@ -302,6 +305,85 @@ func TestMeteringClient_PostBatchUsageEvent(t *testing.T) {
 	}
 	if out.Count != 2 {
 		t.Errorf("got count %d, want 2", out.Count)
+	}
+}
+
+func TestMeteringClient_PostUsageEvent_RetryOn429(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte("throttled"))
+			return
+		}
+		json.NewEncoder(w).Encode(UsageEventResult{
+			UsageEventID: "evt-retry",
+			Status:       MeteringStatusAccepted,
+			Dimension:    "tokens_1m",
+			Quantity:     5,
+		})
+	}))
+	defer srv.Close()
+
+	client := NewMeteringClient(srv.URL, nil)
+	client.Retry = marketplace.RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Millisecond,
+		MaxJitter:   1 * time.Millisecond,
+	}
+
+	out, err := client.PostUsageEvent(context.Background(), UsageEvent{
+		ResourceID: "sub-1",
+		Quantity:   5,
+		Dimension:  "tokens_1m",
+		PlanID:     "basic",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.UsageEventID != "evt-retry" {
+		t.Errorf("got event ID %q, want %q", out.UsageEventID, "evt-retry")
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Errorf("got %d attempts, want 2", got)
+	}
+}
+
+func TestMeteringClient_PostBatchUsageEvent_RetryOn429(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte("throttled"))
+			return
+		}
+		json.NewEncoder(w).Encode(BatchUsageResult{
+			Results: []UsageEventResult{{UsageEventID: "evt-retry", Status: MeteringStatusAccepted}},
+			Count:   1,
+		})
+	}))
+	defer srv.Close()
+
+	client := NewMeteringClient(srv.URL, nil)
+	client.Retry = marketplace.RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Millisecond,
+		MaxJitter:   1 * time.Millisecond,
+	}
+
+	out, err := client.PostBatchUsageEvent(context.Background(), []UsageEvent{
+		{ResourceID: "sub-1", Quantity: 3, Dimension: "tokens_1m"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Count != 1 {
+		t.Errorf("got count %d, want 1", out.Count)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("got %d attempts, want 3", got)
 	}
 }
 

--- a/marketplace/azure/metering.go
+++ b/marketplace/azure/metering.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/zerfoo/zerfoo/marketplace"
 )
 
 // MeteringAPI abstracts Azure Marketplace Metering Service API calls.
@@ -30,22 +32,22 @@ type UsageEvent struct {
 
 // UsageEventResult contains the result of posting a single usage event.
 type UsageEventResult struct {
-	UsageEventID  string        `json:"usageEventId"`
+	UsageEventID  string         `json:"usageEventId"`
 	Status        MeteringStatus `json:"status"`
-	Quantity      float64       `json:"quantity"`
-	Dimension     string        `json:"dimension"`
-	EffectiveTime time.Time     `json:"effectiveStartTime"`
-	PlanID        string        `json:"planId"`
-	MessageTime   time.Time     `json:"messageTime"`
+	Quantity      float64        `json:"quantity"`
+	Dimension     string         `json:"dimension"`
+	EffectiveTime time.Time      `json:"effectiveStartTime"`
+	PlanID        string         `json:"planId"`
+	MessageTime   time.Time      `json:"messageTime"`
 }
 
 // MeteringStatus represents the status of a metering event.
 type MeteringStatus string
 
 const (
-	MeteringStatusAccepted   MeteringStatus = "Accepted"
-	MeteringStatusDuplicate  MeteringStatus = "Duplicate"
-	MeteringStatusExpired    MeteringStatus = "Expired"
+	MeteringStatusAccepted         MeteringStatus = "Accepted"
+	MeteringStatusDuplicate        MeteringStatus = "Duplicate"
+	MeteringStatusExpired          MeteringStatus = "Expired"
 	MeteringStatusResourceNotFound MeteringStatus = "ResourceNotFound"
 )
 
@@ -74,6 +76,10 @@ type MeteringClient struct {
 
 	// HTTPClient is the HTTP client used for API calls.
 	HTTPClient *http.Client
+
+	// Retry configures exponential backoff for metering calls.
+	// Zero value disables retry.
+	Retry marketplace.RetryConfig
 }
 
 // NewMeteringClient creates a new MeteringClient with the given endpoint and token provider.
@@ -83,6 +89,7 @@ func NewMeteringClient(endpoint string, tokenProvider TokenProvider) *MeteringCl
 		APIVersion:    "2018-08-31",
 		TokenProvider: tokenProvider,
 		HTTPClient:    &http.Client{Timeout: 30 * time.Second},
+		Retry:         marketplace.DefaultRetryConfig(),
 	}
 }
 
@@ -93,7 +100,12 @@ func (c *MeteringClient) PostUsageEvent(ctx context.Context, event UsageEvent) (
 		return nil, fmt.Errorf("marshal usage event: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/usageEvent", data)
+	var resp []byte
+	err = marketplace.RetryFunc(ctx, c.Retry, "azure.PostUsageEvent", func() error {
+		var reqErr error
+		resp, reqErr = c.doRequest(ctx, http.MethodPost, "/usageEvent", data)
+		return reqErr
+	})
 	if err != nil {
 		return nil, fmt.Errorf("post usage event: %w", err)
 	}
@@ -116,7 +128,12 @@ func (c *MeteringClient) PostBatchUsageEvent(ctx context.Context, events []Usage
 		return nil, fmt.Errorf("marshal batch usage events: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodPost, "/batchUsageEvent", data)
+	var resp []byte
+	err = marketplace.RetryFunc(ctx, c.Retry, "azure.PostBatchUsageEvent", func() error {
+		var reqErr error
+		resp, reqErr = c.doRequest(ctx, http.MethodPost, "/batchUsageEvent", data)
+		return reqErr
+	})
 	if err != nil {
 		return nil, fmt.Errorf("post batch usage events: %w", err)
 	}

--- a/marketplace/gcp/gcp_test.go
+++ b/marketplace/gcp/gcp_test.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/zerfoo/zerfoo/marketplace"
 )
 
 // mockProcurementAPI is a test double for ProcurementAPI.
@@ -269,6 +272,51 @@ func TestServiceControlClient_ReportErrors(t *testing.T) {
 	err := client.Report(context.Background(), "svc", []Operation{{OperationID: "op-1"}})
 	if err == nil {
 		t.Fatal("expected error for report with errors")
+	}
+}
+
+func TestServiceControlClient_Report_RetryOn429(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte("throttled"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ReportResponse{})
+	}))
+	defer srv.Close()
+
+	client := NewServiceControlClient(nil)
+	client.Endpoint = srv.URL
+	client.Retry = marketplace.RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Millisecond,
+		MaxJitter:   1 * time.Millisecond,
+	}
+
+	quantity := int64(5)
+	ops := []Operation{
+		{
+			OperationID: "op-retry",
+			ConsumerID:  "project:my-project",
+			MetricValues: []MetricValueSet{
+				{
+					MetricName:   DimensionTokens,
+					MetricValues: []MetricValue{{Int64Value: &quantity}},
+				},
+			},
+		},
+	}
+
+	err := client.Report(context.Background(), "zerfoo-marketplace.googleapis.com", ops)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("got %d attempts, want 3", got)
 	}
 }
 

--- a/marketplace/gcp/metering.go
+++ b/marketplace/gcp/metering.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/zerfoo/zerfoo/marketplace"
 )
 
 // ServiceControlAPI abstracts GCP Service Control API calls for usage reporting.
@@ -69,6 +71,9 @@ type ServiceControlClient struct {
 	TokenSource TokenSource
 	// HTTPClient is the HTTP client used for API calls.
 	HTTPClient *http.Client
+	// Retry configures exponential backoff for metering calls.
+	// Zero value disables retry.
+	Retry marketplace.RetryConfig
 }
 
 const defaultServiceControlEndpoint = "https://servicecontrol.googleapis.com/v1"
@@ -79,6 +84,7 @@ func NewServiceControlClient(tokenSource TokenSource) *ServiceControlClient {
 		Endpoint:    defaultServiceControlEndpoint,
 		TokenSource: tokenSource,
 		HTTPClient:  &http.Client{Timeout: 30 * time.Second},
+		Retry:       marketplace.DefaultRetryConfig(),
 	}
 }
 
@@ -90,6 +96,12 @@ func (c *ServiceControlClient) Report(ctx context.Context, serviceName string, o
 		return fmt.Errorf("marshal report request: %w", err)
 	}
 
+	return marketplace.RetryFunc(ctx, c.Retry, "gcp.Report", func() error {
+		return c.doReport(ctx, serviceName, data)
+	})
+}
+
+func (c *ServiceControlClient) doReport(ctx context.Context, serviceName string, data []byte) error {
 	path := "/services/" + serviceName + ":report"
 
 	var bodyReader io.Reader = &bytesReader{data: data}

--- a/marketplace/retry.go
+++ b/marketplace/retry.go
@@ -1,0 +1,68 @@
+package marketplace
+
+import (
+	"context"
+	"log/slog"
+	"math/rand/v2"
+	"time"
+)
+
+// RetryConfig controls exponential backoff retry behavior for metering calls.
+type RetryConfig struct {
+	// MaxAttempts is the total number of attempts (including the first).
+	MaxAttempts int
+	// BaseDelay is the initial delay before the first retry.
+	BaseDelay time.Duration
+	// MaxJitter is the maximum random jitter added to each delay.
+	MaxJitter time.Duration
+}
+
+// DefaultRetryConfig returns the standard retry configuration for marketplace
+// metering: 3 attempts with 1s base delay and 500ms max jitter.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Second,
+		MaxJitter:   500 * time.Millisecond,
+	}
+}
+
+// RetryFunc executes fn with exponential backoff retry. It logs each retry
+// attempt at warn level and logs at error level if all attempts fail.
+// The operation parameter is used in log messages to identify the call.
+func RetryFunc(ctx context.Context, cfg RetryConfig, operation string, fn func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < cfg.MaxAttempts; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+
+		if attempt < cfg.MaxAttempts-1 {
+			delay := cfg.BaseDelay << uint(attempt)
+			jitter := time.Duration(rand.Int64N(int64(cfg.MaxJitter)))
+			delay += jitter
+
+			slog.Warn("marketplace metering retry",
+				"operation", operation,
+				"attempt", attempt+1,
+				"max_attempts", cfg.MaxAttempts,
+				"error", lastErr,
+				"next_delay", delay,
+			)
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+
+	slog.Error("marketplace metering failed after all retries",
+		"operation", operation,
+		"attempts", cfg.MaxAttempts,
+		"error", lastErr,
+	)
+	return lastErr
+}

--- a/marketplace/retry_test.go
+++ b/marketplace/retry_test.go
@@ -1,0 +1,100 @@
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetryFunc_SucceedsFirstAttempt(t *testing.T) {
+	calls := 0
+	err := RetryFunc(context.Background(), RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Millisecond,
+		MaxJitter:   1 * time.Millisecond,
+	}, "test.op", func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("got %d calls, want 1", calls)
+	}
+}
+
+func TestRetryFunc_SucceedsOnRetry(t *testing.T) {
+	calls := 0
+	err := RetryFunc(context.Background(), RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Millisecond,
+		MaxJitter:   1 * time.Millisecond,
+	}, "test.op", func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient error")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("got %d calls, want 3", calls)
+	}
+}
+
+func TestRetryFunc_AllAttemptsFail(t *testing.T) {
+	calls := 0
+	testErr := errors.New("persistent error")
+	err := RetryFunc(context.Background(), RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Millisecond,
+		MaxJitter:   1 * time.Millisecond,
+	}, "test.op", func() error {
+		calls++
+		return testErr
+	})
+	if !errors.Is(err, testErr) {
+		t.Fatalf("got error %v, want %v", err, testErr)
+	}
+	if calls != 3 {
+		t.Errorf("got %d calls, want 3", calls)
+	}
+}
+
+func TestRetryFunc_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := RetryFunc(ctx, RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Second,
+		MaxJitter:   1 * time.Millisecond,
+	}, "test.op", func() error {
+		calls++
+		cancel()
+		return errors.New("fail")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got error %v, want context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Errorf("got %d calls, want 1", calls)
+	}
+}
+
+func TestRetryFunc_ZeroConfig(t *testing.T) {
+	calls := 0
+	err := RetryFunc(context.Background(), RetryConfig{}, "test.op", func() error {
+		calls++
+		return errors.New("should not be called")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("got %d calls, want 0", calls)
+	}
+}


### PR DESCRIPTION
## Summary
- **T108.10**: Add exponential backoff retry to marketplace metering (H11) across AWS, Azure, and GCP providers

## Test plan
- [x] go vet ./marketplace/... clean
- [x] go test -race ./marketplace/... pass