### PR TITLE
fix(gguf): restore all K-quant to Q4_0 re-quantization

### DIFF
--- a/model/gguf/loader.go
+++ b/model/gguf/loader.go
@@ -173,7 +173,11 @@ func decodeQ5KTensor(shape []int, numElements int, raw []byte) (*tensor.TensorNu
 	if err != nil {
 		return nil, fmt.Errorf("Q5_K decode: %w", err)
 	}
-	return tensor.NewWithStorage[float32](shape, q5k)
+	// Re-quantize Q5_K to Q4_0 for fast GEMV decode path.
+	f32 := make([]float32, numElements)
+	q5k.Dequantize(f32)
+	q4 := tensor.QuantizeQ4(f32)
+	return tensor.NewWithStorage[float32](shape, q4)
 }
 
 func decodeQ6KTensor(shape []int, numElements int, raw []byte) (*tensor.TensorNumeric[float32], error) {
@@ -181,7 +185,13 @@ func decodeQ6KTensor(shape []int, numElements int, raw []byte) (*tensor.TensorNu
 	if err != nil {
 		return nil, fmt.Errorf("Q6_K decode: %w", err)
 	}
-	return tensor.NewWithStorage[float32](shape, q6k)
+	// Re-quantize Q6_K to Q4_0 for fast GEMV decode path.
+	// Native Q6_K GEMV is ~33% slower than Q4_0 GEMV on GB10.
+	// TODO: optimize Q6_K GEMV kernel, then use native Q6_K.
+	f32 := make([]float32, numElements)
+	q6k.Dequantize(f32)
+	q4 := tensor.QuantizeQ4(f32)
+	return tensor.NewWithStorage[float32](shape, q4)
 }
 
 // decodeQ5_0Tensor decodes Q5_0 blocks and re-quantizes to Q4_0 for fast GEMV.

--- a/model/gguf/loader_test.go
+++ b/model/gguf/loader_test.go
@@ -228,7 +228,7 @@ func TestLoadTensors_Q8_0(t *testing.T) {
 	}
 }
 
-func TestDecodeQ5KTensor_NativeStorage(t *testing.T) {
+func TestDecodeQ5KTensor_ReQuantizesToQ4(t *testing.T) {
 	// Q5_K: 256 elements per super-block, 176 bytes per block.
 	const numElements = 256
 	const blockBytes = 176
@@ -245,8 +245,8 @@ func TestDecodeQ5KTensor_NativeStorage(t *testing.T) {
 	}
 
 	// Q5_K should use native Q5KStorage (no re-quantization).
-	if _, ok := tns.GetStorage().(*tensor.Q5KStorage); !ok {
-		t.Fatalf("expected Q5KStorage, got %T", tns.GetStorage())
+	if _, ok := tns.GetStorage().(*tensor.Q4Storage); !ok {
+		t.Fatalf("expected Q4Storage after re-quant, got %T", tns.GetStorage())
 	}
 
 	// All-zero Q5_K block dequantizes to all zeros.
@@ -562,7 +562,7 @@ func TestLoadTensors_BF16(t *testing.T) {
 	}
 }
 
-func TestDecodeQ6KTensor_NativeStorage(t *testing.T) {
+func TestDecodeQ6KTensor_ReQuantizesToQ4(t *testing.T) {
 	// Create 256 elements (1 Q6_K super-block = 210 bytes).
 	const numElements = 256
 	const blockBytes = 210
@@ -600,8 +600,8 @@ func TestDecodeQ6KTensor_NativeStorage(t *testing.T) {
 	}
 
 	// Q6_K should use native Q6KStorage (no re-quantization).
-	if _, ok := tns.GetStorage().(*tensor.Q6KStorage); !ok {
-		t.Fatalf("expected Q6KStorage, got %T", tns.GetStorage())
+	if _, ok := tns.GetStorage().(*tensor.Q4Storage); !ok {
+		t.Fatalf("expected Q4Storage after re-quant, got %T", tns.GetStorage())
 	}
 
 	// Verify the tensor contains dequantized float32 data (not all zeros,
@@ -621,18 +621,28 @@ func TestDecodeQ6KTensor_NativeStorage(t *testing.T) {
 		t.Error("expected non-zero dequantized values")
 	}
 
-	// Verify round-trip: dequantizing via the storage should produce
-	// identical values to dequantizing the same raw data directly.
+	// Verify approximate round-trip: Q6_K → F32 → Q4_0 → F32 is lossy,
+	// so values should be within re-quantization tolerance of the Q6_K originals.
 	q6k, err := tensor.NewQ6KStorageFromRaw(raw, numElements)
 	if err != nil {
 		t.Fatalf("NewQ6KStorageFromRaw: %v", err)
 	}
 	ref := make([]float32, numElements)
 	q6k.Dequantize(ref)
-	for i, want := range ref {
-		if data[i] != want {
-			t.Errorf("index %d: got %v, want %v", i, data[i], want)
+	maxErr := float32(0)
+	for i := range ref {
+		diff := data[i] - ref[i]
+		if diff < 0 {
+			diff = -diff
 		}
+		if diff > maxErr {
+			maxErr = diff
+		}
+	}
+	// Q4_0 has 4-bit precision per block of 32 values; typical error is
+	// proportional to the range of values in each block.
+	if maxErr > 50 {
+		t.Errorf("max re-quantization error = %v, want < 50", maxErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

Restore Q5_K and Q6_K re-quantization to Q4_0, completing the revert of native K-quant loading. All K-quant GEMV kernels are slower than Q4_0 on GB10:

- Q4_K native: 128 tok/s (was 236 with Q4_0)
- Q6_K native: 158 tok/s (was 236 with Q4_0)
- Q4_0 (baseline): 236 tok/s

The infrastructure (virtual transpose, merged QKV, GEMV kernel .cu files) remains for when the kernels are optimized.

## Test plan

- [x] `go test ./model/gguf/` passes with tolerance-based Q6_K test
- [ ] DGX benchmark: Gemma 3 1B back to ~236 tok/s