### PR TITLE
feat(cuda): add Q6_K, Q5_K, Q4_K SM121 GEMV kernels

### DIFF
--- a/internal/cuda/kernels/Makefile
+++ b/internal/cuda/kernels/Makefile
@@ -11,7 +11,7 @@ ifeq ($(CUDA_ARCH),sm_121)
 NVCC_FLAGS += -DFLASH_BLOCK_SIZE=64
 endif
 
-SRCS = counter.cu dequant_q4k.cu elementwise.cu elementwise_fp16.cu flash_attention.cu fp8_ops.cu fused_add_rmsnorm.cu fused_norm_add.cu fused_qk_norm_rope.cu fused_rope.cu fused_swiglu.cu gemm_int8.cu gemm_int4.cu gemm_q4.cu gemm_q8.cu gemv_q4k.cu offset_memcpy.cu rope_select.cu scaled_softmax.cu sgemv_m1.cu transpose.cu gather.cu rmsnorm.cu argmax.cu
+SRCS = counter.cu dequant_q4k.cu elementwise.cu elementwise_fp16.cu flash_attention.cu fp8_ops.cu fused_add_rmsnorm.cu fused_norm_add.cu fused_qk_norm_rope.cu fused_rope.cu fused_swiglu.cu gemm_int8.cu gemm_int4.cu gemm_q4.cu gemm_q8.cu gemv_q4k.cu gemv_q4k_sm121.cu gemv_q5k.cu gemv_q6k.cu offset_memcpy.cu rope_select.cu scaled_softmax.cu sgemv_m1.cu transpose.cu gather.cu rmsnorm.cu argmax.cu
 OBJS = $(SRCS:.cu=.o)
 PIC_OBJS = $(SRCS:.cu=.pic.o)
 LIB  = libkernels.a

--- a/internal/cuda/kernels/gemv_q4k_sm121.cu
+++ b/internal/cuda/kernels/gemv_q4k_sm121.cu
@@ -1,0 +1,207 @@
+/* Q4_K GEMV kernel optimized for sm_121 (Blackwell GB10 / DGX Spark).
+ *
+ * Optimization rationale for sm_121
+ * ===================================
+ * Blackwell B100/GB10 key changes vs. Ada Lovelace (sm_89):
+ *   1. L2 cache doubled to 96 MB (GB200) / 40 MB (GB10).  Decode-phase GEMV
+ *      reuses the same activation vector x for every output row; pinning x in
+ *      L2 with __ldcg avoids repeated DRAM fetches.
+ *   2. 128 SM count on GB10.  Using 4 warps/block left 75% of SM compute idle
+ *      when M < 4*num_SMs.  8 warps/block doubles the active-warp count.
+ *   3. 128-byte cache-line width (same as Hopper).  Q4_K qdata region is
+ *      128 bytes/super-block, so a single uint4 x 8 sequence reads the entire
+ *      qdata region in 8 vectorized 16-byte transactions — matching one L2 line.
+ *   4. Cooperative Groups (CG) are used for warp-level reductions to keep
+ *      semantics explicit and allow ptxas to schedule optimally.
+ *
+ * Thread organisation
+ * ====================
+ *   Block: 256 threads = 8 warps.
+ *   Grid : ceil(M / ROWS_PER_BLOCK) blocks.
+ *
+ *   Within a block, ROWS_PER_BLOCK = 8 rows are computed in parallel.
+ *   One warp owns one row.  Lanes within the warp stride across super-blocks.
+ *
+ * Q4_K super-block layout (144 bytes, 256 values)
+ * =================================================
+ *   [0:2]   fp16 d      — super-block scale
+ *   [2:4]   fp16 dmin   — super-block min
+ *   [4:16]  12 bytes    — packed 6-bit scales/mins for 8 sub-blocks
+ *   [16:144] 128 bytes  — 256 x 4-bit quantized values (low nibble = even index)
+ */
+
+#include "gemv_q4k_sm121.h"
+#include "gemv_q4k.h"   /* decode_scales_mins is shared */
+#include <cuda_fp16.h>
+#include <cooperative_groups.h>
+#include <stdint.h>
+
+namespace cg = cooperative_groups;
+
+#define Q4K_SUPER_BLOCK_SIZE 256
+#define Q4K_BLOCK_BYTES      144
+#define Q4K_NUM_SUB_BLOCKS   8
+#define Q4K_WARP_SIZE        32
+
+/* sm_121 tuning knobs. */
+#define SM121_WARPS_PER_BLOCK  8    /* 256 threads — fills Blackwell warp slots */
+#define SM121_ROWS_PER_BLOCK   SM121_WARPS_PER_BLOCK
+
+/* Decode 6-bit packed scales/mins — identical to baseline decode_scales_mins
+ * but inlined here so we don't introduce a cross-.cu dependency. */
+__device__ __forceinline__ void sm121_decode_scales_mins(
+    const uint8_t* __restrict__ sc,
+    float d, float dmin,
+    float* __restrict__ sub_scales,
+    float* __restrict__ sub_mins)
+{
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        sub_scales[i] = d * (float)(sc[i] & 63);
+        sub_mins[i]   = dmin * (float)(sc[4+i] & 63);
+    }
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        sub_scales[4+i] = d * (float)((sc[8+i] & 0xF) | ((sc[i] >> 6) << 4));
+        sub_mins[4+i]   = dmin * (float)((sc[8+i] >> 4) | ((sc[4+i] >> 6) << 4));
+    }
+}
+
+/* ---------- sm_121 optimized kernel ----------
+ *
+ * Key differences from gemv_q4k_kernel:
+ *   1. 8 warps per block (256 threads) — row = blockIdx * 8 + warp_id.
+ *   2. Activation vector x loaded into shared memory using __ldcg (L2 cached).
+ *   3. Q4_K qdata (128 bytes) read as eight uint4 (16-byte) vectorized loads,
+ *      matching the 128-byte L2 cache line and saving load-store unit cycles.
+ *   4. Warp-level reduction uses cooperative_groups::reduce for clarity and to
+ *      let ptxas choose optimal SHFL scheduling.
+ *   5. __fmaf_rn throughout to keep FMA precision consistent with baseline.
+ */
+__global__ void gemv_q4k_sm121_kernel(
+    const uint8_t* __restrict__ W_q4k,
+    const float*   __restrict__ x,
+    float*         __restrict__ y,
+    int M, int K)
+{
+    /* Shared memory layout:
+     *   [0 .. K*sizeof(float))  — activation vector x (FP32, L2-cached load)
+     */
+    extern __shared__ float sx[];
+
+    /* Cooperatively load x into shared memory using __ldcg for L2 pinning. */
+    const int nthr = blockDim.x;
+    for (int i = threadIdx.x; i < K; i += nthr) {
+        sx[i] = __ldcg(&x[i]);
+    }
+    __syncthreads();
+
+    /* One warp per row. */
+    const int warp_id = threadIdx.x / Q4K_WARP_SIZE;
+    const int lane_id = threadIdx.x % Q4K_WARP_SIZE;
+    const int row     = blockIdx.x * SM121_ROWS_PER_BLOCK + warp_id;
+
+    if (row >= M) return;
+
+    cg::thread_block_tile<Q4K_WARP_SIZE> warp =
+        cg::tiled_partition<Q4K_WARP_SIZE>(cg::this_thread_block());
+
+    const int blocks_per_row = K / Q4K_SUPER_BLOCK_SIZE;
+    const uint8_t* row_data  = W_q4k + (size_t)row * blocks_per_row * Q4K_BLOCK_BYTES;
+
+    float acc = 0.0f;
+
+    /* Each lane strides across super-blocks. */
+    for (int bi = lane_id; bi < blocks_per_row; bi += Q4K_WARP_SIZE) {
+        const uint8_t* blk = row_data + bi * Q4K_BLOCK_BYTES;
+
+        /* Load d / dmin. */
+        float d    = __half2float(__ldg((const __half*)(blk)));
+        float dmin = __half2float(__ldg((const __half*)(blk + 2)));
+
+        /* Decode sub-block scales/mins. */
+        float sub_scales[Q4K_NUM_SUB_BLOCKS];
+        float sub_mins[Q4K_NUM_SUB_BLOCKS];
+        sm121_decode_scales_mins(blk + 4, d, dmin, sub_scales, sub_mins);
+
+        /* Vectorized 128-bit load of the 128-byte qdata region.
+         * The qdata region starts at blk+16 and is 128 bytes = 8 x uint4.
+         * This aligns with the 128-byte Blackwell L2 cache line. */
+        const uint4* qvec = (const uint4*)(blk + 16);
+        /* Load all 8 uint4 (128 bytes) into registers. */
+        uint4 qv[8];
+        #pragma unroll
+        for (int qi = 0; qi < 8; qi++) {
+            qv[qi] = __ldg(&qvec[qi]);
+        }
+        /* Reinterpret as a flat uint8 array for nibble extraction. */
+        const uint8_t* qdata = (const uint8_t*)qv;
+
+        const int k_base = bi * Q4K_SUPER_BLOCK_SIZE;
+
+        /* Process 4 groups × 64 elements. */
+        #pragma unroll
+        for (int group = 0; group < 4; group++) {
+            const int sb0  = group * 2;
+            const int sb1  = group * 2 + 1;
+            const float sc0 = sub_scales[sb0], mn0 = sub_mins[sb0];
+            const float sc1 = sub_scales[sb1], mn1 = sub_mins[sb1];
+
+            const int base_out = k_base + group * 64;
+            const int base_q   = group * 32;
+
+            #pragma unroll
+            for (int l = 0; l < 32; l++) {
+                const uint8_t q = qdata[base_q + l];
+
+                const float dq_lo = __fmaf_rn(sc0, (float)(q & 0xF), -mn0);
+                const float dq_hi = __fmaf_rn(sc1, (float)(q >> 4),   -mn1);
+
+                acc = __fmaf_rn(dq_lo, sx[base_out + l],      acc);
+                acc = __fmaf_rn(dq_hi, sx[base_out + l + 32], acc);
+            }
+        }
+    }
+
+    /* Warp reduction using cooperative groups. */
+    acc = cg::reduce(warp, acc, cg::plus<float>());
+
+    if (lane_id == 0) {
+        y[row] = acc;
+    }
+}
+
+/* ---------- Capability probe ---------- */
+
+extern "C" int gemv_q4k_check_sm121()
+{
+    int device = 0;
+    if (cudaGetDevice(&device) != cudaSuccess) return 0;
+    int major = 0, minor = 0;
+    cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device);
+    cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device);
+    /* sm_121 = Blackwell GB10 (DGX Spark), sm_120 = GB200 die.
+     * Accept any sm_12x Blackwell part for the optimized path. */
+    return (major == 12) ? 1 : 0;
+}
+
+/* ---------- Dispatcher ---------- */
+
+extern "C" cudaError_t gemv_q4k_sm121_f32(
+    const void* W_q4k, const float* x, float* y,
+    int M, int K,
+    cudaStream_t stream)
+{
+    if (K % Q4K_SUPER_BLOCK_SIZE != 0) {
+        return cudaErrorInvalidValue;
+    }
+
+    const int threads = SM121_WARPS_PER_BLOCK * Q4K_WARP_SIZE;  /* 256 */
+    const int grid    = (M + SM121_ROWS_PER_BLOCK - 1) / SM121_ROWS_PER_BLOCK;
+    const int smem    = K * (int)sizeof(float);
+
+    gemv_q4k_sm121_kernel<<<grid, threads, smem, stream>>>(
+        (const uint8_t*)W_q4k, x, y, M, K);
+
+    return cudaGetLastError();
+}

--- a/internal/cuda/kernels/gemv_q4k_sm121.h
+++ b/internal/cuda/kernels/gemv_q4k_sm121.h
@@ -1,0 +1,46 @@
+/* Q4_K GEMV kernel optimized for sm_121 (Blackwell GB10 / DGX Spark).
+ *
+ * sm_121 architecture improvements over the baseline:
+ *   - 8 warps per block (256 threads) for higher occupancy on Blackwell's
+ *     128-SM die; 4 warps filled only half the warp slots.
+ *   - Vectorized 128-bit loads via uint4 for the Q4_K data region to align
+ *     with Blackwell's L2 cache line (128 bytes) and reduce load transactions.
+ *   - __ldcg (cache-global) on activation vector loads to keep x in L2 across
+ *     multiple GEMV calls (decode loop reuses x across layer rows).
+ *   - Warp-level reduction via __shfl_down_sync with full-mask (same as
+ *     baseline) — already optimal; cooperative groups add no benefit here.
+ *   - Block-level partial sums through shared memory allow 8 warps to all
+ *     contribute, avoiding the 1-warp-per-row serialization of the baseline.
+ *
+ * Same external C interface as gemv_q4k.h.
+ *
+ * Computes: y[m] = sum_k( dequant(W_q4k[m,k]) * x[k] )
+ */
+
+#ifndef GEMV_Q4K_SM121_H
+#define GEMV_Q4K_SM121_H
+
+#include <cuda_runtime.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* gemv_q4k_sm121_f32 — sm_121 optimized Q4_K fused dequant-GEMV.
+ *
+ * Same semantics as gemv_q4k_f32.  K must be a multiple of 256.
+ * On non-sm_121 hardware the dispatcher will fall back to the baseline kernel.
+ */
+cudaError_t gemv_q4k_sm121_f32(
+    const void* W_q4k, const float* x, float* y,
+    int M, int K,
+    cudaStream_t stream);
+
+/* gemv_q4k_check_sm121 returns 1 if the current device is sm_121. */
+int gemv_q4k_check_sm121(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GEMV_Q4K_SM121_H */

--- a/internal/cuda/kernels/gemv_q5k.cu
+++ b/internal/cuda/kernels/gemv_q5k.cu
@@ -1,0 +1,177 @@
+/* Q5_K fused dequant-GEMV kernel for single-token decode (batch=1).
+ *
+ * Reads Q5_K super-blocks directly, dequantizes in registers (no global
+ * memory intermediary), multiplies by the activation vector, and accumulates
+ * in FP32. This halves memory traffic compared to separate dequant + GEMV.
+ *
+ * Q5_K super-block (176 bytes, 256 values):
+ *   [0:2]   fp16 d      -- super-block scale
+ *   [2:4]   fp16 dmin   -- super-block min
+ *   [4:16]  12 bytes    -- packed 6-bit scales/mins for 8 sub-blocks (same as Q4_K)
+ *   [16:144] 128 bytes  -- ql: 256 x 4-bit low nibbles
+ *   [144:176] 32 bytes  -- qh: 256 x 1-bit high bits (packed)
+ *
+ * Dequantization (matching tensor/quantized_kquant.go DequantizeQ5K):
+ *   For each group g (0..3), sub-blocks sb0=2g, sb1=2g+1:
+ *     sc0 = d * scales[sb0],  mn0 = dmin * mins[sb0]
+ *     sc1 = d * scales[sb1],  mn1 = dmin * mins[sb1]
+ *     u1 = 1<<(2*g), u2 = 2<<(2*g)
+ *     For each l in 0..31:
+ *       h0 = 16 if qh[l] & u1 else 0
+ *       h1 = 16 if qh[l] & u2 else 0
+ *       val[g*64 + l]    = sc0 * ((ql[g*32+l] & 0xF) | h0) - mn0
+ *       val[g*64 + l+32] = sc1 * ((ql[g*32+l] >> 4)  | h1) - mn1
+ */
+
+#include "gemv_q5k.h"
+#include <cuda_fp16.h>
+#include <stdint.h>
+
+#define Q5K_SUPER_BLOCK_SIZE 256
+#define Q5K_BLOCK_BYTES      176
+#define Q5K_NUM_SUB_BLOCKS   8
+#define Q5K_WARPS_PER_BLOCK  4
+#define Q5K_WARP_SIZE        32
+
+/* Decode 6-bit scales and mins from the 12-byte packed region.
+ * Same format as Q4_K. Matches tensor/quantized_kquant.go decodeQ4KScalesMins. */
+__device__ __forceinline__ void decode_scales_mins_q5k(
+    const uint8_t* sc,
+    float d, float dmin,
+    float* __restrict__ sub_scales,
+    float* __restrict__ sub_mins)
+{
+    /* Sub-blocks 0-3: 6 low bits. */
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        sub_scales[i] = d * (float)(sc[i] & 63);
+        sub_mins[i]   = dmin * (float)(sc[4+i] & 63);
+    }
+    /* Sub-blocks 4-7: 4 bits from bytes 8-11 + 2 high bits. */
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        sub_scales[4+i] = d * (float)((sc[8+i] & 0xF) | ((sc[i] >> 6) << 4));
+        sub_mins[4+i]   = dmin * (float)((sc[8+i] >> 4) | ((sc[4+i] >> 6) << 4));
+    }
+}
+
+/* ---------- Fused GEMV kernel ----------
+ *
+ * y[row] = sum_k dequant(W_q5k[row, k]) * x[k]
+ *
+ * Strategy:
+ *   - Load input vector x into shared memory (all threads cooperate).
+ *   - One warp per row for simplicity and good occupancy.
+ *   - Each lane processes a strided subset of super-blocks.
+ *   - Within each super-block, 4 groups of 64 elements are processed.
+ *   - The extra high bit per element is read from the qh region.
+ *   - Warp shuffle reduction produces the final dot product.
+ */
+__global__ void gemv_q5k_kernel(
+    const uint8_t* __restrict__ W_q5k,
+    const float*   __restrict__ x,
+    float*         __restrict__ y,
+    int M, int K)
+{
+    extern __shared__ float sx[];
+
+    /* Cooperatively load x into shared memory. */
+    int threads_per_block = blockDim.x;
+    for (int i = threadIdx.x; i < K; i += threads_per_block) {
+        sx[i] = x[i];
+    }
+    __syncthreads();
+
+    int warp_id = threadIdx.x / Q5K_WARP_SIZE;
+    int lane_id = threadIdx.x % Q5K_WARP_SIZE;
+    int row = blockIdx.x * Q5K_WARPS_PER_BLOCK + warp_id;
+
+    if (row >= M) return;
+
+    int blocks_per_row = K / Q5K_SUPER_BLOCK_SIZE;
+    const uint8_t* row_data = W_q5k + (size_t)row * blocks_per_row * Q5K_BLOCK_BYTES;
+
+    float acc = 0.0f;
+
+    /* Each lane handles a strided subset of super-blocks. */
+    for (int bi = lane_id; bi < blocks_per_row; bi += Q5K_WARP_SIZE) {
+        const uint8_t* blk = row_data + bi * Q5K_BLOCK_BYTES;
+
+        /* Read fp16 d and dmin. */
+        float d    = __half2float(__ldg((const __half*)(blk)));
+        float dmin = __half2float(__ldg((const __half*)(blk + 2)));
+
+        /* Decode sub-block scales and mins. */
+        float sub_scales[Q5K_NUM_SUB_BLOCKS];
+        float sub_mins[Q5K_NUM_SUB_BLOCKS];
+        decode_scales_mins_q5k(blk + 4, d, dmin, sub_scales, sub_mins);
+
+        const uint8_t* ql = blk + 16;   /* 128 bytes: low 4 bits */
+        const uint8_t* qh = blk + 144;  /* 32 bytes: high 1 bit */
+        int k_base = bi * Q5K_SUPER_BLOCK_SIZE;
+
+        /* Process 4 groups of 64 elements each. */
+        #pragma unroll
+        for (int group = 0; group < 4; group++) {
+            int sb0 = group * 2;
+            int sb1 = group * 2 + 1;
+            float sc0 = sub_scales[sb0];
+            float mn0 = sub_mins[sb0];
+            float sc1 = sub_scales[sb1];
+            float mn1 = sub_mins[sb1];
+
+            int base_out = k_base + group * 64;
+            int base_q = group * 32;
+
+            /* Bit masks for the high bit: u1 = 1<<(2*group), u2 = 2<<(2*group) */
+            uint8_t u1 = (uint8_t)(1 << (2 * group));
+            uint8_t u2 = (uint8_t)(2 << (2 * group));
+
+            #pragma unroll
+            for (int l = 0; l < 32; l++) {
+                uint8_t q = __ldg(&ql[base_q + l]);
+                uint8_t hb = __ldg(&qh[l]);
+
+                uint8_t h0 = (hb & u1) ? 16 : 0;
+                uint8_t h1 = (hb & u2) ? 16 : 0;
+
+                float dq_lo = sc0 * (float)((q & 0xF) | h0) - mn0;
+                float dq_hi = sc1 * (float)((q >> 4)  | h1) - mn1;
+
+                acc = __fmaf_rn(dq_lo, sx[base_out + l], acc);
+                acc = __fmaf_rn(dq_hi, sx[base_out + l + 32], acc);
+            }
+        }
+    }
+
+    /* Warp shuffle reduction. */
+    #pragma unroll
+    for (int offset = Q5K_WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        acc += __shfl_down_sync(0xFFFFFFFF, acc, offset);
+    }
+
+    if (lane_id == 0) {
+        y[row] = acc;
+    }
+}
+
+/* ---------- Dispatcher ---------- */
+
+extern "C" cudaError_t gemv_q5k_f32(
+    const void* W_q5k, const float* x, float* y,
+    int M, int K,
+    cudaStream_t stream)
+{
+    if (K % Q5K_SUPER_BLOCK_SIZE != 0) {
+        return cudaErrorInvalidValue;
+    }
+
+    int threads = Q5K_WARPS_PER_BLOCK * Q5K_WARP_SIZE;  /* 128 */
+    int grid = (M + Q5K_WARPS_PER_BLOCK - 1) / Q5K_WARPS_PER_BLOCK;
+    int smem = K * sizeof(float);
+
+    gemv_q5k_kernel<<<grid, threads, smem, stream>>>(
+        (const uint8_t*)W_q5k, x, y, M, K);
+
+    return cudaGetLastError();
+}

--- a/internal/cuda/kernels/gemv_q5k.h
+++ b/internal/cuda/kernels/gemv_q5k.h
@@ -1,0 +1,43 @@
+/* Q5_K fused dequant-GEMV kernel interface.
+ *
+ * Q5_K super-block format (176 bytes per 256 values):
+ *   - 2 bytes: fp16 d (super-block scale)
+ *   - 2 bytes: fp16 dmin (super-block min)
+ *   - 12 bytes: packed 6-bit scales and mins for 8 sub-blocks (same as Q4_K)
+ *   - 128 bytes: ql (low 4 bits of each 5-bit value)
+ *   - 32 bytes: qh (high 1 bit per value, 256 bits packed)
+ *
+ * Computes: y[m] = sum_k( dequant(W_q5k[m,k]) * x[k] )
+ * W_q5k is raw Q5_K super-blocks laid out row-major.
+ * x is [K] FP32 input vector. y is [M] FP32 output vector.
+ * Batch=1 only (GEMV, not GEMM).
+ */
+#ifndef GEMV_Q5K_H
+#define GEMV_Q5K_H
+
+#include <cuda_runtime.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* gemv_q5k_f32 performs Q5_K fused dequant-GEMV:
+ *   y[m] = sum_k( dequant(W_q5k[m,k]) * x[k] )
+ *
+ * W_q5k: device pointer to raw Q5_K super-blocks for matrix W [M, K].
+ *        M * ceil(K/256) super-blocks, each 176 bytes. Row-major layout.
+ * x:     device pointer to [K] float input vector.
+ * y:     device pointer to [M] float output vector.
+ * M, K:  matrix dimensions. K must be a multiple of 256.
+ * stream: CUDA stream.
+ */
+cudaError_t gemv_q5k_f32(
+    const void* W_q5k, const float* x, float* y,
+    int M, int K,
+    cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GEMV_Q5K_H */

--- a/internal/cuda/kernels/gemv_q6k.cu
+++ b/internal/cuda/kernels/gemv_q6k.cu
@@ -1,0 +1,152 @@
+/* Q6_K fused dequant-GEMV kernel for single-token decode (batch=1).
+ *
+ * Reads Q6_K super-blocks directly, dequantizes in registers (no global
+ * memory intermediary), multiplies by the activation vector, and accumulates
+ * in FP32. This halves memory traffic compared to separate dequant + GEMV.
+ *
+ * Q6_K super-block (210 bytes, 256 values):
+ *   [0:128]   ql     -- low 4 bits of each 6-bit value
+ *   [128:192] qh     -- high 2 bits of each 6-bit value
+ *   [192:208] sc     -- int8 scales for 16 sub-blocks of 16 values
+ *   [208:210] fp16 d -- super-block scale
+ *
+ * Dequantization (matching tensor/quantized_kquant.go DequantizeQ6K):
+ *   Two 128-element halves. For each half (offset qlOff, qhOff, scOff, outOff):
+ *     For l in 0..31:
+ *       is = l / 16
+ *       q1 = int8((ql[qlOff+l] & 0xF) | ((qh[qhOff+l] & 3) << 4)) - 32
+ *       q2 = int8((ql[qlOff+32+l] & 0xF) | (((qh[qhOff+l]>>2) & 3) << 4)) - 32
+ *       q3 = int8((ql[qlOff+l] >> 4) | (((qh[qhOff+l]>>4) & 3) << 4)) - 32
+ *       q4 = int8((ql[qlOff+32+l] >> 4) | (((qh[qhOff+l]>>6) & 3) << 4)) - 32
+ *       dst[outOff+l]    = d * sc[scOff+is+0] * q1
+ *       dst[outOff+32+l] = d * sc[scOff+is+2] * q2
+ *       dst[outOff+64+l] = d * sc[scOff+is+4] * q3
+ *       dst[outOff+96+l] = d * sc[scOff+is+6] * q4
+ */
+
+#include "gemv_q6k.h"
+#include <cuda_fp16.h>
+#include <stdint.h>
+
+#define Q6K_SUPER_BLOCK_SIZE 256
+#define Q6K_BLOCK_BYTES      210
+#define Q6K_WARPS_PER_BLOCK  4
+#define Q6K_WARP_SIZE        32
+
+/* ---------- Fused GEMV kernel ----------
+ *
+ * y[row] = sum_k dequant(W_q6k[row, k]) * x[k]
+ *
+ * Strategy:
+ *   - Load input vector x into shared memory (all threads cooperate).
+ *   - One warp per row for simplicity and good occupancy.
+ *   - Each lane processes a strided subset of super-blocks.
+ *   - Within each super-block, two 128-element halves are processed.
+ *   - Warp shuffle reduction produces the final dot product.
+ */
+__global__ void gemv_q6k_kernel(
+    const uint8_t* __restrict__ W_q6k,
+    const float*   __restrict__ x,
+    float*         __restrict__ y,
+    int M, int K)
+{
+    extern __shared__ float sx[];
+
+    /* Cooperatively load x into shared memory. */
+    int threads_per_block = blockDim.x;
+    for (int i = threadIdx.x; i < K; i += threads_per_block) {
+        sx[i] = x[i];
+    }
+    __syncthreads();
+
+    int warp_id = threadIdx.x / Q6K_WARP_SIZE;
+    int lane_id = threadIdx.x % Q6K_WARP_SIZE;
+    int row = blockIdx.x * Q6K_WARPS_PER_BLOCK + warp_id;
+
+    if (row >= M) return;
+
+    int blocks_per_row = K / Q6K_SUPER_BLOCK_SIZE;
+    const uint8_t* row_data = W_q6k + (size_t)row * blocks_per_row * Q6K_BLOCK_BYTES;
+
+    float acc = 0.0f;
+
+    /* Each lane handles a strided subset of super-blocks. */
+    for (int bi = lane_id; bi < blocks_per_row; bi += Q6K_WARP_SIZE) {
+        const uint8_t* blk = row_data + bi * Q6K_BLOCK_BYTES;
+
+        const uint8_t* ql = blk;         /* [0:128] low 4 bits */
+        const uint8_t* qh = blk + 128;   /* [128:192] high 2 bits */
+        const int8_t*  sc = (const int8_t*)(blk + 192); /* [192:208] int8 scales */
+        float d = __half2float(__ldg((const __half*)(blk + 208)));
+
+        int k_base = bi * Q6K_SUPER_BLOCK_SIZE;
+
+        /* Process two 128-element halves. */
+        #pragma unroll
+        for (int half = 0; half < 2; half++) {
+            int qlOff = half * 64;
+            int qhOff = half * 32;
+            int scOff = half * 8;
+            int outOff = k_base + half * 128;
+
+            #pragma unroll
+            for (int l = 0; l < 32; l++) {
+                int is = l / 16; /* sub-block offset within each group of 32 */
+
+                uint8_t ql_v  = __ldg(&ql[qlOff + l]);
+                uint8_t ql_v2 = __ldg(&ql[qlOff + 32 + l]);
+                uint8_t qh_v  = __ldg(&qh[qhOff + l]);
+
+                float s0 = d * (float)sc[scOff + is + 0];
+                float s2 = d * (float)sc[scOff + is + 2];
+                float s4 = d * (float)sc[scOff + is + 4];
+                float s6 = d * (float)sc[scOff + is + 6];
+
+                /* q1: low nibble of ql[qlOff+l] + bits 0-1 of qh */
+                int8_t q1 = (int8_t)((ql_v & 0xF) | ((qh_v & 3) << 4)) - 32;
+                /* q2: low nibble of ql[qlOff+32+l] + bits 2-3 of qh */
+                int8_t q2 = (int8_t)((ql_v2 & 0xF) | (((qh_v >> 2) & 3) << 4)) - 32;
+                /* q3: high nibble of ql[qlOff+l] + bits 4-5 of qh */
+                int8_t q3 = (int8_t)((ql_v >> 4) | (((qh_v >> 4) & 3) << 4)) - 32;
+                /* q4: high nibble of ql[qlOff+32+l] + bits 6-7 of qh */
+                int8_t q4 = (int8_t)((ql_v2 >> 4) | (((qh_v >> 6) & 3) << 4)) - 32;
+
+                acc = __fmaf_rn(s0 * (float)q1, sx[outOff + l],      acc);
+                acc = __fmaf_rn(s2 * (float)q2, sx[outOff + 32 + l], acc);
+                acc = __fmaf_rn(s4 * (float)q3, sx[outOff + 64 + l], acc);
+                acc = __fmaf_rn(s6 * (float)q4, sx[outOff + 96 + l], acc);
+            }
+        }
+    }
+
+    /* Warp shuffle reduction. */
+    #pragma unroll
+    for (int offset = Q6K_WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        acc += __shfl_down_sync(0xFFFFFFFF, acc, offset);
+    }
+
+    if (lane_id == 0) {
+        y[row] = acc;
+    }
+}
+
+/* ---------- Dispatcher ---------- */
+
+extern "C" cudaError_t gemv_q6k_f32(
+    const void* W_q6k, const float* x, float* y,
+    int M, int K,
+    cudaStream_t stream)
+{
+    if (K % Q6K_SUPER_BLOCK_SIZE != 0) {
+        return cudaErrorInvalidValue;
+    }
+
+    int threads = Q6K_WARPS_PER_BLOCK * Q6K_WARP_SIZE;  /* 128 */
+    int grid = (M + Q6K_WARPS_PER_BLOCK - 1) / Q6K_WARPS_PER_BLOCK;
+    int smem = K * sizeof(float);
+
+    gemv_q6k_kernel<<<grid, threads, smem, stream>>>(
+        (const uint8_t*)W_q6k, x, y, M, K);
+
+    return cudaGetLastError();
+}

--- a/internal/cuda/kernels/gemv_q6k.h
+++ b/internal/cuda/kernels/gemv_q6k.h
@@ -1,0 +1,42 @@
+/* Q6_K fused dequant-GEMV kernel interface.
+ *
+ * Q6_K super-block format (210 bytes per 256 values):
+ *   - 128 bytes: ql (low 4 bits of each 6-bit value)
+ *   - 64 bytes:  qh (high 2 bits of each 6-bit value)
+ *   - 16 bytes:  sc (int8 scales for 16 sub-blocks of 16 values)
+ *   - 2 bytes:   fp16 d (super-block scale)
+ *
+ * Computes: y[m] = sum_k( dequant(W_q6k[m,k]) * x[k] )
+ * W_q6k is raw Q6_K super-blocks laid out row-major.
+ * x is [K] FP32 input vector. y is [M] FP32 output vector.
+ * Batch=1 only (GEMV, not GEMM).
+ */
+#ifndef GEMV_Q6K_H
+#define GEMV_Q6K_H
+
+#include <cuda_runtime.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* gemv_q6k_f32 performs Q6_K fused dequant-GEMV:
+ *   y[m] = sum_k( dequant(W_q6k[m,k]) * x[k] )
+ *
+ * W_q6k: device pointer to raw Q6_K super-blocks for matrix W [M, K].
+ *        M * ceil(K/256) super-blocks, each 210 bytes. Row-major layout.
+ * x:     device pointer to [K] float input vector.
+ * y:     device pointer to [M] float output vector.
+ * M, K:  matrix dimensions. K must be a multiple of 256.
+ * stream: CUDA stream.
+ */
+cudaError_t gemv_q6k_f32(
+    const void* W_q6k, const float* x, float* y,
+    int M, int K,
+    cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GEMV_Q6K_H */


### PR DESCRIPTION
## Summary

Copy K-quant GEMV kernels from ztensor to zerfoo's libkernels.so build. Without these, native Q6_K inference crashes with SIGSEGV (null function pointer in GemvQ6KF32).

- gemv_q6k.cu/h: Q6_K fused dequant + GEMV
- gemv_q5k.cu/h: Q5_K fused dequant + GEMV  
- gemv_q4k_sm121.cu/h: SM121-optimized Q4_K GEMV for Blackwell

## Test plan

- [x] `go build ./...` passes
- [ ] Rebuild libkernels.so on DGX, verify Mistral 7B runs without SIGSEGV