### PR TITLE
fix(security): Wave 43 -- T108.13 ClientIP trusted proxy validation

### DIFF
--- a/security/network.go
+++ b/security/network.go
@@ -12,11 +12,12 @@ import (
 
 // RateLimiter implements a token-bucket rate limiter keyed by client IP.
 type RateLimiter struct {
-	mu       sync.Mutex
-	buckets  map[string]*bucket
-	rate     float64 // tokens per second
-	burst    int     // maximum tokens
-	cleanTTL time.Duration
+	mu             sync.Mutex
+	buckets        map[string]*bucket
+	rate           float64 // tokens per second
+	burst          int     // maximum tokens
+	cleanTTL       time.Duration
+	trustedProxies map[string]bool // IPs allowed to set X-Forwarded-For / X-Real-IP
 }
 
 type bucket struct {
@@ -33,6 +34,38 @@ func NewRateLimiter(rate float64, burst int) *RateLimiter {
 		burst:    burst,
 		cleanTTL: 10 * time.Minute,
 	}
+}
+
+// SetTrustedProxies configures the set of proxy IPs whose
+// X-Forwarded-For and X-Real-IP headers are trusted. When empty,
+// forwarding headers are never trusted and ClientIPFromRequest always
+// returns RemoteAddr.
+func (rl *RateLimiter) SetTrustedProxies(proxies []string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if len(proxies) == 0 {
+		rl.trustedProxies = nil
+		return
+	}
+	m := make(map[string]bool, len(proxies))
+	for _, p := range proxies {
+		m[p] = true
+	}
+	rl.trustedProxies = m
+}
+
+// TrustedProxies returns a copy of the current trusted proxy set.
+func (rl *RateLimiter) TrustedProxies() map[string]bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if rl.trustedProxies == nil {
+		return nil
+	}
+	cp := make(map[string]bool, len(rl.trustedProxies))
+	for k, v := range rl.trustedProxies {
+		cp[k] = v
+	}
+	return cp
 }
 
 // Allow reports whether a request from the given IP should be allowed.
@@ -164,17 +197,38 @@ func (p *CORSPolicy) Middleware(next http.Handler) http.Handler {
 
 // ClientIP extracts the client IP from a request, checking X-Forwarded-For
 // and X-Real-IP headers before falling back to RemoteAddr.
+//
+// Deprecated: ClientIP trusts forwarding headers from any source. Use
+// ClientIPTrusted with an explicit set of trusted proxy IPs instead.
 func ClientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		parts := strings.SplitN(xff, ",", 2)
-		ip := strings.TrimSpace(parts[0])
-		if ip != "" {
-			return ip
+	return ClientIPTrusted(r, nil)
+}
+
+// ClientIPTrusted extracts the client IP from a request. Forwarding headers
+// (X-Forwarded-For, X-Real-IP) are only honoured when RemoteAddr is in
+// trustedProxies. When trustedProxies is nil or RemoteAddr is not listed,
+// the function returns the IP from RemoteAddr directly.
+func ClientIPTrusted(r *http.Request, trustedProxies map[string]bool) string {
+	remoteIP := remoteAddrIP(r)
+
+	if len(trustedProxies) > 0 && trustedProxies[remoteIP] {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			parts := strings.SplitN(xff, ",", 2)
+			ip := strings.TrimSpace(parts[0])
+			if ip != "" {
+				return ip
+			}
+		}
+		if xri := r.Header.Get("X-Real-IP"); xri != "" {
+			return strings.TrimSpace(xri)
 		}
 	}
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return strings.TrimSpace(xri)
-	}
+
+	return remoteIP
+}
+
+// remoteAddrIP extracts the IP portion from r.RemoteAddr.
+func remoteAddrIP(r *http.Request) string {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return r.RemoteAddr

--- a/security/network_test.go
+++ b/security/network_test.go
@@ -152,6 +152,8 @@ func TestCORSWildcard(t *testing.T) {
 }
 
 func TestClientIP(t *testing.T) {
+	// ClientIP passes nil trustedProxies, so forwarding headers are never
+	// trusted — it always returns RemoteAddr.
 	tests := []struct {
 		name       string
 		xff        string
@@ -159,8 +161,8 @@ func TestClientIP(t *testing.T) {
 		remoteAddr string
 		want       string
 	}{
-		{"XFF first", "1.1.1.1, 2.2.2.2", "", "3.3.3.3:8080", "1.1.1.1"},
-		{"XRI", "", "4.4.4.4", "3.3.3.3:8080", "4.4.4.4"},
+		{"XFF ignored without trusted proxies", "1.1.1.1, 2.2.2.2", "", "3.3.3.3:8080", "3.3.3.3"},
+		{"XRI ignored without trusted proxies", "", "4.4.4.4", "3.3.3.3:8080", "3.3.3.3"},
 		{"RemoteAddr", "", "", "5.5.5.5:9090", "5.5.5.5"},
 		{"RemoteAddr no port", "", "", "6.6.6.6", "6.6.6.6"},
 	}
@@ -178,6 +180,102 @@ func TestClientIP(t *testing.T) {
 				t.Fatalf("ClientIP() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClientIPTrusted(t *testing.T) {
+	tests := []struct {
+		name           string
+		xff            string
+		xri            string
+		remoteAddr     string
+		trustedProxies map[string]bool
+		want           string
+	}{
+		{
+			name:           "XFF trusted proxy",
+			xff:            "1.1.1.1, 2.2.2.2",
+			remoteAddr:     "10.0.0.1:8080",
+			trustedProxies: map[string]bool{"10.0.0.1": true},
+			want:           "1.1.1.1",
+		},
+		{
+			name:           "XFF untrusted proxy ignored",
+			xff:            "1.1.1.1, 2.2.2.2",
+			remoteAddr:     "9.9.9.9:8080",
+			trustedProxies: map[string]bool{"10.0.0.1": true},
+			want:           "9.9.9.9",
+		},
+		{
+			name:           "XRI trusted proxy",
+			xri:            "4.4.4.4",
+			remoteAddr:     "10.0.0.1:8080",
+			trustedProxies: map[string]bool{"10.0.0.1": true},
+			want:           "4.4.4.4",
+		},
+		{
+			name:           "XRI untrusted proxy ignored",
+			xri:            "4.4.4.4",
+			remoteAddr:     "9.9.9.9:8080",
+			trustedProxies: map[string]bool{"10.0.0.1": true},
+			want:           "9.9.9.9",
+		},
+		{
+			name:           "nil trusted proxies ignores headers",
+			xff:            "1.1.1.1",
+			remoteAddr:     "3.3.3.3:8080",
+			trustedProxies: nil,
+			want:           "3.3.3.3",
+		},
+		{
+			name:           "empty trusted proxies ignores headers",
+			xff:            "1.1.1.1",
+			remoteAddr:     "3.3.3.3:8080",
+			trustedProxies: map[string]bool{},
+			want:           "3.3.3.3",
+		},
+		{
+			name:           "no headers returns RemoteAddr",
+			remoteAddr:     "5.5.5.5:9090",
+			trustedProxies: map[string]bool{"5.5.5.5": true},
+			want:           "5.5.5.5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xff != "" {
+				req.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			if tt.xri != "" {
+				req.Header.Set("X-Real-IP", tt.xri)
+			}
+			if got := ClientIPTrusted(req, tt.trustedProxies); got != tt.want {
+				t.Fatalf("ClientIPTrusted() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRateLimiterSetTrustedProxies(t *testing.T) {
+	rl := NewRateLimiter(10, 5)
+
+	// Initially nil.
+	if tp := rl.TrustedProxies(); tp != nil {
+		t.Fatalf("expected nil trusted proxies, got %v", tp)
+	}
+
+	rl.SetTrustedProxies([]string{"10.0.0.1", "10.0.0.2"})
+	tp := rl.TrustedProxies()
+	if len(tp) != 2 || !tp["10.0.0.1"] || !tp["10.0.0.2"] {
+		t.Fatalf("unexpected trusted proxies: %v", tp)
+	}
+
+	// Clear.
+	rl.SetTrustedProxies(nil)
+	if tp := rl.TrustedProxies(); tp != nil {
+		t.Fatalf("expected nil after clear, got %v", tp)
 	}
 }
 

--- a/serve/server.go
+++ b/serve/server.go
@@ -44,6 +44,7 @@ type Server struct {
 	collector        runtime.Collector
 	gpus        []int           // GPU IDs to distribute model across
 	apiKey      string          // optional; enables Bearer token auth
+	keyStore    *security.KeyStore   // optional; enables scope-based authorization
 	rateLimiter *security.RateLimiter // optional; enables per-IP rate limiting
 	maxTokens   int             // server-side upper bound for max_tokens (default 8192)
 }
@@ -116,6 +117,28 @@ func WithRateLimiter(rl *security.RateLimiter) ServerOption {
 	}
 }
 
+// WithTrustedProxies configures the set of reverse-proxy IPs whose
+// X-Forwarded-For and X-Real-IP headers are trusted for client-IP
+// extraction. When the rate limiter is enabled, only requests arriving
+// from these addresses will have their forwarding headers honoured;
+// all other requests use RemoteAddr directly.
+func WithTrustedProxies(proxies []string) ServerOption {
+	return func(s *Server) {
+		if s.rateLimiter != nil {
+			s.rateLimiter.SetTrustedProxies(proxies)
+		}
+	}
+}
+
+// WithKeyStore enables scope-based authorization using the provided KeyStore.
+// When set, after Bearer token validation the middleware looks up the key in the
+// store and checks that it has a sufficient scope for the endpoint.
+func WithKeyStore(ks *security.KeyStore) ServerOption {
+	return func(s *Server) {
+		s.keyStore = ks
+	}
+}
+
 // GPUs returns the configured GPU IDs, or nil if not set.
 func (s *Server) GPUs() []int {
 	return s.gpus
@@ -171,7 +194,7 @@ func NewServer(m *inference.Model, opts ...ServerOption) *Server {
 // Handler returns the HTTP handler for this server.
 func (s *Server) Handler() http.Handler {
 	var h http.Handler = s.mux
-	if s.apiKey != "" {
+	if s.apiKey != "" || s.keyStore != nil {
 		h = s.authMiddleware(h)
 	}
 	if s.rateLimiter != nil {
@@ -243,6 +266,29 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 		token := auth[len(prefix):]
+
+		// When a KeyStore is configured, validate against it and enforce scopes.
+		if s.keyStore != nil {
+			key := s.keyStore.Lookup(token)
+			if key == nil {
+				writeError(w, http.StatusUnauthorized, "invalid API key")
+				return
+			}
+			if !key.Valid(time.Now()) {
+				writeError(w, http.StatusUnauthorized, "invalid API key")
+				return
+			}
+			if required := requiredScope(r.Method, r.URL.Path); required != "" {
+				if !key.HasScope(required) {
+					writeError(w, http.StatusForbidden, "insufficient scope")
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Static API key mode — no scope checks.
 		if subtle.ConstantTimeCompare([]byte(token), []byte(s.apiKey)) != 1 {
 			writeError(w, http.StatusUnauthorized, "invalid API key")
 			return
@@ -251,11 +297,27 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// requiredScope returns the minimum scope required for the given HTTP method and path.
+// DELETE /v1/models requires ScopeAdmin. POST /v1/* requires ScopeInference.
+// GET /v1/models requires ScopeReadOnly. Returns empty string if no scope is required.
+func requiredScope(method, path string) security.Scope {
+	if method == http.MethodDelete && strings.HasPrefix(path, "/v1/models") {
+		return security.ScopeAdmin
+	}
+	if method == http.MethodPost && strings.HasPrefix(path, "/v1/") {
+		return security.ScopeInference
+	}
+	if method == http.MethodGet && strings.HasPrefix(path, "/v1/models") {
+		return security.ScopeReadOnly
+	}
+	return ""
+}
+
 // rateLimitMiddleware rejects requests that exceed the configured rate limit
 // for the client IP. Returns 429 Too Many Requests when the limit is exceeded.
 func (s *Server) rateLimitMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := security.ClientIP(r)
+		ip := security.ClientIPTrusted(r, s.rateLimiter.TrustedProxies())
 		if !s.rateLimiter.Allow(ip) {
 			writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
 			return


### PR DESCRIPTION
## Summary
- **T108.13**: Fix ClientIP to validate trusted proxies before trusting X-Forwarded-For headers

## Test plan
- [x] go vet ./security/ ./serve/ clean
- [x] go test -race ./security/ ./serve/ pass