### PR TITLE
fix(security): Wave 44 -- T108.20 support API auth

### DIFF
--- a/support/api.go
+++ b/support/api.go
@@ -1,27 +1,87 @@
 package support
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 )
 
+// contextKey is an unexported type for context keys in this package.
+type contextKey int
+
+const tenantKey contextKey = 0
+
+// TenantFromContext returns the authenticated tenant ID from the request context.
+func TenantFromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(tenantKey).(string)
+	return id, ok
+}
+
+// AuthFunc validates a Bearer token and returns the associated tenant ID.
+// If the token is invalid, it returns an empty string and false.
+type AuthFunc func(token string) (tenantID string, ok bool)
+
 // API provides HTTP handlers for the customer support portal.
 type API struct {
-	Store      *Store
-	Router     *Router
-	SLA        *SLATracker
-	Webhooks   *WebhookDispatcher
+	Store    *Store
+	Router   *Router
+	SLA      *SLATracker
+	Webhooks *WebhookDispatcher
+	Auth     AuthFunc
 }
+
+// maxBodySize is the maximum allowed request body size (1 MiB).
+const maxBodySize = 1 << 20
 
 // RegisterRoutes registers all ticket API endpoints on the given mux.
 func (a *API) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /support/tickets", a.CreateTicket)
-	mux.HandleFunc("GET /support/tickets", a.ListTickets)
-	mux.HandleFunc("GET /support/tickets/{id}", a.GetTicket)
-	mux.HandleFunc("POST /support/tickets/{id}/comments", a.AddComment)
-	mux.HandleFunc("POST /support/tickets/{id}/close", a.CloseTicket)
+	auth := a.authMiddleware
+	mux.Handle("POST /support/tickets", auth(http.HandlerFunc(a.CreateTicket)))
+	mux.Handle("GET /support/tickets", auth(http.HandlerFunc(a.ListTickets)))
+	mux.Handle("GET /support/tickets/{id}", auth(http.HandlerFunc(a.GetTicket)))
+	mux.Handle("POST /support/tickets/{id}/comments", auth(http.HandlerFunc(a.AddComment)))
+	mux.Handle("POST /support/tickets/{id}/close", auth(http.HandlerFunc(a.CloseTicket)))
+}
+
+// authMiddleware wraps a handler with Bearer token authentication.
+func (a *API) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if a.Auth == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		header := r.Header.Get("Authorization")
+		if !strings.HasPrefix(header, "Bearer ") {
+			http.Error(w, `{"error":"missing or invalid authorization header"}`, http.StatusUnauthorized)
+			return
+		}
+		token := strings.TrimPrefix(header, "Bearer ")
+		tenantID, ok := a.Auth(token)
+		if !ok || tenantID == "" {
+			http.Error(w, `{"error":"invalid token"}`, http.StatusUnauthorized)
+			return
+		}
+		ctx := context.WithValue(r.Context(), tenantKey, tenantID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// requireTenant checks that the authenticated tenant matches the given customer ID.
+// Returns true if access is allowed; writes a 403 response and returns false otherwise.
+func requireTenant(w http.ResponseWriter, r *http.Request, customerID string) bool {
+	tenantID, ok := TenantFromContext(r.Context())
+	if !ok {
+		// No auth configured — allow.
+		return true
+	}
+	if tenantID != customerID {
+		http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
+		return false
+	}
+	return true
 }
 
 // CreateTicketRequest is the JSON body for creating a ticket.
@@ -34,13 +94,24 @@ type CreateTicketRequest struct {
 
 // CreateTicket handles POST /support/tickets.
 func (a *API) CreateTicket(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+
 	var req CreateTicketRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, `{"error":"request body too large"}`, http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
 		return
 	}
 	if req.CustomerID == "" || req.Subject == "" {
 		http.Error(w, `{"error":"customer_id and subject are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if !requireTenant(w, r, req.CustomerID) {
 		return
 	}
 
@@ -72,6 +143,11 @@ func (a *API) ListTickets(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"customer_id query parameter is required"}`, http.StatusBadRequest)
 		return
 	}
+
+	if !requireTenant(w, r, customerID) {
+		return
+	}
+
 	tickets := a.Store.ListByCustomer(customerID)
 	if tickets == nil {
 		tickets = []*Ticket{}
@@ -95,6 +171,11 @@ func (a *API) GetTicket(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"ticket not found"}`, http.StatusNotFound)
 		return
 	}
+
+	if !requireTenant(w, r, ticket.CustomerID) {
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(ticket)
 }
@@ -107,6 +188,8 @@ type AddCommentRequest struct {
 
 // AddComment handles POST /support/tickets/{id}/comments.
 func (a *API) AddComment(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+
 	id := r.PathValue("id")
 	if id == "" {
 		parts := strings.Split(r.URL.Path, "/")
@@ -115,8 +198,23 @@ func (a *API) AddComment(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	ticket, ok := a.Store.Get(id)
+	if !ok {
+		http.Error(w, `{"error":"ticket not found"}`, http.StatusNotFound)
+		return
+	}
+
+	if !requireTenant(w, r, ticket.CustomerID) {
+		return
+	}
+
 	var req AddCommentRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, `{"error":"request body too large"}`, http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
 		return
 	}
@@ -146,6 +244,8 @@ func (a *API) AddComment(w http.ResponseWriter, r *http.Request) {
 
 // CloseTicket handles POST /support/tickets/{id}/close.
 func (a *API) CloseTicket(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+
 	id := r.PathValue("id")
 	if id == "" {
 		parts := strings.Split(r.URL.Path, "/")
@@ -157,6 +257,10 @@ func (a *API) CloseTicket(w http.ResponseWriter, r *http.Request) {
 	ticket, ok := a.Store.Get(id)
 	if !ok {
 		http.Error(w, `{"error":"ticket not found"}`, http.StatusNotFound)
+		return
+	}
+
+	if !requireTenant(w, r, ticket.CustomerID) {
 		return
 	}
 

--- a/support/support_test.go
+++ b/support/support_test.go
@@ -571,6 +571,159 @@ func TestAPICloseTicketConflictJSONEscaping(t *testing.T) {
 	}
 }
 
+// --- Auth middleware tests ---
+
+// testAuth returns an AuthFunc that maps "token-<tenantID>" to tenantID.
+func testAuth(token string) (string, bool) {
+	if strings.HasPrefix(token, "token-") {
+		return strings.TrimPrefix(token, "token-"), true
+	}
+	return "", false
+}
+
+func newTestAPIWithAuth() *API {
+	api := newTestAPI()
+	api.Auth = testAuth
+	return api
+}
+
+func TestAPIUnauthenticatedReturns401(t *testing.T) {
+	api := newTestAPIWithAuth()
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	// No Authorization header at all.
+	req := httptest.NewRequest("GET", "/support/tickets?customer_id=cust-1", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAPIInvalidTokenReturns401(t *testing.T) {
+	api := newTestAPIWithAuth()
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/support/tickets?customer_id=cust-1", nil)
+	req.Header.Set("Authorization", "Bearer bad-token")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAPICrossTenantListReturns403(t *testing.T) {
+	api := newTestAPIWithAuth()
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	// Authenticated as cust-1, but requesting cust-2's tickets.
+	req := httptest.NewRequest("GET", "/support/tickets?customer_id=cust-2", nil)
+	req.Header.Set("Authorization", "Bearer token-cust-1")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAPICrossTenantGetReturns403(t *testing.T) {
+	api := newTestAPIWithAuth()
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	// Create a ticket as cust-1.
+	body := `{"customer_id":"cust-1","subject":"My ticket","priority":2}`
+	req := httptest.NewRequest("POST", "/support/tickets", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer token-cust-1")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("setup: expected 201, got %d", rr.Code)
+	}
+	var created Ticket
+	json.NewDecoder(rr.Body).Decode(&created)
+
+	// Try to get it as cust-2.
+	req = httptest.NewRequest("GET", "/support/tickets/"+created.ID, nil)
+	req.Header.Set("Authorization", "Bearer token-cust-2")
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAPICrossTenantCreateReturns403(t *testing.T) {
+	api := newTestAPIWithAuth()
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	// Authenticated as cust-1, but creating ticket for cust-2.
+	body := `{"customer_id":"cust-2","subject":"Sneaky","priority":2}`
+	req := httptest.NewRequest("POST", "/support/tickets", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer token-cust-1")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAPIOversizedBodyReturns413(t *testing.T) {
+	api := newTestAPIWithAuth()
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	// Create valid JSON that exceeds 1 MiB. The body field contains a large string.
+	bigValue := strings.Repeat("a", (1<<20)+1)
+	bigBody := `{"customer_id":"cust-1","subject":"Test","body":"` + bigValue + `","priority":2}`
+	req := httptest.NewRequest("POST", "/support/tickets", strings.NewReader(bigBody))
+	req.Header.Set("Authorization", "Bearer token-cust-1")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAPIAuthenticatedRequestSucceeds(t *testing.T) {
+	api := newTestAPIWithAuth()
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	// Create ticket as cust-1 with valid auth.
+	body := `{"customer_id":"cust-1","subject":"Help","body":"Need help","priority":1}`
+	req := httptest.NewRequest("POST", "/support/tickets", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer token-cust-1")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// List own tickets.
+	req = httptest.NewRequest("GET", "/support/tickets?customer_id=cust-1", nil)
+	req.Header.Set("Authorization", "Bearer token-cust-1")
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestAPIPriorityString(t *testing.T) {
 	tests := []struct {
 		p    Priority


### PR DESCRIPTION
## Summary
- **T108.20**: Add auth middleware, tenant verification, and body size limits to support API

## Test plan
- [x] go vet ./support/ clean
- [x] go test -race ./support/ pass