### PR TITLE
docs: update benchmark claims and devlog for multi-model results

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pure Go ML framework -- inference, training, and serving. Embed any GGUF model i
 [![Go Reference](https://pkg.go.dev/badge/github.com/zerfoo/zerfoo.svg)](https://pkg.go.dev/github.com/zerfoo/zerfoo)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-**244 tok/s** on Gemma 3 1B Q4_K_M (95% memory bandwidth utilization) -- 20% faster than Ollama. Zero CGo. 20 model architectures. Tabular ML and time-series forecasting built in.
+**236 tok/s** on Gemma 3 1B Q4_K_M (92% memory bandwidth utilization) -- 16% faster than Ollama. Zero CGo. 20 model architectures. Tabular ML and time-series forecasting built in.
 
 ## Quick Start
 
@@ -136,7 +136,7 @@ for _, tc := range result.ToolCalls {
 
 | Architecture | Format | Special Features |
 |-------------|--------|-----------------|
-| Gemma 3 | GGUF Q4_K | Production. CUDA graph capture, 244 tok/s |
+| Gemma 3 | GGUF Q4_K | Production. CUDA graph capture, 236 tok/s |
 | Gemma 3n | GGUF | Mobile-optimized variant |
 | Llama 3 | GGUF | RoPE theta=500K |
 | Llama 4 | GGUF | Latest generation |

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -5,6 +5,38 @@ Entries are newest-first. Prune entries older than 90 days during /trim.
 
 ---
 
+## 2026-03-25: Multi-model benchmark — Zerfoo vs Ollama (6 architectures)
+
+**Type:** benchmark
+**Tags:** benchmark, ollama, multi-model, DGX Spark, throughput
+
+**Problem:** Zerfoo claimed 245 tok/s on Gemma 3 1B (20% faster than Ollama) but this was measured on a single model. Need head-to-head comparison across all supported architectures.
+
+**Root cause:** N/A (benchmark, not bug).
+
+**Results (DGX Spark GB10, commit 294aa43, Ollama v0.17.7, 128 tokens, 3 runs median, greedy):**
+
+| Model | Zerfoo (tok/s) | Ollama (tok/s) | Ratio | Winner |
+|-------|----------------|----------------|-------|--------|
+| Gemma 3 1B Q4_K_M | 236.38 | 204.37 | 1.16x | Zerfoo |
+| DeepSeek R1 1.5B Q4_K_M | 192.83 | 184.75 | 1.04x | Zerfoo |
+| Llama 3.2 3B Q4_K_M | 96.06 | 97.66 | 0.98x | ~Even |
+| Mistral 7B Q4_K_M | 11.61 | 46.77 | 0.25x | Ollama |
+| Phi 3 mini Q4_K_M | FAIL | 90.80 | N/A | GGUF load failure |
+| Llama 3.1 8B Q4_K_M | FAIL | 42.85 | N/A | GGUF load failure |
+
+**Key findings:**
+1. Gemma 3 1B advantage confirmed at 1.16x (down from 1.20x due to v1.19.0 codebase changes — still meets >= 1.15x target).
+2. DeepSeek R1 1.5B: Zerfoo slightly faster (1.04x).
+3. Llama 3.2 3B: Parity with Ollama (0.98x).
+4. **Mistral 7B: major regression** — Zerfoo 4x slower than Ollama. Only 11.61 tok/s vs expected ~50+ tok/s. Needs investigation (likely missing CUDA graph capture or fallback to CPU path for some ops).
+5. Phi 3 mini and Llama 3.1 8B: GGUF files from HuggingFace fail to load. Parser compatibility issue with these specific GGUF variants.
+6. ztensor v0.3.0 had linux/arm64 dlopen linker failure — upgraded to v0.4.1 to fix.
+
+**Impact:** README updated from "244 tok/s, 20% faster" to "236 tok/s, 16% faster". Website benchmarks page updated with multi-model comparison table. Mistral 7B regression needs separate issue.
+
+---
+
 ## 2026-03-20: E103 throughput regression root cause — two compounding bugs
 
 **Type:** investigation


### PR DESCRIPTION
## Summary

- Update README headline from "244 tok/s, 20% faster" to "236 tok/s, 16% faster" to match the multi-model benchmark results from PR #174
- Add devlog entry documenting the full 6-architecture benchmark run
- Website benchmarks page already updated separately (zerfoo.github.io commit 95945d8)

## Changes

- **README.md**: Update tok/s claim (244 → 236) and advantage claim (20% → 16%)
- **docs/devlog.md**: Add benchmark entry with results table, findings, and impact notes

## Context

PR #174 established that the Gemma 3 1B advantage is 1.16x (16%), not 1.20x (20%). The README and docs need to reflect the actual measured numbers.

## Test plan

- [x] Numbers match benchmark results from PR #174
- [x] Website already updated and pushed