### PR TITLE
feat(timeseries): add GraniteTimeSeriesConfig for GGUF metadata

### DIFF
--- a/inference/timeseries/granite_config.go
+++ b/inference/timeseries/granite_config.go
@@ -1,0 +1,126 @@
+package timeseries
+
+import "fmt"
+
+// GraniteTimeSeriesConfig extends TimeSeriesSignalConfig with Granite-specific
+// fields for IBM Granite Time Series models (TTM, FlowState, TSPulse).
+type GraniteTimeSeriesConfig struct {
+	TimeSeriesSignalConfig // embed existing config
+
+	// Common Granite TS fields
+	ModelType   string // ts.signal.model_type — "ttm", "flowstate", "tspulse" (required)
+	ContextLen  int    // ts.signal.context_len — context window (512, 1024, 1536)
+	ForecastLen int    // ts.signal.forecast_len — prediction horizon
+
+	// TTM-specific
+	NumMixerLayers int  // ts.signal.num_mixer_layers — TSMixer backbone depth
+	ChannelMixing  bool // ts.signal.channel_mixing — TTM decoder channel mixing enabled
+	PatchLen       int  // ts.signal.patch_len — patch length for adaptive patching
+	NumPatches     int  // ts.signal.num_patches — number of patches
+
+	// FlowState-specific
+	ScaleFactor  float32 // ts.signal.scale_factor — temporal scale for sampling rate adaptation
+	NumSSMLayers int     // ts.signal.num_ssm_layers — SSM encoder depth
+
+	// TSPulse-specific
+	MaskType string // ts.signal.mask_type — "hybrid" or "block"
+	HeadType string // ts.signal.head_type — "allhead" or "dualhead"
+}
+
+// LoadGraniteTimeSeriesConfig extracts GraniteTimeSeriesConfig from a GGUF
+// metadata map. Only ts.signal.model_type is required; all other fields have
+// sensible defaults.
+func LoadGraniteTimeSeriesConfig(meta map[string]interface{}) (*GraniteTimeSeriesConfig, error) {
+	cfg := &GraniteTimeSeriesConfig{
+		ScaleFactor: 1.0,
+	}
+
+	// Required: model_type
+	modelType, ok := getMetaString(meta, "ts.signal.model_type")
+	if !ok {
+		return nil, fmt.Errorf("missing required metadata key %q", "ts.signal.model_type")
+	}
+	cfg.ModelType = modelType
+
+	// Load embedded base config (tolerant — ignore error since base has its
+	// own required fields that may not apply to Granite models).
+	if base, err := LoadTimeSeriesSignalConfig(meta); err == nil {
+		cfg.TimeSeriesSignalConfig = base
+	}
+
+	// Common Granite TS fields
+	if v, ok := getMetaInt(meta, "ts.signal.context_len"); ok {
+		cfg.ContextLen = v
+	}
+	if v, ok := getMetaInt(meta, "ts.signal.forecast_len"); ok {
+		cfg.ForecastLen = v
+	}
+
+	// TTM-specific
+	if v, ok := getMetaInt(meta, "ts.signal.num_mixer_layers"); ok {
+		cfg.NumMixerLayers = v
+	}
+	if v, ok := getMetaBool(meta, "ts.signal.channel_mixing"); ok {
+		cfg.ChannelMixing = v
+	}
+	if v, ok := getMetaInt(meta, "ts.signal.patch_len"); ok {
+		cfg.PatchLen = v
+	}
+	if v, ok := getMetaInt(meta, "ts.signal.num_patches"); ok {
+		cfg.NumPatches = v
+	}
+
+	// FlowState-specific
+	if v, ok := getMetaFloat32(meta, "ts.signal.scale_factor"); ok {
+		cfg.ScaleFactor = v
+	}
+	if v, ok := getMetaInt(meta, "ts.signal.num_ssm_layers"); ok {
+		cfg.NumSSMLayers = v
+	}
+
+	// TSPulse-specific
+	if v, ok := getMetaString(meta, "ts.signal.mask_type"); ok {
+		cfg.MaskType = v
+	}
+	if v, ok := getMetaString(meta, "ts.signal.head_type"); ok {
+		cfg.HeadType = v
+	}
+
+	return cfg, nil
+}
+
+// getMetaString extracts a string value from GGUF metadata.
+func getMetaString(meta map[string]interface{}, key string) (string, bool) {
+	v, ok := meta[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// getMetaBool extracts a boolean value from GGUF metadata.
+func getMetaBool(meta map[string]interface{}, key string) (bool, bool) {
+	v, ok := meta[key]
+	if !ok {
+		return false, false
+	}
+	b, ok := v.(bool)
+	return b, ok
+}
+
+// getMetaFloat32 extracts a float32 value from GGUF metadata.
+func getMetaFloat32(meta map[string]interface{}, key string) (float32, bool) {
+	v, ok := meta[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float32:
+		return n, true
+	case float64:
+		return float32(n), true
+	default:
+		return 0, false
+	}
+}

--- a/inference/timeseries/granite_config_test.go
+++ b/inference/timeseries/granite_config_test.go
@@ -1,0 +1,175 @@
+package timeseries
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadGraniteTimeSeriesConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		meta    map[string]interface{}
+		check   func(t *testing.T, cfg *GraniteTimeSeriesConfig)
+		wantErr string
+	}{
+		{
+			name: "TTM model with all keys",
+			meta: map[string]interface{}{
+				"ts.signal.model_type":        "ttm",
+				"ts.signal.context_len":       uint32(512),
+				"ts.signal.forecast_len":      uint32(96),
+				"ts.signal.num_mixer_layers":  uint32(4),
+				"ts.signal.channel_mixing":    true,
+				"ts.signal.patch_len":         uint32(16),
+				"ts.signal.num_patches":       uint32(32),
+				"ts.signal.input_features":    uint32(3),
+			},
+			check: func(t *testing.T, cfg *GraniteTimeSeriesConfig) {
+				if cfg.ModelType != "ttm" {
+					t.Errorf("ModelType = %q, want %q", cfg.ModelType, "ttm")
+				}
+				if cfg.ContextLen != 512 {
+					t.Errorf("ContextLen = %d, want 512", cfg.ContextLen)
+				}
+				if cfg.ForecastLen != 96 {
+					t.Errorf("ForecastLen = %d, want 96", cfg.ForecastLen)
+				}
+				if cfg.NumMixerLayers != 4 {
+					t.Errorf("NumMixerLayers = %d, want 4", cfg.NumMixerLayers)
+				}
+				if !cfg.ChannelMixing {
+					t.Error("ChannelMixing = false, want true")
+				}
+				if cfg.PatchLen != 16 {
+					t.Errorf("PatchLen = %d, want 16", cfg.PatchLen)
+				}
+				if cfg.NumPatches != 32 {
+					t.Errorf("NumPatches = %d, want 32", cfg.NumPatches)
+				}
+				// Embedded base config should have loaded input_features
+				if cfg.InputFeatures != 3 {
+					t.Errorf("InputFeatures = %d, want 3", cfg.InputFeatures)
+				}
+				// Default scale_factor should be 1.0
+				if cfg.ScaleFactor != 1.0 {
+					t.Errorf("ScaleFactor = %f, want 1.0", cfg.ScaleFactor)
+				}
+			},
+		},
+		{
+			name: "FlowState model",
+			meta: map[string]interface{}{
+				"ts.signal.model_type":      "flowstate",
+				"ts.signal.context_len":     uint32(1024),
+				"ts.signal.forecast_len":    uint32(192),
+				"ts.signal.scale_factor":    float32(2.5),
+				"ts.signal.num_ssm_layers":  uint32(8),
+			},
+			check: func(t *testing.T, cfg *GraniteTimeSeriesConfig) {
+				if cfg.ModelType != "flowstate" {
+					t.Errorf("ModelType = %q, want %q", cfg.ModelType, "flowstate")
+				}
+				if cfg.ContextLen != 1024 {
+					t.Errorf("ContextLen = %d, want 1024", cfg.ContextLen)
+				}
+				if cfg.ForecastLen != 192 {
+					t.Errorf("ForecastLen = %d, want 192", cfg.ForecastLen)
+				}
+				if cfg.ScaleFactor != 2.5 {
+					t.Errorf("ScaleFactor = %f, want 2.5", cfg.ScaleFactor)
+				}
+				if cfg.NumSSMLayers != 8 {
+					t.Errorf("NumSSMLayers = %d, want 8", cfg.NumSSMLayers)
+				}
+			},
+		},
+		{
+			name: "TSPulse model",
+			meta: map[string]interface{}{
+				"ts.signal.model_type":    "tspulse",
+				"ts.signal.context_len":   uint32(1536),
+				"ts.signal.forecast_len":  uint32(336),
+				"ts.signal.mask_type":     "hybrid",
+				"ts.signal.head_type":     "dualhead",
+			},
+			check: func(t *testing.T, cfg *GraniteTimeSeriesConfig) {
+				if cfg.ModelType != "tspulse" {
+					t.Errorf("ModelType = %q, want %q", cfg.ModelType, "tspulse")
+				}
+				if cfg.ContextLen != 1536 {
+					t.Errorf("ContextLen = %d, want 1536", cfg.ContextLen)
+				}
+				if cfg.ForecastLen != 336 {
+					t.Errorf("ForecastLen = %d, want 336", cfg.ForecastLen)
+				}
+				if cfg.MaskType != "hybrid" {
+					t.Errorf("MaskType = %q, want %q", cfg.MaskType, "hybrid")
+				}
+				if cfg.HeadType != "dualhead" {
+					t.Errorf("HeadType = %q, want %q", cfg.HeadType, "dualhead")
+				}
+			},
+		},
+		{
+			name: "missing optional keys use defaults",
+			meta: map[string]interface{}{
+				"ts.signal.model_type": "ttm",
+			},
+			check: func(t *testing.T, cfg *GraniteTimeSeriesConfig) {
+				if cfg.ModelType != "ttm" {
+					t.Errorf("ModelType = %q, want %q", cfg.ModelType, "ttm")
+				}
+				if cfg.ContextLen != 0 {
+					t.Errorf("ContextLen = %d, want 0", cfg.ContextLen)
+				}
+				if cfg.ForecastLen != 0 {
+					t.Errorf("ForecastLen = %d, want 0", cfg.ForecastLen)
+				}
+				if cfg.ChannelMixing {
+					t.Error("ChannelMixing = true, want false")
+				}
+				if cfg.ScaleFactor != 1.0 {
+					t.Errorf("ScaleFactor = %f, want 1.0", cfg.ScaleFactor)
+				}
+				if cfg.MaskType != "" {
+					t.Errorf("MaskType = %q, want empty", cfg.MaskType)
+				}
+				if cfg.HeadType != "" {
+					t.Errorf("HeadType = %q, want empty", cfg.HeadType)
+				}
+			},
+		},
+		{
+			name:    "missing required model_type returns error",
+			meta:    map[string]interface{}{},
+			wantErr: "ts.signal.model_type",
+		},
+		{
+			name: "missing model_type with other keys returns error",
+			meta: map[string]interface{}{
+				"ts.signal.context_len":  uint32(512),
+				"ts.signal.forecast_len": uint32(96),
+			},
+			wantErr: "ts.signal.model_type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := LoadGraniteTimeSeriesConfig(tt.meta)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error %q should mention %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tt.check(t, cfg)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add GraniteTimeSeriesConfig struct and LoadGraniteTimeSeriesConfig function for IBM Granite Time Series models (TTM, FlowState, TSPulse). Part of docs/plan-granite-ts.md Wave 1.

New ts.signal.* metadata keys: model_type, context_len, forecast_len, num_mixer_layers, channel_mixing, patch_len, num_patches, scale_factor, num_ssm_layers, mask_type, head_type.

## Test plan

- [x] Table-driven tests for TTM, FlowState, TSPulse configs
- [x] Missing optional keys use correct defaults
- [x] Missing required model_type returns error
- [x] Existing tests unbroken