### PR TITLE
fix(gguf): restore Q4_K re-quantization for GEMV performance

### DIFF
--- a/model/gguf/loader.go
+++ b/model/gguf/loader.go
@@ -158,7 +158,14 @@ func decodeQ4KTensor(shape []int, numElements int, raw []byte) (*tensor.TensorNu
 	if err != nil {
 		return nil, fmt.Errorf("Q4_K decode: %w", err)
 	}
-	return tensor.NewWithStorage[float32](shape, q4k)
+	// Re-quantize Q4_K to Q4_0 for fast GEMV decode path. The Q4_K GEMV kernel
+	// is ~45% slower than Q4_0 GEMV on GB10 (128 vs 236 tok/s on Gemma 3 1B).
+	// The Q4_0 path trades per-sub-block 6-bit scale precision for throughput.
+	// TODO: optimize Q4_K GEMV kernel to match Q4_0 speed, then use native Q4_K.
+	f32 := make([]float32, numElements)
+	q4k.Dequantize(f32)
+	q4 := tensor.QuantizeQ4(f32)
+	return tensor.NewWithStorage[float32](shape, q4)
 }
 
 func decodeQ5KTensor(shape []int, numElements int, raw []byte) (*tensor.TensorNumeric[float32], error) {


### PR DESCRIPTION
## Summary

Revert native Q4_K loading from PR #179. Benchmarks show Q4_K GEMV is ~45% slower than Q4_0 GEMV on GB10:

- **With native Q4_K**: 128 tok/s on Gemma 3 1B (45% regression)
- **With Q4_K→Q4_0 re-quant**: 241 tok/s on Gemma 3 1B (original performance)

Keep Q5_K and Q6_K native — they have dedicated GEMV kernels and re-quantizing to Q4_0 loses significant precision.

## What stays
- Q5_K native loading (PR #179)
- Q6_K native loading (PR #179)
- Virtual transpose for Q4K/Q5K/Q6K (PR #179)
- K-quant GEMV kernels in libkernels.so (PR #182)
- Merged QKV/GateUp for Q4K (PR #181)

## What reverts
- Q4_K native loading only — restored dequant→Q4_0 re-quantization path