### PR TITLE
fix(timeseries): E109 T109.3 -- store normalization stats for PredictWindowed (C-003)

### DIFF
--- a/timeseries/cfc.go
+++ b/timeseries/cfc.go
@@ -49,8 +49,10 @@ type CfC struct {
 	// Optional GPU engine for accelerated training. When non-nil,
 	// TrainWindowed uses float32 tensor operations instead of the
 	// pure-Go float64 CPU path.
-	engine compute.Engine[float32]
-	ops    numeric.Arithmetic[float32]
+	engine    compute.Engine[float32]
+	ops       numeric.Arithmetic[float32]
+	normMeans [][]float64 // per-channel normalization means from training
+	normStds  [][]float64 // per-channel normalization stds from training
 }
 
 // NewCfC creates a new CfC model with the given configuration.
@@ -246,7 +248,7 @@ func (c *CfC) TrainWindowed(windows [][][]float64, labels []float64, config Trai
 	}
 
 	// Z-score normalize inputs to prevent gradient explosion on multi-scale data.
-	windows, _, _ = normalizeWindows(windows)
+	windows, c.normMeans, c.normStds = normalizeWindows(windows)
 
 	nParams := c.paramCount()
 	m := make([]float64, nParams)
@@ -603,6 +605,11 @@ func (c *CfC) PredictWindowed(modelPath string, windows [][][]float64) ([]float6
 		return nil, fmt.Errorf("cfc: empty input")
 	}
 
+	// Apply normalization from training if available.
+	if c.normMeans != nil {
+		windows = applyNormalization(windows, c.normMeans, c.normStds)
+	}
+
 	outDim := c.config.OutputSize * c.config.OutputLen
 	out := make([]float64, 0, nSamples*outDim)
 	for _, w := range windows {
@@ -706,10 +713,12 @@ func (c *CfC) flatParams() []*float64 {
 
 // cfcWeights is the JSON-serializable form of CfC parameters.
 type cfcWeights struct {
-	Config CfCConfig       `json:"config"`
-	Layers []cfcLayerFile  `json:"layers"`
-	OutW   [][]float64     `json:"out_w"`
-	OutB   []float64       `json:"out_b"`
+	Config    CfCConfig       `json:"config"`
+	Layers    []cfcLayerFile  `json:"layers"`
+	OutW      [][]float64     `json:"out_w"`
+	OutB      []float64       `json:"out_b"`
+	NormMeans [][]float64     `json:"norm_means,omitempty"`
+	NormStds  [][]float64     `json:"norm_stds,omitempty"`
 }
 
 type cfcLayerFile struct {
@@ -723,9 +732,11 @@ type cfcLayerFile struct {
 // SaveWeights writes the model weights to a JSON file.
 func (c *CfC) SaveWeights(path string) error {
 	w := cfcWeights{
-		Config: c.config,
-		OutW:   c.outW,
-		OutB:   c.outB,
+		Config:    c.config,
+		OutW:      c.outW,
+		OutB:      c.outB,
+		NormMeans: c.normMeans,
+		NormStds:  c.normStds,
 	}
 	for _, l := range c.layers {
 		w.Layers = append(w.Layers, cfcLayerFile{
@@ -768,5 +779,7 @@ func (c *CfC) loadWeights(path string) error {
 	}
 	c.outW = w.OutW
 	c.outB = w.OutB
+	c.normMeans = w.NormMeans
+	c.normStds = w.NormStds
 	return nil
 }

--- a/timeseries/cfc_engine.go
+++ b/timeseries/cfc_engine.go
@@ -44,7 +44,7 @@ func (c *CfC) trainWindowedEngine(windows [][][]float64, labels []float64, confi
 		config.Epsilon = 1e-8
 	}
 
-	windows, _, _ = normalizeWindows(windows)
+	windows, c.normMeans, c.normStds = normalizeWindows(windows)
 	ctx := context.Background()
 
 	// paramRef holds a float32 working copy and pointers back into the model's

--- a/timeseries/cfc_test.go
+++ b/timeseries/cfc_test.go
@@ -450,3 +450,45 @@ func TestCfC_TrainWindowed_MultiScale(t *testing.T) {
 	assertFiniteWeights(t, m.flatParams())
 	t.Logf("multi-scale training: final_loss=%.6f (20 epochs, 5 channels, 200 samples)", result.FinalLoss)
 }
+
+func TestCfC_PredictWindowed_NormalizationApplied(t *testing.T) {
+	nChannels := 3
+	inputLen := 8
+	m, err := NewCfC(CfCConfig{
+		InputSize:  nChannels,
+		HiddenSize: 8,
+		OutputSize: 2,
+		NumLayers:  1,
+		OutputLen:  3,
+	})
+	if err != nil {
+		t.Fatalf("NewCfC: %v", err)
+	}
+
+	windows, labels := makeMultiScaleWindows(100, nChannels, inputLen, 2*3)
+
+	_, err = m.TrainWindowed(windows, labels, TrainConfig{
+		Epochs:       10,
+		LR:           1e-3,
+		GradClip:     1.0,
+		WarmupEpochs: 3,
+	})
+	if err != nil {
+		t.Fatalf("TrainWindowed: %v", err)
+	}
+
+	if m.normMeans == nil || m.normStds == nil {
+		t.Fatal("normMeans/normStds not stored after training")
+	}
+
+	preds, err := m.PredictWindowed("", windows[:5])
+	if err != nil {
+		t.Fatalf("PredictWindowed: %v", err)
+	}
+
+	for i, v := range preds {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			t.Fatalf("prediction[%d] = %v, want finite", i, v)
+		}
+	}
+}

--- a/timeseries/dlinear.go
+++ b/timeseries/dlinear.go
@@ -139,6 +139,8 @@ type DLinear struct {
 	seasonalW [][]float64            // [channels][outputLen * inputLen]
 	seasonalB [][]float64            // [channels][outputLen]
 	engine    compute.Engine[float32] // optional; enables GPU-accelerated training
+	normMeans [][]float64            // per-channel normalization means from training
+	normStds  [][]float64            // per-channel normalization stds from training
 }
 
 // DLinearOption configures a DLinear model.
@@ -314,7 +316,7 @@ func (d *DLinear) TrainWindowed(windows [][][]float64, labels []float64, config 
 	}
 
 	// Z-score normalize inputs to prevent gradient explosion on multi-scale data.
-	windows, _, _ = normalizeWindows(windows)
+	windows, d.normMeans, d.normStds = normalizeWindows(windows)
 
 	// Flatten all parameters and their gradients for AdamW.
 	nParams := d.paramCount()
@@ -422,6 +424,27 @@ func (d *DLinear) TrainWindowed(windows [][][]float64, labels []float64, config 
 	return result, nil
 }
 
+// applyNormalization normalizes windows using stored means and stds from training.
+func applyNormalization(windows [][][]float64, means, stds [][]float64) [][][]float64 {
+	nSamples := len(windows)
+	if nSamples == 0 {
+		return windows
+	}
+	nChannels := len(windows[0])
+	inputLen := len(windows[0][0])
+	out := make([][][]float64, nSamples)
+	for i := 0; i < nSamples; i++ {
+		out[i] = make([][]float64, nChannels)
+		for c := 0; c < nChannels; c++ {
+			out[i][c] = make([]float64, inputLen)
+			for t := 0; t < inputLen; t++ {
+				out[i][c][t] = (windows[i][c][t] - means[c][t]) / (stds[c][t] + 1e-8)
+			}
+		}
+	}
+	return out
+}
+
 // PredictWindowed runs inference on windowed data.
 // windows: [nSamples][channels][inputLen].
 // Returns flat predictions of length nSamples * channels * outputLen.
@@ -436,6 +459,11 @@ func (d *DLinear) PredictWindowed(modelPath string, windows [][][]float64) ([]fl
 	nSamples := len(windows)
 	if nSamples == 0 {
 		return nil, fmt.Errorf("dlinear: empty input")
+	}
+
+	// Apply normalization from training if available.
+	if d.normMeans != nil {
+		windows = applyNormalization(windows, d.normMeans, d.normStds)
 	}
 
 	out := make([]float64, 0, nSamples*d.config.Channels*d.config.OutputLen)
@@ -499,6 +527,8 @@ type dlinearWeights struct {
 	TrendB     [][]float64     `json:"trend_b"`
 	SeasonalW  [][]float64     `json:"seasonal_w"`
 	SeasonalB  [][]float64     `json:"seasonal_b"`
+	NormMeans  [][]float64     `json:"norm_means,omitempty"`
+	NormStds   [][]float64     `json:"norm_stds,omitempty"`
 }
 
 // SaveWeights writes the model weights to a JSON file.
@@ -509,6 +539,8 @@ func (d *DLinear) SaveWeights(path string) error {
 		TrendB:    d.trendB,
 		SeasonalW: d.seasonalW,
 		SeasonalB: d.seasonalB,
+		NormMeans: d.normMeans,
+		NormStds:  d.normStds,
 	}
 	data, err := json.Marshal(w)
 	if err != nil {
@@ -534,5 +566,7 @@ func (d *DLinear) loadWeights(path string) error {
 	d.trendB = w.TrendB
 	d.seasonalW = w.SeasonalW
 	d.seasonalB = w.SeasonalB
+	d.normMeans = w.NormMeans
+	d.normStds = w.NormStds
 	return nil
 }

--- a/timeseries/dlinear_engine.go
+++ b/timeseries/dlinear_engine.go
@@ -31,7 +31,7 @@ func (d *DLinear) trainWindowedEngine(windows [][][]float64, labels []float64, c
 	}
 
 	nSamples := len(windows)
-	windows, _, _ = normalizeWindows(windows)
+	windows, d.normMeans, d.normStds = normalizeWindows(windows)
 
 	ctx := context.Background()
 	eng := d.engine

--- a/timeseries/dlinear_test.go
+++ b/timeseries/dlinear_test.go
@@ -650,3 +650,40 @@ func TestDLinear_TrainWindowed_MultiScale(t *testing.T) {
 	assertFiniteWeights(t, m.flatParams())
 	t.Logf("multi-scale training: final_loss=%.6f (20 epochs, 5 channels, 500 samples)", result.FinalLoss)
 }
+
+func TestDLinear_PredictWindowed_NormalizationApplied(t *testing.T) {
+	inputLen := 10
+	outputLen := 3
+	nChannels := 3
+	m, err := NewDLinear(inputLen, outputLen, nChannels, 3)
+	if err != nil {
+		t.Fatalf("NewDLinear: %v", err)
+	}
+
+	windows, labels := makeMultiScaleWindows(100, nChannels, inputLen, nChannels*outputLen)
+
+	_, err = m.TrainWindowed(windows, labels, TrainConfig{
+		Epochs:       10,
+		LR:           1e-3,
+		GradClip:     1.0,
+		WarmupEpochs: 3,
+	})
+	if err != nil {
+		t.Fatalf("TrainWindowed: %v", err)
+	}
+
+	if m.normMeans == nil || m.normStds == nil {
+		t.Fatal("normMeans/normStds not stored after training")
+	}
+
+	preds, err := m.PredictWindowed("", windows[:5])
+	if err != nil {
+		t.Fatalf("PredictWindowed: %v", err)
+	}
+
+	for i, v := range preds {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			t.Fatalf("prediction[%d] = %v, want finite", i, v)
+		}
+	}
+}

--- a/timeseries/nhits.go
+++ b/timeseries/nhits.go
@@ -39,10 +39,12 @@ type nhitsStack struct {
 // The hierarchical design lets different stacks capture patterns at different
 // temporal granularities.
 type NHiTS struct {
-	config NHiTSConfig
-	engine compute.Engine[float32]
-	ops    numeric.Arithmetic[float32]
-	stacks []nhitsStack
+	config    NHiTSConfig
+	engine    compute.Engine[float32]
+	ops       numeric.Arithmetic[float32]
+	stacks    []nhitsStack
+	normMeans [][]float64 // per-channel normalization means from training
+	normStds  [][]float64 // per-channel normalization stds from training
 }
 
 // NewNHiTS creates a new N-HiTS model with the given configuration.
@@ -503,7 +505,7 @@ func (n *NHiTS) TrainWindowed(windows [][][]float64, labels []float64, config Tr
 	}
 
 	// Z-score normalize inputs to prevent gradient explosion on multi-scale data.
-	windows, _, _ = normalizeWindows(windows)
+	windows, n.normMeans, n.normStds = normalizeWindows(windows)
 
 	ctx := context.Background()
 	result := &TrainResult{}
@@ -730,8 +732,10 @@ func (n *NHiTS) adamUpdate(params, grads []float32, state *adamState, beta1, bet
 
 // nhitsModelFile is the JSON structure for saving/loading N-HiTS models.
 type nhitsModelFile struct {
-	Config NHiTSConfig      `json:"config"`
-	Stacks []nhitsStackFile `json:"stacks"`
+	Config    NHiTSConfig      `json:"config"`
+	Stacks    []nhitsStackFile `json:"stacks"`
+	NormMeans [][]float64      `json:"norm_means,omitempty"`
+	NormStds  [][]float64      `json:"norm_stds,omitempty"`
 }
 
 type nhitsStackFile struct {
@@ -744,7 +748,7 @@ type nhitsStackFile struct {
 
 // Save writes the N-HiTS model to a JSON file.
 func (n *NHiTS) Save(path string) error {
-	mf := nhitsModelFile{Config: n.config}
+	mf := nhitsModelFile{Config: n.config, NormMeans: n.normMeans, NormStds: n.normStds}
 	for _, stack := range n.stacks {
 		sf := nhitsStackFile{PoolKernel: stack.poolKernel}
 		for _, l := range stack.mlpLayers {
@@ -774,6 +778,11 @@ func (n *NHiTS) PredictWindowed(modelPath string, windows [][][]float64) ([]floa
 
 	if len(windows) == 0 {
 		return nil, fmt.Errorf("nhits predict: no windows provided")
+	}
+
+	// Apply normalization from training if available.
+	if n.normMeans != nil {
+		windows = applyNormalization(windows, n.normMeans, n.normStds)
 	}
 
 	numSamples := len(windows)
@@ -833,6 +842,8 @@ func (n *NHiTS) Load(path string) error {
 		copy(stack.outputProj.biases.Data(), float64ToFloat32(sf.ProjBias))
 	}
 
+	n.normMeans = mf.NormMeans
+	n.normStds = mf.NormStds
 	return nil
 }
 

--- a/timeseries/nhits_test.go
+++ b/timeseries/nhits_test.go
@@ -810,3 +810,53 @@ func TestNHiTS_HighChannelNoNilPanic(t *testing.T) {
 		})
 	}
 }
+
+func TestNHiTS_PredictWindowed_NormalizationApplied(t *testing.T) {
+	engine, ops := newTestEngine()
+
+	nChannels := 3
+	inputLen := 8
+	outputLen := 4
+	config := NHiTSConfig{
+		InputLength:  inputLen,
+		OutputLength: outputLen,
+		Channels:     nChannels,
+		PoolKernels:  []int{2, 4},
+		HiddenSize:   16,
+		NumMLPLayers: 2,
+	}
+
+	m, err := NewNHiTS(config, engine, ops)
+	if err != nil {
+		t.Fatalf("NewNHiTS: %v", err)
+	}
+	m.initWeightsSmall()
+
+	windows, labels := makeMultiScaleWindows(100, nChannels, inputLen, outputLen)
+
+	_, err = m.TrainWindowed(windows, labels, TrainConfig{
+		Epochs:       10,
+		LR:           1e-3,
+		BatchSize:    32,
+		GradClip:     1.0,
+		WarmupEpochs: 3,
+	})
+	if err != nil {
+		t.Fatalf("TrainWindowed: %v", err)
+	}
+
+	if m.normMeans == nil || m.normStds == nil {
+		t.Fatal("normMeans/normStds not stored after training")
+	}
+
+	preds, err := m.PredictWindowed("", windows[:5])
+	if err != nil {
+		t.Fatalf("PredictWindowed: %v", err)
+	}
+
+	for i, v := range preds {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			t.Fatalf("prediction[%d] = %v, want finite", i, v)
+		}
+	}
+}

--- a/timeseries/patchtst.go
+++ b/timeseries/patchtst.go
@@ -46,13 +46,15 @@ type encoderLayer struct {
 
 // PatchTST implements the Patch Time-Series Transformer.
 type PatchTST struct {
-	config   PatchTSTConfig
-	engine   compute.Engine[float32]
-	ops      numeric.Arithmetic[float32]
-	patchEmb linearLayer                    // patch_length -> d_model
-	posEmb   *tensor.TensorNumeric[float32] // [1, num_patches, d_model]
-	layers   []encoderLayer
-	head     linearLayer // num_patches * d_model -> output_dim
+	config    PatchTSTConfig
+	engine    compute.Engine[float32]
+	ops       numeric.Arithmetic[float32]
+	patchEmb  linearLayer                    // patch_length -> d_model
+	posEmb    *tensor.TensorNumeric[float32] // [1, num_patches, d_model]
+	layers    []encoderLayer
+	head      linearLayer // num_patches * d_model -> output_dim
+	normMeans [][]float64 // per-channel normalization means from training
+	normStds  [][]float64 // per-channel normalization stds from training
 }
 
 // NewPatchTST creates a new PatchTST model with the given configuration.
@@ -1165,7 +1167,7 @@ func (m *PatchTST) TrainWindowed(windows [][][]float64, labels []float64, config
 	}
 
 	// Z-score normalize inputs to prevent gradient explosion on multi-scale data.
-	windows, _, _ = normalizeWindows(windows)
+	windows, m.normMeans, m.normStds = normalizeWindows(windows)
 
 	if m.engine != nil {
 		return m.trainWindowedEngine(windows, labels, config)
@@ -1188,6 +1190,11 @@ func (m *PatchTST) PredictWindowed(modelPath string, windows [][][]float64) ([]f
 		return nil, fmt.Errorf("patchtst: empty input")
 	}
 
+	// Apply normalization from training if available.
+	if m.normMeans != nil {
+		windows = applyNormalization(windows, m.normMeans, m.normStds)
+	}
+
 	params := m.extractParamsF64()
 	out := make([]float64, 0, nSamples*m.config.OutputDim)
 	for _, w := range windows {
@@ -1199,13 +1206,15 @@ func (m *PatchTST) PredictWindowed(modelPath string, windows [][][]float64) ([]f
 
 // patchTSTWeights is the JSON-serializable form of PatchTST parameters.
 type patchTSTWeights struct {
-	Config    PatchTSTConfig    `json:"config"`
-	PatchEmbW []float64        `json:"patch_emb_w"`
-	PatchEmbB []float64        `json:"patch_emb_b"`
-	PosEmb    []float64        `json:"pos_emb"`
+	Config    PatchTSTConfig     `json:"config"`
+	PatchEmbW []float64         `json:"patch_emb_w"`
+	PatchEmbB []float64         `json:"patch_emb_b"`
+	PosEmb    []float64         `json:"pos_emb"`
 	Layers    []encoderLayerJSON `json:"layers"`
-	HeadW     []float64        `json:"head_w"`
-	HeadB     []float64        `json:"head_b"`
+	HeadW     []float64         `json:"head_w"`
+	HeadB     []float64         `json:"head_b"`
+	NormMeans [][]float64       `json:"norm_means,omitempty"`
+	NormStds  [][]float64       `json:"norm_stds,omitempty"`
 }
 
 type encoderLayerJSON struct {
@@ -1237,6 +1246,8 @@ func (m *PatchTST) SaveWeights(path string) error {
 		PosEmb:    p.posEmb,
 		HeadW:     p.headW,
 		HeadB:     p.headB,
+		NormMeans: m.normMeans,
+		NormStds:  m.normStds,
 	}
 	for _, l := range p.layers {
 		w.Layers = append(w.Layers, encoderLayerJSON{
@@ -1291,5 +1302,7 @@ func (m *PatchTST) loadWeights(path string) error {
 		}
 	}
 	m.writeBackF32(p)
+	m.normMeans = w.NormMeans
+	m.normStds = w.NormStds
 	return nil
 }

--- a/timeseries/patchtst_test.go
+++ b/timeseries/patchtst_test.go
@@ -718,3 +718,52 @@ func TestPatchTST_TrainWindowed_EngineConvergence(t *testing.T) {
 	t.Logf("engine convergence: loss[0]=%.6f -> loss[9]=%.6f",
 		result.LossHistory[0], result.LossHistory[9])
 }
+
+func TestPatchTST_PredictWindowed_NormalizationApplied(t *testing.T) {
+	engine, ops := newTestEngine()
+
+	nChannels := 3
+	inputLen := 8
+	outputDim := 1
+	config := PatchTSTConfig{
+		InputLength: inputLen,
+		PatchLength: 4,
+		Stride:      4,
+		DModel:      8,
+		NHeads:      2,
+		NLayers:     1,
+		OutputDim:   outputDim,
+	}
+
+	m, err := NewPatchTST(config, engine, ops)
+	if err != nil {
+		t.Fatalf("NewPatchTST: %v", err)
+	}
+
+	windows, labels := makeMultiScaleWindows(20, nChannels, inputLen, outputDim)
+
+	_, err = m.TrainWindowed(windows, labels, TrainConfig{
+		Epochs:       5,
+		LR:           1e-3,
+		GradClip:     1.0,
+		WarmupEpochs: 2,
+	})
+	if err != nil {
+		t.Fatalf("TrainWindowed: %v", err)
+	}
+
+	if m.normMeans == nil || m.normStds == nil {
+		t.Fatal("normMeans/normStds not stored after training")
+	}
+
+	preds, err := m.PredictWindowed("", windows[:5])
+	if err != nil {
+		t.Fatalf("PredictWindowed: %v", err)
+	}
+
+	for i, v := range preds {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			t.Fatalf("prediction[%d] = %v, want finite", i, v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **T109.3** (C-003): Store z-score normalization means/stds during TrainWindowed and apply in PredictWindowed for all 4 backends (DLinear, NHiTS, CfC, PatchTST)

## Test plan
- [x] go test -race ./timeseries/ pass (all 4 backends)