### PR TITLE
feat(serve): add Guardian content moderation API endpoints

### DIFF
--- a/serve/guard.go
+++ b/serve/guard.go
@@ -1,0 +1,327 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/zerfoo/zerfoo/inference/guardian"
+	"github.com/zerfoo/ztensor/metrics/runtime"
+)
+
+// maxGuardBatch is the maximum number of inputs in a single guard batch request.
+const maxGuardBatch = 256
+
+// GuardEvaluator abstracts a Guardian safety evaluator for testability.
+type GuardEvaluator interface {
+	Evaluate(ctx context.Context, req guardian.GuardianRequest) ([]guardian.Verdict, error)
+	EvaluateBatch(ctx context.Context, inputs []guardian.GuardianInput, risks []string) (*guardian.BatchResult, error)
+	Scan(ctx context.Context, input guardian.GuardianInput) (*guardian.ScanResult, error)
+}
+
+// WithGuardEvaluator sets the Guardian evaluator for the /v1/guard endpoints.
+func WithGuardEvaluator(e GuardEvaluator) ServerOption {
+	return func(s *Server) {
+		s.guardEvaluator = e
+	}
+}
+
+// GuardRequest is the request body for POST /v1/guard.
+type GuardRequest struct {
+	Model  string              `json:"model"`
+	Input  guardian.GuardianInput `json:"input"`
+	Risks  []string            `json:"risks"`
+	Format string              `json:"format,omitempty"`
+	Think  bool                `json:"think,omitempty"`
+}
+
+// GuardResponse is the response body for POST /v1/guard.
+type GuardResponse struct {
+	Model     string         `json:"model"`
+	Flagged   bool           `json:"flagged"`
+	Verdicts  []VerdictData  `json:"verdicts"`
+	LatencyMs int64          `json:"latency_ms"`
+}
+
+// VerdictData holds a single risk verdict in the API response.
+type VerdictData struct {
+	Risk       string  `json:"risk"`
+	Unsafe     bool    `json:"unsafe"`
+	Confidence float64 `json:"confidence"`
+	Reasoning  string  `json:"reasoning"`
+}
+
+// GuardBatchRequest is the request body for POST /v1/guard/batch.
+type GuardBatchRequest struct {
+	Model  string                  `json:"model"`
+	Inputs []guardian.GuardianInput `json:"inputs"`
+	Risks  []string                `json:"risks"`
+}
+
+// GuardBatchResponse is the response body for POST /v1/guard/batch.
+type GuardBatchResponse struct {
+	Model     string             `json:"model"`
+	Results   []GuardBatchResult `json:"results"`
+	LatencyMs int64              `json:"latency_ms"`
+}
+
+// GuardBatchResult holds verdicts for a single input in a batch.
+type GuardBatchResult struct {
+	Index    int           `json:"index"`
+	Flagged  bool          `json:"flagged"`
+	Verdicts []VerdictData `json:"verdicts"`
+}
+
+// GuardScanRequest is the request body for POST /v1/guard/scan.
+type GuardScanRequest struct {
+	Model string                `json:"model"`
+	Input guardian.GuardianInput `json:"input"`
+}
+
+// GuardScanResponse is the response body for POST /v1/guard/scan.
+type GuardScanResponse struct {
+	Model       string        `json:"model"`
+	Flagged     bool          `json:"flagged"`
+	HighestRisk string        `json:"highest_risk,omitempty"`
+	Verdicts    []VerdictData `json:"verdicts"`
+	LatencyMs   int64         `json:"latency_ms"`
+}
+
+// GuardMetrics records Guardian-specific Prometheus metrics.
+type GuardMetrics struct {
+	requestsTotal runtime.CounterMetric
+	latencyMs     runtime.HistogramMetric
+}
+
+// NewGuardMetrics creates Guardian metrics backed by the given collector.
+func NewGuardMetrics(c runtime.Collector) *GuardMetrics {
+	return &GuardMetrics{
+		requestsTotal: c.Counter("guard_requests_total"),
+		latencyMs:     c.Histogram("guard_latency_ms", latencyBuckets),
+	}
+}
+
+func (s *Server) handleGuard(w http.ResponseWriter, r *http.Request) {
+	s.inflight.Add(1)
+	defer s.inflight.Done()
+
+	if s.guardEvaluator == nil {
+		writeError(w, http.StatusNotImplemented, "guardian evaluation is not configured")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
+	var req GuardRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if isMaxBytesError(err) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		s.logger.Debug("invalid request body", "error", err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Model == "" {
+		writeError(w, http.StatusBadRequest, "model is required")
+		return
+	}
+
+	if req.Input.User == "" {
+		writeError(w, http.StatusBadRequest, "input.user is required")
+		return
+	}
+
+	// Validate risk categories.
+	for _, risk := range req.Risks {
+		if _, ok := guardian.RiskDefinitions[risk]; !ok {
+			writeError(w, http.StatusBadRequest, "invalid risk category: "+risk)
+			return
+		}
+	}
+
+	start := time.Now()
+
+	verdicts, err := s.guardEvaluator.Evaluate(r.Context(), guardian.GuardianRequest{
+		Input:  req.Input,
+		Risks:  req.Risks,
+		Format: req.Format,
+		Think:  req.Think,
+	})
+	if err != nil {
+		writeError(w, inferenceErrorStatus(err), s.sanitizeError(err))
+		return
+	}
+
+	flagged := false
+	data := make([]VerdictData, len(verdicts))
+	for i, v := range verdicts {
+		if v.Unsafe {
+			flagged = true
+		}
+		data[i] = VerdictData{
+			Risk:       v.Risk,
+			Unsafe:     v.Unsafe,
+			Confidence: v.Confidence,
+			Reasoning:  v.Reasoning,
+		}
+	}
+
+	latency := time.Since(start).Milliseconds()
+
+	s.guardMetrics.requestsTotal.Inc()
+	s.guardMetrics.latencyMs.Observe(float64(latency))
+
+	writeJSON(w, http.StatusOK, GuardResponse{
+		Model:     req.Model,
+		Flagged:   flagged,
+		Verdicts:  data,
+		LatencyMs: latency,
+	})
+}
+
+func (s *Server) handleGuardBatch(w http.ResponseWriter, r *http.Request) {
+	s.inflight.Add(1)
+	defer s.inflight.Done()
+
+	if s.guardEvaluator == nil {
+		writeError(w, http.StatusNotImplemented, "guardian evaluation is not configured")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
+	var req GuardBatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if isMaxBytesError(err) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		s.logger.Debug("invalid request body", "error", err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Model == "" {
+		writeError(w, http.StatusBadRequest, "model is required")
+		return
+	}
+
+	if len(req.Inputs) == 0 {
+		writeError(w, http.StatusBadRequest, "inputs is required")
+		return
+	}
+
+	if len(req.Inputs) > maxGuardBatch {
+		writeError(w, http.StatusBadRequest, "inputs exceeds maximum batch size of 256")
+		return
+	}
+
+	// Validate risk categories.
+	for _, risk := range req.Risks {
+		if _, ok := guardian.RiskDefinitions[risk]; !ok {
+			writeError(w, http.StatusBadRequest, "invalid risk category: "+risk)
+			return
+		}
+	}
+
+	start := time.Now()
+
+	result, err := s.guardEvaluator.EvaluateBatch(r.Context(), req.Inputs, req.Risks)
+	if err != nil {
+		writeError(w, inferenceErrorStatus(err), s.sanitizeError(err))
+		return
+	}
+
+	results := make([]GuardBatchResult, len(result.Results))
+	for i, ir := range result.Results {
+		data := make([]VerdictData, len(ir.Verdicts))
+		for j, v := range ir.Verdicts {
+			data[j] = VerdictData{
+				Risk:       v.Risk,
+				Unsafe:     v.Unsafe,
+				Confidence: v.Confidence,
+				Reasoning:  v.Reasoning,
+			}
+		}
+		results[i] = GuardBatchResult{
+			Index:    ir.Index,
+			Flagged:  ir.Flagged,
+			Verdicts: data,
+		}
+	}
+
+	latency := time.Since(start).Milliseconds()
+
+	s.guardMetrics.requestsTotal.Inc()
+	s.guardMetrics.latencyMs.Observe(float64(latency))
+
+	writeJSON(w, http.StatusOK, GuardBatchResponse{
+		Model:     req.Model,
+		Results:   results,
+		LatencyMs: latency,
+	})
+}
+
+func (s *Server) handleGuardScan(w http.ResponseWriter, r *http.Request) {
+	s.inflight.Add(1)
+	defer s.inflight.Done()
+
+	if s.guardEvaluator == nil {
+		writeError(w, http.StatusNotImplemented, "guardian evaluation is not configured")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
+	var req GuardScanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if isMaxBytesError(err) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		s.logger.Debug("invalid request body", "error", err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Model == "" {
+		writeError(w, http.StatusBadRequest, "model is required")
+		return
+	}
+
+	if req.Input.User == "" {
+		writeError(w, http.StatusBadRequest, "input.user is required")
+		return
+	}
+
+	start := time.Now()
+
+	result, err := s.guardEvaluator.Scan(r.Context(), req.Input)
+	if err != nil {
+		writeError(w, inferenceErrorStatus(err), s.sanitizeError(err))
+		return
+	}
+
+	data := make([]VerdictData, len(result.Verdicts))
+	for i, v := range result.Verdicts {
+		data[i] = VerdictData{
+			Risk:       v.Risk,
+			Unsafe:     v.Unsafe,
+			Confidence: v.Confidence,
+			Reasoning:  v.Reasoning,
+		}
+	}
+
+	latency := time.Since(start).Milliseconds()
+
+	s.guardMetrics.requestsTotal.Inc()
+	s.guardMetrics.latencyMs.Observe(float64(latency))
+
+	writeJSON(w, http.StatusOK, GuardScanResponse{
+		Model:       req.Model,
+		Flagged:     result.Flagged,
+		HighestRisk: result.HighestRisk,
+		Verdicts:    data,
+		LatencyMs:   latency,
+	})
+}

--- a/serve/guard_test.go
+++ b/serve/guard_test.go
@@ -1,0 +1,261 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/zerfoo/zerfoo/inference/guardian"
+)
+
+// mockGuardEvaluator implements GuardEvaluator for testing.
+type mockGuardEvaluator struct {
+	verdicts    []guardian.Verdict
+	batchResult *guardian.BatchResult
+	scanResult  *guardian.ScanResult
+	err         error
+}
+
+func (m *mockGuardEvaluator) Evaluate(_ context.Context, req guardian.GuardianRequest) ([]guardian.Verdict, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.verdicts != nil {
+		return m.verdicts, nil
+	}
+	// Default: return one safe verdict per risk.
+	risks := req.Risks
+	if len(risks) == 0 {
+		risks = guardian.HarmRiskCategories()
+	}
+	out := make([]guardian.Verdict, len(risks))
+	for i, r := range risks {
+		out[i] = guardian.Verdict{
+			Risk:       r,
+			Unsafe:     false,
+			Confidence: 0.1,
+		}
+	}
+	return out, nil
+}
+
+func (m *mockGuardEvaluator) EvaluateBatch(_ context.Context, inputs []guardian.GuardianInput, risks []string) (*guardian.BatchResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.batchResult != nil {
+		return m.batchResult, nil
+	}
+	// Default: return safe results for each input.
+	result := &guardian.BatchResult{
+		Results: make([]guardian.InputResult, len(inputs)),
+	}
+	for i := range inputs {
+		verdicts := make([]guardian.Verdict, len(risks))
+		for j, r := range risks {
+			verdicts[j] = guardian.Verdict{
+				Risk:       r,
+				Unsafe:     false,
+				Confidence: 0.1,
+			}
+		}
+		result.Results[i] = guardian.InputResult{
+			Index:    i,
+			Verdicts: verdicts,
+			Flagged:  false,
+		}
+	}
+	return result, nil
+}
+
+func (m *mockGuardEvaluator) Scan(_ context.Context, _ guardian.GuardianInput) (*guardian.ScanResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.scanResult != nil {
+		return m.scanResult, nil
+	}
+	return &guardian.ScanResult{
+		Flagged:  false,
+		Verdicts: []guardian.Verdict{{Risk: "harm", Unsafe: false, Confidence: 0.1}},
+	}, nil
+}
+
+func newGuardServer(t *testing.T, e GuardEvaluator) *httptest.Server {
+	t.Helper()
+	mdl := buildTestModel(t)
+	srv := NewServer(mdl, WithGuardEvaluator(e))
+	return httptest.NewServer(srv.Handler())
+}
+
+func TestGuardEndpoint(t *testing.T) {
+	eval := &mockGuardEvaluator{
+		verdicts: []guardian.Verdict{
+			{Risk: "harm", Unsafe: true, Confidence: 0.9},
+			{Risk: "jailbreaking", Unsafe: false, Confidence: 0.3},
+		},
+	}
+	ts := newGuardServer(t, eval)
+	defer ts.Close()
+
+	body := `{"model":"granite-guardian-3.3-8b","input":{"user":"How to hack a computer"},"risks":["harm","jailbreaking"]}`
+	resp := doPost(t, ts.URL+"/v1/guard", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, data)
+	}
+
+	var result GuardResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if result.Model != "granite-guardian-3.3-8b" {
+		t.Errorf("model = %q, want %q", result.Model, "granite-guardian-3.3-8b")
+	}
+	if !result.Flagged {
+		t.Error("flagged = false, want true")
+	}
+	if len(result.Verdicts) != 2 {
+		t.Fatalf("verdicts length = %d, want 2", len(result.Verdicts))
+	}
+	if result.Verdicts[0].Risk != "harm" {
+		t.Errorf("verdicts[0].risk = %q, want %q", result.Verdicts[0].Risk, "harm")
+	}
+	if !result.Verdicts[0].Unsafe {
+		t.Error("verdicts[0].unsafe = false, want true")
+	}
+	if result.Verdicts[0].Confidence != 0.9 {
+		t.Errorf("verdicts[0].confidence = %f, want 0.9", result.Verdicts[0].Confidence)
+	}
+	if result.Verdicts[1].Unsafe {
+		t.Error("verdicts[1].unsafe = true, want false")
+	}
+}
+
+func TestGuardBatchEndpoint(t *testing.T) {
+	eval := &mockGuardEvaluator{
+		batchResult: &guardian.BatchResult{
+			Results: []guardian.InputResult{
+				{
+					Index:   0,
+					Flagged: true,
+					Verdicts: []guardian.Verdict{
+						{Risk: "harm", Unsafe: true, Confidence: 0.95},
+					},
+				},
+				{
+					Index:   1,
+					Flagged: false,
+					Verdicts: []guardian.Verdict{
+						{Risk: "harm", Unsafe: false, Confidence: 0.1},
+					},
+				},
+			},
+		},
+	}
+	ts := newGuardServer(t, eval)
+	defer ts.Close()
+
+	body := `{"model":"granite-guardian-3.3-8b","inputs":[{"user":"text1"},{"user":"text2"}],"risks":["harm"]}`
+	resp := doPost(t, ts.URL+"/v1/guard/batch", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, data)
+	}
+
+	var result GuardBatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if result.Model != "granite-guardian-3.3-8b" {
+		t.Errorf("model = %q, want %q", result.Model, "granite-guardian-3.3-8b")
+	}
+	if len(result.Results) != 2 {
+		t.Fatalf("results length = %d, want 2", len(result.Results))
+	}
+	if !result.Results[0].Flagged {
+		t.Error("results[0].flagged = false, want true")
+	}
+	if result.Results[1].Flagged {
+		t.Error("results[1].flagged = true, want false")
+	}
+}
+
+func TestGuardScanEndpoint(t *testing.T) {
+	eval := &mockGuardEvaluator{
+		scanResult: &guardian.ScanResult{
+			Flagged:     true,
+			HighestRisk: "harm",
+			Verdicts: []guardian.Verdict{
+				{Risk: "harm", Unsafe: true, Confidence: 0.9},
+				{Risk: "jailbreaking", Unsafe: false, Confidence: 0.2},
+			},
+		},
+	}
+	ts := newGuardServer(t, eval)
+	defer ts.Close()
+
+	body := `{"model":"granite-guardian-3.3-8b","input":{"user":"dangerous text"}}`
+	resp := doPost(t, ts.URL+"/v1/guard/scan", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, data)
+	}
+
+	var result GuardScanResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if result.Model != "granite-guardian-3.3-8b" {
+		t.Errorf("model = %q, want %q", result.Model, "granite-guardian-3.3-8b")
+	}
+	if !result.Flagged {
+		t.Error("flagged = false, want true")
+	}
+	if result.HighestRisk != "harm" {
+		t.Errorf("highest_risk = %q, want %q", result.HighestRisk, "harm")
+	}
+	if len(result.Verdicts) != 2 {
+		t.Fatalf("verdicts length = %d, want 2", len(result.Verdicts))
+	}
+}
+
+func TestGuardMissingModel(t *testing.T) {
+	ts := newGuardServer(t, &mockGuardEvaluator{})
+	defer ts.Close()
+
+	body := `{"input":{"user":"hello"},"risks":["harm"]}`
+	resp := doPost(t, ts.URL+"/v1/guard", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400; body: %s", resp.StatusCode, data)
+	}
+}
+
+func TestGuardInvalidRisk(t *testing.T) {
+	ts := newGuardServer(t, &mockGuardEvaluator{})
+	defer ts.Close()
+
+	body := `{"model":"granite-guardian-3.3-8b","input":{"user":"hello"},"risks":["nonexistent_risk"]}`
+	resp := doPost(t, ts.URL+"/v1/guard", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400; body: %s", resp.StatusCode, data)
+	}
+}

--- a/serve/server.go
+++ b/serve/server.go
@@ -34,9 +34,11 @@ type Server struct {
 	inflight    sync.WaitGroup  // tracks in-flight inference requests
 	transcriber      Transcriber          // optional; enables /v1/audio/transcriptions
 	classifier       Classifier           // optional; enables /v1/classify
+	guardEvaluator   GuardEvaluator       // optional; enables /v1/guard endpoints
 	logger           log.Logger
 	metrics          *ServerMetrics
 	classifyMetrics  *ClassifyMetrics
+	guardMetrics     *GuardMetrics
 	collector        runtime.Collector
 	gpus        []int           // GPU IDs to distribute model across
 	apiKey      string          // optional; enables Bearer token auth
@@ -174,6 +176,7 @@ func NewServer(m *inference.Model, opts ...ServerOption) *Server {
 	}
 	s.metrics = NewServerMetrics(s.collector)
 	s.classifyMetrics = NewClassifyMetrics(s.collector)
+	s.guardMetrics = NewGuardMetrics(s.collector)
 	s.mux.HandleFunc("POST /v1/chat/completions", s.recoveryMiddleware(s.handleChatCompletions))
 	s.mux.HandleFunc("POST /v1/completions", s.recoveryMiddleware(s.handleCompletions))
 	s.mux.HandleFunc("POST /v1/embeddings", s.recoveryMiddleware(s.handleEmbeddings))
@@ -182,6 +185,9 @@ func NewServer(m *inference.Model, opts ...ServerOption) *Server {
 	s.mux.HandleFunc("DELETE /v1/models/{id...}", s.recoveryMiddleware(s.handleModelDelete))
 	s.mux.HandleFunc("POST /v1/audio/transcriptions", s.recoveryMiddleware(s.handleAudioTranscriptions))
 	s.mux.HandleFunc("POST /v1/classify", s.recoveryMiddleware(s.handleClassify))
+	s.mux.HandleFunc("POST /v1/guard", s.recoveryMiddleware(s.handleGuard))
+	s.mux.HandleFunc("POST /v1/guard/batch", s.recoveryMiddleware(s.handleGuardBatch))
+	s.mux.HandleFunc("POST /v1/guard/scan", s.recoveryMiddleware(s.handleGuardScan))
 	s.mux.HandleFunc("GET /healthz", s.recoveryMiddleware(s.handleHealthz))
 	s.mux.HandleFunc("GET /readyz", s.recoveryMiddleware(s.handleReadyz))
 	s.mux.HandleFunc("GET /openapi.yaml", s.recoveryMiddleware(handleOpenAPISpec))


### PR DESCRIPTION
POST /v1/guard, /v1/guard/batch, /v1/guard/scan with Prometheus metrics, validation, mock evaluator interface. 5 tests. GG-T3.1.