### PR TITLE
fix(serve): Wave 45 -- T108.23 isOOMError false positives

### DIFF
--- a/serve/server.go
+++ b/serve/server.go
@@ -396,7 +396,8 @@ func isOOMError(err error) bool {
 	return strings.Contains(msg, "out of memory") ||
 		strings.Contains(msg, "oom") ||
 		strings.Contains(msg, "cannot allocate") ||
-		strings.Contains(msg, "cuda")
+		strings.Contains(msg, "cuda_error_out_of_memory") ||
+		strings.Contains(msg, "cublas_status_alloc_failed")
 }
 
 // inferenceErrorStatus returns the appropriate HTTP status code for an inference error.

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -1435,6 +1435,9 @@ func TestIsOOMError(t *testing.T) {
 		{"CUDA out of memory: tried to allocate 2.00 GiB", true},
 		{"OOM killed", true},
 		{"cannot allocate memory", true},
+		{"CUDA_ERROR_OUT_OF_MEMORY", true},
+		{"CUBLAS_STATUS_ALLOC_FAILED", true},
+		{"cuda driver version mismatch", false},
 		{"forward error", false},
 		{"invalid request body", false},
 	}


### PR DESCRIPTION
## Summary
- **T108.23**: Replace broad "cuda" match with specific OOM patterns in isOOMError

## Test plan
- [x] go test -race ./serve/ pass