### PR TITLE
fix(security): Wave 43 -- T108.12 warn/refuse no API key

### DIFF
--- a/cmd/cli/coverage_gaps_test.go
+++ b/cmd/cli/coverage_gaps_test.go
@@ -21,7 +21,7 @@ func TestServeCommand_WithCacheDir(t *testing.T) {
 		// Verify option was passed (we can't inspect it but at least exercise the path).
 		return nil, errors.New("expected load fail")
 	}
-	err := cmd.Run(context.Background(), []string{"--cache-dir", "/tmp/test-cache", "test-model"})
+	err := cmd.Run(context.Background(), []string{"--allow-no-auth", "--cache-dir", "/tmp/test-cache", "test-model"})
 	if err == nil {
 		t.Error("expected error from load")
 	}
@@ -43,7 +43,7 @@ func TestServeCommand_ListenAndServeError(t *testing.T) {
 	}
 
 	// Use an invalid port to force ListenAndServe to fail.
-	err := cmd.Run(context.Background(), []string{"--port", "invalid-port", "test-model"})
+	err := cmd.Run(context.Background(), []string{"--allow-no-auth", "--port", "invalid-port", "test-model"})
 	if err == nil {
 		t.Error("expected error from invalid port")
 	}

--- a/cmd/cli/serve.go
+++ b/cmd/cli/serve.go
@@ -45,9 +45,13 @@ func (c *ServeCommand) Description() string {
 // Run implements Command.Run.
 func (c *ServeCommand) Run(ctx context.Context, args []string) error {
 	var modelID, cacheDir, port, gpusRaw, apiKey, tlsCert, tlsKey string
+	var allowNoAuth bool
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
+		case "--allow-no-auth":
+			allowNoAuth = true
+			continue
 		case "--port":
 			if i+1 >= len(args) {
 				return errors.New("--port requires a value")
@@ -120,6 +124,14 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("invalid --gpus value: %w", err)
 		}
+	}
+
+	// Require explicit opt-in when no API key is configured.
+	if apiKey == "" && !allowNoAuth {
+		return errors.New("set --api-key, ZERFOO_API_KEY, or --allow-no-auth")
+	}
+	if apiKey == "" && allowNoAuth {
+		_, _ = fmt.Fprintf(c.out, "WARN: serve: no API key configured, all endpoints are public\n")
 	}
 
 	li := startLoading(c.out)
@@ -218,6 +230,7 @@ OPTIONS:
   --cache-dir <dir>   Override model cache directory
   --gpus <ids>        Comma-separated GPU IDs to distribute model across (e.g. 0,1,2,3)
   --api-key <key>     Require Bearer token auth (env: ZERFOO_API_KEY)
+  --allow-no-auth     Allow starting without an API key (public endpoints)
   --tls-cert <path>   Path to TLS certificate file (requires --tls-key)
   --tls-key <path>    Path to TLS private key file (requires --tls-cert)
 

--- a/cmd/cli/serve_test.go
+++ b/cmd/cli/serve_test.go
@@ -55,7 +55,7 @@ func TestServeCommand_LoadError(t *testing.T) {
 	cmd.loadFn = func(_ string, _ ...inference.Option) (*inference.Model, error) {
 		return nil, errors.New("load failed")
 	}
-	err := cmd.Run(context.Background(), []string{"test-model"})
+	err := cmd.Run(context.Background(), []string{"--allow-no-auth", "test-model"})
 	if err == nil {
 		t.Error("expected error from load")
 	}
@@ -98,7 +98,7 @@ func TestServeCommand_WithCoordinator(t *testing.T) {
 		return nil, errors.New("load failed")
 	}
 	// Fails at load, but exercises the coordinator path.
-	_ = cmd.Run(context.Background(), []string{"test-model"})
+	_ = cmd.Run(context.Background(), []string{"--allow-no-auth", "test-model"})
 }
 
 func TestServeCommand_StartsAndStopsOnCancel(t *testing.T) {
@@ -114,7 +114,7 @@ func TestServeCommand_StartsAndStopsOnCancel(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- cmd.Run(ctx, []string{"--port", "0", "test-model"})
+		errCh <- cmd.Run(ctx, []string{"--port", "0", "--allow-no-auth", "test-model"})
 	}()
 
 	// Give server a moment to start, then cancel.
@@ -141,7 +141,7 @@ func TestServeCommand_CustomPort(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- cmd.Run(ctx, []string{"--port", "0", "test-model"})
+		errCh <- cmd.Run(ctx, []string{"--port", "0", "--allow-no-auth", "test-model"})
 	}()
 
 	cancel()
@@ -206,6 +206,47 @@ func TestParseGPUList(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestServeCommand_NoKeyNoFlag(t *testing.T) {
+	var out bytes.Buffer
+	cmd := NewServeCommand(nil, &out)
+	cmd.loadFn = func(_ string, _ ...inference.Option) (*inference.Model, error) {
+		return nil, errors.New("should not be called")
+	}
+	err := cmd.Run(context.Background(), []string{"test-model"})
+	if err == nil {
+		t.Fatal("expected error when no API key and no --allow-no-auth")
+	}
+	want := "set --api-key, ZERFOO_API_KEY, or --allow-no-auth"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want to contain %q", err.Error(), want)
+	}
+}
+
+func TestServeCommand_AllowNoAuth(t *testing.T) {
+	mdl := buildCLITestModel(t)
+	var out bytes.Buffer
+	cmd := NewServeCommand(nil, &out)
+	cmd.loadFn = func(_ string, _ ...inference.Option) (*inference.Model, error) {
+		return mdl, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cmd.Run(ctx, []string{"--port", "0", "--allow-no-auth", "test-model"})
+	}()
+
+	cancel()
+	err := <-errCh
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if !strings.Contains(out.String(), "no API key configured") {
+		t.Errorf("output = %q, want warning about no API key", out.String())
 	}
 }
 
@@ -281,7 +322,7 @@ func TestServeCommand_TLSFlagsParsed(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- cmd.Run(ctx, []string{"--port", "0", "--tls-cert", "cert.pem", "--tls-key", "key.pem", "test-model"})
+		errCh <- cmd.Run(ctx, []string{"--port", "0", "--allow-no-auth", "--tls-cert", "cert.pem", "--tls-key", "key.pem", "test-model"})
 	}()
 
 	// Cancel immediately — the server will fail to start with invalid TLS files,
@@ -307,7 +348,7 @@ func TestServeCommand_GPUsFlagValid(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- cmd.Run(ctx, []string{"--port", "0", "--gpus", "0,1,2,3", "test-model"})
+		errCh <- cmd.Run(ctx, []string{"--port", "0", "--allow-no-auth", "--gpus", "0,1,2,3", "test-model"})
 	}()
 
 	cancel()


### PR DESCRIPTION
## Summary
- **T108.12**: Warn or refuse startup when no API key configured. Add --allow-no-auth flag.

## Test plan
- [x] go vet ./serve/ ./cmd/cli/ clean
- [x] go test -race ./serve/ ./cmd/cli/ pass