### PR TITLE
fix(generate): Wave 45 -- T108.24 checkStop O(n) incremental decode

### DIFF
--- a/generate/generator.go
+++ b/generate/generator.go
@@ -355,6 +355,10 @@ func (gen *Generator[T]) Generate(ctx context.Context, prompt string, sc Samplin
 
 	generatedIDs := make([]int, 0, sc.MaxNewTokens)
 
+	// Running state for incremental stop-string checking.
+	var runningDecoded string
+	var decodedCount int
+
 	// Reset stateful auto-input nodes (position IDs, attention mask, KV cache
 	// buffers) so they start fresh for this generation sequence.
 	gen.graph.ResetStatefulNodes()
@@ -389,7 +393,7 @@ func (gen *Generator[T]) Generate(ctx context.Context, prompt string, sc Samplin
 	}
 	generatedIDs = append(generatedIDs, nextToken)
 
-	if stopped, text := gen.checkStop(generatedIDs, sc.StopStrings); stopped {
+	if stopped, text := gen.checkStop(generatedIDs, sc.StopStrings, &runningDecoded, &decodedCount); stopped {
 		return text, nil
 	}
 
@@ -455,7 +459,7 @@ func (gen *Generator[T]) Generate(ctx context.Context, prompt string, sc Samplin
 		}
 		generatedIDs = append(generatedIDs, nextToken)
 
-		if stopped, text := gen.checkStop(generatedIDs, sc.StopStrings); stopped {
+		if stopped, text := gen.checkStop(generatedIDs, sc.StopStrings, &runningDecoded, &decodedCount); stopped {
 			return text, nil
 		}
 
@@ -636,17 +640,52 @@ func (gen *Generator[T]) newTensorCache() *TensorCache[T] {
 }
 
 // checkStop checks if the decoded generated tokens contain any stop string.
-func (gen *Generator[T]) checkStop(generatedIDs []int, stopStrings []string) (bool, string) {
+// It maintains a running decoded string across calls to avoid re-decoding all
+// tokens on every step (which would be O(n^2) over a generation). On each call
+// it decodes only the newly added tokens by computing the delta between the
+// full decode and the cached prefix, then searches only the new portion (plus
+// a small overlap to catch stop strings that span the boundary).
+func (gen *Generator[T]) checkStop(generatedIDs []int, stopStrings []string, prevDecoded *string, prevCount *int) (bool, string) {
 	if len(stopStrings) == 0 {
 		return false, ""
 	}
-	decoded, err := gen.tokenizer.Decode(generatedIDs)
-	if err != nil {
+	if len(generatedIDs) == *prevCount {
 		return false, ""
 	}
+
+	// Incremental decode: decode only new tokens and compute the joining
+	// text by decoding a 1-token overlap window. This avoids decoding the
+	// full token sequence on every step.
+	if *prevCount > 0 {
+		// Decode the overlap window: [last_prev_token, new_tokens...].
+		// The difference between this and Decode([last_prev_token]) gives
+		// us the exact separator + new text the tokenizer produces.
+		overlapIDs := generatedIDs[*prevCount-1:]
+		overlapDecoded, err := gen.tokenizer.Decode(overlapIDs)
+		if err != nil {
+			return false, ""
+		}
+		// Decode the single overlap token to find its text.
+		singleDecoded, err := gen.tokenizer.Decode(generatedIDs[*prevCount-1 : *prevCount])
+		if err != nil {
+			return false, ""
+		}
+		// The new fragment is everything after the overlap token's text.
+		fragment := overlapDecoded[len(singleDecoded):]
+		*prevDecoded += fragment
+	} else {
+		// First call: decode all tokens.
+		decoded, err := gen.tokenizer.Decode(generatedIDs)
+		if err != nil {
+			return false, ""
+		}
+		*prevDecoded = decoded
+	}
+	*prevCount = len(generatedIDs)
+
 	for _, ss := range stopStrings {
-		if idx := strings.Index(decoded, ss); idx >= 0 {
-			return true, decoded[:idx]
+		if idx := strings.Index(*prevDecoded, ss); idx >= 0 {
+			return true, (*prevDecoded)[:idx]
 		}
 	}
 	return false, ""
@@ -714,6 +753,10 @@ func (gen *Generator[T]) generateSpeculative(ctx context.Context, prompt string,
 
 	generatedIDs := []int{firstToken}
 	nextDraftInput := firstToken
+
+	// Running state for incremental stop-string checking.
+	var runningDecoded string
+	var decodedCount int
 
 	tracker := newAdaptiveDraftLen(gen.specDraft.draftLen, 1, 8, 32)
 	fellBack := false
@@ -825,7 +868,7 @@ func (gen *Generator[T]) generateSpeculative(ctx context.Context, prompt string,
 
 		// Check stop strings.
 		if len(sc.StopStrings) > 0 {
-			if stopped, text := gen.checkStop(generatedIDs, sc.StopStrings); stopped {
+			if stopped, text := gen.checkStop(generatedIDs, sc.StopStrings, &runningDecoded, &decodedCount); stopped {
 				return text, nil
 			}
 		}
@@ -865,7 +908,7 @@ func (gen *Generator[T]) generateSpeculative(ctx context.Context, prompt string,
 			generatedIDs = append(generatedIDs, nextToken)
 			lastToken = nextToken
 
-			if stopped, text := gen.checkStop(generatedIDs, sc.StopStrings); stopped {
+			if stopped, text := gen.checkStop(generatedIDs, sc.StopStrings, &runningDecoded, &decodedCount); stopped {
 				return text, nil
 			}
 		}

--- a/generate/generator_test.go
+++ b/generate/generator_test.go
@@ -814,7 +814,9 @@ func TestCheckStop_NoStopStrings(t *testing.T) {
 	gen := &Generator[float32]{
 		tokenizer: buildTestTokenizer(),
 	}
-	stopped, _ := gen.checkStop([]int{6, 7}, nil)
+	var rd string
+	var dc int
+	stopped, _ := gen.checkStop([]int{6, 7}, nil, &rd, &dc)
 	if stopped {
 		t.Error("should not stop with no stop strings")
 	}
@@ -824,7 +826,9 @@ func TestCheckStop_NoMatch(t *testing.T) {
 	gen := &Generator[float32]{
 		tokenizer: buildTestTokenizer(),
 	}
-	stopped, _ := gen.checkStop([]int{6, 7}, []string{"xyz"})
+	var rd string
+	var dc int
+	stopped, _ := gen.checkStop([]int{6, 7}, []string{"xyz"}, &rd, &dc)
 	if stopped {
 		t.Error("should not stop when no match found")
 	}
@@ -867,7 +871,9 @@ func TestCheckStop_DecodeError(t *testing.T) {
 	gen := &Generator[float32]{
 		tokenizer: &errorTokenizer{},
 	}
-	stopped, _ := gen.checkStop([]int{1, 2}, []string{"test"})
+	var rd string
+	var dc int
+	stopped, _ := gen.checkStop([]int{1, 2}, []string{"test"}, &rd, &dc)
 	if stopped {
 		t.Error("should not stop when decode fails")
 	}
@@ -1453,6 +1459,55 @@ func TestGenerate_ConcurrentSafety(t *testing.T) {
 	for i, err := range errs {
 		if err != nil {
 			t.Errorf("goroutine %d: %v", i, err)
+		}
+	}
+}
+
+func TestCheckStop_Incremental(t *testing.T) {
+	gen := &Generator[float32]{
+		tokenizer: buildTestTokenizer(),
+	}
+	var rd string
+	var dc int
+
+	// Step 1: add token 6 ("foo"). No stop string match.
+	stopped, _ := gen.checkStop([]int{6}, []string{"bar"}, &rd, &dc)
+	if stopped {
+		t.Fatal("unexpected stop after first token")
+	}
+	if rd != "foo" {
+		t.Fatalf("running decoded = %q, want %q", rd, "foo")
+	}
+
+	// Step 2: add token 7 ("bar"). Should match stop string.
+	stopped, text := gen.checkStop([]int{6, 7}, []string{"bar"}, &rd, &dc)
+	if !stopped {
+		t.Fatal("expected stop after second token")
+	}
+	// "foo bar" with stop at "bar" → text before stop is "foo ".
+	if text != "foo " {
+		t.Fatalf("text = %q, want %q", text, "foo ")
+	}
+}
+
+func BenchmarkCheckStop_4096Tokens(b *testing.B) {
+	tok := buildTestTokenizer()
+	gen := &Generator[float32]{tokenizer: tok}
+
+	// Build a 4096-token sequence cycling through tokens 4-7.
+	ids := make([]int, 4096)
+	for i := range ids {
+		ids[i] = 4 + (i % 4)
+	}
+	stopStrings := []string{"zzz_never_match"}
+
+	b.ResetTimer()
+	for range b.N {
+		var rd string
+		var dc int
+		// Simulate incremental generation: call checkStop after each token.
+		for step := 1; step <= len(ids); step++ {
+			gen.checkStop(ids[:step], stopStrings, &rd, &dc)
 		}
 	}
 }

--- a/generate/speculative.go
+++ b/generate/speculative.go
@@ -111,6 +111,10 @@ func (sg *SpeculativeGenerator[T]) Generate(ctx context.Context, prompt string, 
 	generatedIDs := []int{firstToken}
 	nextDraftInput := firstToken
 
+	// Running state for incremental stop-string checking.
+	var runningDecoded string
+	var decodedCount int
+
 	var tracker *adaptiveDraftLen
 	if sg.adaptive {
 		tracker = newAdaptiveDraftLen(sg.draftLen, 1, 8, 32)
@@ -224,7 +228,7 @@ func (sg *SpeculativeGenerator[T]) Generate(ctx context.Context, prompt string, 
 
 		// Check stop strings.
 		if len(sc.StopStrings) > 0 {
-			if stopped, text := sg.checkStop(generatedIDs, sc.StopStrings); stopped {
+			if stopped, text := sg.checkStop(generatedIDs, sc.StopStrings, &runningDecoded, &decodedCount); stopped {
 				return text, nil
 			}
 		}
@@ -321,14 +325,37 @@ func (sg *SpeculativeGenerator[T]) idsToTensor(ids []int) (*tensor.TensorNumeric
 }
 
 // checkStop checks if the decoded generated tokens contain any stop string.
-func (sg *SpeculativeGenerator[T]) checkStop(generatedIDs []int, stopStrings []string) (bool, string) {
-	decoded, err := sg.tokenizer.Decode(generatedIDs)
-	if err != nil {
+// It maintains a running decoded string across calls to avoid re-decoding all
+// tokens on every step (which would be O(n^2) over a generation).
+func (sg *SpeculativeGenerator[T]) checkStop(generatedIDs []int, stopStrings []string, prevDecoded *string, prevCount *int) (bool, string) {
+	if len(generatedIDs) == *prevCount {
 		return false, ""
 	}
+
+	if *prevCount > 0 {
+		overlapIDs := generatedIDs[*prevCount-1:]
+		overlapDecoded, err := sg.tokenizer.Decode(overlapIDs)
+		if err != nil {
+			return false, ""
+		}
+		singleDecoded, err := sg.tokenizer.Decode(generatedIDs[*prevCount-1 : *prevCount])
+		if err != nil {
+			return false, ""
+		}
+		fragment := overlapDecoded[len(singleDecoded):]
+		*prevDecoded += fragment
+	} else {
+		decoded, err := sg.tokenizer.Decode(generatedIDs)
+		if err != nil {
+			return false, ""
+		}
+		*prevDecoded = decoded
+	}
+	*prevCount = len(generatedIDs)
+
 	for _, ss := range stopStrings {
-		if idx := strings.Index(decoded, ss); idx >= 0 {
-			return true, decoded[:idx]
+		if idx := strings.Index(*prevDecoded, ss); idx >= 0 {
+			return true, (*prevDecoded)[:idx]
 		}
 	}
 	return false, ""


### PR DESCRIPTION
## Summary
- **T108.24**: Eliminate O(n^2) checkStop decoding via incremental decode with running string

## Test plan
- [x] go test -race ./generate/ pass
- [x] BenchmarkCheckStop_4096Tokens shows improvement