### PR TITLE
feat(serve): add Guardian guardrails middleware for chat completions

### DIFF
--- a/serve/guardian_middleware.go
+++ b/serve/guardian_middleware.go
@@ -1,0 +1,198 @@
+package serve
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/zerfoo/zerfoo/inference/guardian"
+)
+
+// GuardianMiddlewareConfig controls how the Guardian safety middleware
+// intercepts chat completion requests.
+type GuardianMiddlewareConfig struct {
+	Model       string   // Guardian model path
+	Risks       []string // risk categories (default: HarmRiskCategories)
+	CheckInput  bool     // scan user prompts (default: true)
+	CheckOutput bool     // scan assistant responses (default: false)
+	BlockOnFlag bool     // return 400 if flagged (default: true)
+}
+
+// guardianFlaggedResponse is returned when content is flagged and BlockOnFlag is true.
+type guardianFlaggedResponse struct {
+	Error    string       `json:"error"`
+	Verdicts []VerdictData `json:"verdicts"`
+}
+
+// GuardianMiddleware returns HTTP middleware that wraps chat completion
+// requests with Guardian safety checks. If evaluator is nil the middleware
+// is a no-op pass-through.
+func GuardianMiddleware(evaluator GuardEvaluator, config GuardianMiddlewareConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Pass through when evaluator is nil or not a chat completions request.
+			if evaluator == nil || r.URL.Path != "/v1/chat/completions" || r.Method != http.MethodPost {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Read and buffer the request body so we can parse it and
+			// still forward it to the inner handler.
+			body, err := io.ReadAll(r.Body)
+			r.Body.Close()
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "failed to read request body")
+				return
+			}
+
+			var req ChatCompletionRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				// Let the inner handler deal with malformed JSON.
+				r.Body = io.NopCloser(bytes.NewReader(body))
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			risks := config.Risks
+			if len(risks) == 0 {
+				risks = guardian.HarmRiskCategories()
+			}
+
+			// --- Input check ---
+			if config.CheckInput {
+				userMsg := lastUserMessage(req.Messages)
+				if userMsg != "" {
+					verdicts, evalErr := evaluator.Evaluate(r.Context(), guardian.GuardianRequest{
+						Input: guardian.GuardianInput{User: userMsg},
+						Risks: risks,
+					})
+					if evalErr == nil {
+						flagged, data := toVerdictData(verdicts)
+						if flagged {
+							if config.BlockOnFlag {
+								writeJSON(w, http.StatusBadRequest, guardianFlaggedResponse{
+									Error:    "content_flagged",
+									Verdicts: data,
+								})
+								return
+							}
+							w.Header().Set("X-Guardian-Flagged", "true")
+						}
+					}
+				}
+			}
+
+			// --- Forward to inner handler ---
+			r.Body = io.NopCloser(bytes.NewReader(body))
+
+			if !config.CheckOutput {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Capture the inner handler's response for output checking.
+			rec := &responseBuffer{header: make(http.Header)}
+			next.ServeHTTP(rec, r)
+
+			// --- Output check ---
+			assistantMsg := extractAssistantContent(rec.body.Bytes())
+			if assistantMsg != "" {
+				verdicts, evalErr := evaluator.Evaluate(r.Context(), guardian.GuardianRequest{
+					Input: guardian.GuardianInput{
+						User:      lastUserMessage(req.Messages),
+						Assistant: assistantMsg,
+					},
+					Risks: risks,
+				})
+				if evalErr == nil {
+					flagged, data := toVerdictData(verdicts)
+					if flagged {
+						if config.BlockOnFlag {
+							writeJSON(w, http.StatusBadRequest, guardianFlaggedResponse{
+								Error:    "content_flagged",
+								Verdicts: data,
+							})
+							return
+						}
+						w.Header().Set("X-Guardian-Flagged", "true")
+					}
+				}
+			}
+
+			// Forward the captured response.
+			copyHeader(w.Header(), rec.header)
+			w.WriteHeader(rec.status)
+			w.Write(rec.body.Bytes()) //nolint:errcheck
+		})
+	}
+}
+
+// responseBuffer captures an HTTP response in memory.
+type responseBuffer struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func (rb *responseBuffer) Header() http.Header { return rb.header }
+
+func (rb *responseBuffer) WriteHeader(code int) { rb.status = code }
+
+func (rb *responseBuffer) Write(b []byte) (int, error) {
+	if rb.status == 0 {
+		rb.status = http.StatusOK
+	}
+	return rb.body.Write(b)
+}
+
+// lastUserMessage returns the content of the last message with role "user".
+func lastUserMessage(msgs []ChatMessage) string {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "user" {
+			return msgs[i].Content
+		}
+	}
+	return ""
+}
+
+// extractAssistantContent parses a ChatCompletionResponse and returns the
+// first choice's assistant message content.
+func extractAssistantContent(data []byte) string {
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return ""
+	}
+	if len(resp.Choices) == 0 {
+		return ""
+	}
+	return resp.Choices[0].Message.Content
+}
+
+// toVerdictData converts guardian verdicts to API verdict data and reports
+// whether any verdict is flagged as unsafe.
+func toVerdictData(verdicts []guardian.Verdict) (bool, []VerdictData) {
+	flagged := false
+	data := make([]VerdictData, len(verdicts))
+	for i, v := range verdicts {
+		if v.Unsafe {
+			flagged = true
+		}
+		data[i] = VerdictData{
+			Risk:       v.Risk,
+			Unsafe:     v.Unsafe,
+			Confidence: v.Confidence,
+			Reasoning:  v.Reasoning,
+		}
+	}
+	return flagged, data
+}
+
+// copyHeader copies all headers from src to dst.
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}

--- a/serve/guardian_middleware_test.go
+++ b/serve/guardian_middleware_test.go
@@ -1,0 +1,250 @@
+package serve
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/zerfoo/zerfoo/inference/guardian"
+)
+
+// echoHandler writes a fixed ChatCompletionResponse so the middleware has
+// something to inspect when CheckOutput is enabled.
+func echoHandler(content string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := ChatCompletionResponse{
+			ID:     "chatcmpl-test",
+			Object: "chat.completion",
+			Model:  "test-model",
+			Choices: []ChatCompletionChoice{
+				{Index: 0, Message: ChatMessage{Role: "assistant", Content: content}, FinishReason: "stop"},
+			},
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+}
+
+func chatBody(t *testing.T, userMsg string) *bytes.Buffer {
+	t.Helper()
+	req := ChatCompletionRequest{
+		Model:    "test-model",
+		Messages: []ChatMessage{{Role: "user", Content: userMsg}},
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes.NewBuffer(b)
+}
+
+func TestGuardianMiddleware_SafeInputPassesThrough(t *testing.T) {
+	eval := &mockGuardEvaluator{} // default: all safe
+	mw := GuardianMiddleware(eval, GuardianMiddlewareConfig{
+		CheckInput:  true,
+		BlockOnFlag: true,
+	})
+
+	inner := echoHandler("hello world")
+	handler := mw(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", chatBody(t, "hi"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ChatCompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "hello world" {
+		t.Fatalf("unexpected content: %s", resp.Choices[0].Message.Content)
+	}
+}
+
+func TestGuardianMiddleware_HarmfulInputBlocked(t *testing.T) {
+	eval := &mockGuardEvaluator{
+		verdicts: []guardian.Verdict{
+			{Risk: "harm", Unsafe: true, Confidence: 0.95, Reasoning: "harmful content detected"},
+		},
+	}
+	mw := GuardianMiddleware(eval, GuardianMiddlewareConfig{
+		CheckInput:  true,
+		BlockOnFlag: true,
+	})
+
+	inner := echoHandler("should not reach")
+	handler := mw(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", chatBody(t, "bad stuff"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp guardianFlaggedResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error != "content_flagged" {
+		t.Fatalf("expected error content_flagged, got %q", resp.Error)
+	}
+	if len(resp.Verdicts) != 1 || !resp.Verdicts[0].Unsafe {
+		t.Fatalf("expected one unsafe verdict, got %+v", resp.Verdicts)
+	}
+}
+
+func TestGuardianMiddleware_CheckInputFalseSkipsScanning(t *testing.T) {
+	eval := &mockGuardEvaluator{
+		verdicts: []guardian.Verdict{
+			{Risk: "harm", Unsafe: true, Confidence: 0.95},
+		},
+	}
+	mw := GuardianMiddleware(eval, GuardianMiddlewareConfig{
+		CheckInput:  false,
+		BlockOnFlag: true,
+	})
+
+	inner := echoHandler("passed through")
+	handler := mw(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", chatBody(t, "bad stuff"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (input scanning disabled), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGuardianMiddleware_CheckOutputScansAssistantResponse(t *testing.T) {
+	// Input is safe, but output evaluator will flag it.
+	callCount := 0
+	eval := &mockGuardEvaluator{}
+	// Override Evaluate to flag only when assistant content is present (output check).
+	origEval := &outputFlaggingEvaluator{callCount: &callCount}
+
+	mw := GuardianMiddleware(origEval, GuardianMiddlewareConfig{
+		CheckInput:  true,
+		CheckOutput: true,
+		BlockOnFlag: true,
+	})
+
+	inner := echoHandler("toxic response")
+	handler := mw(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", chatBody(t, "hello"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// The output check should have flagged it.
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 from output check, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	_ = eval // used for reference only
+}
+
+// outputFlaggingEvaluator returns safe for input checks (no assistant) and
+// unsafe for output checks (assistant present).
+type outputFlaggingEvaluator struct {
+	callCount *int
+}
+
+func (e *outputFlaggingEvaluator) Evaluate(_ context.Context, req guardian.GuardianRequest) ([]guardian.Verdict, error) {
+	*e.callCount++
+	if req.Input.Assistant != "" {
+		return []guardian.Verdict{{Risk: "harm", Unsafe: true, Confidence: 0.99}}, nil
+	}
+	return []guardian.Verdict{{Risk: "harm", Unsafe: false, Confidence: 0.01}}, nil
+}
+
+func (e *outputFlaggingEvaluator) EvaluateBatch(_ context.Context, _ []guardian.GuardianInput, _ []string) (*guardian.BatchResult, error) {
+	return &guardian.BatchResult{}, nil
+}
+
+func (e *outputFlaggingEvaluator) Scan(_ context.Context, _ guardian.GuardianInput) (*guardian.ScanResult, error) {
+	return &guardian.ScanResult{}, nil
+}
+
+func TestGuardianMiddleware_BlockOnFlagFalseAllowsFlaggedContent(t *testing.T) {
+	eval := &mockGuardEvaluator{
+		verdicts: []guardian.Verdict{
+			{Risk: "harm", Unsafe: true, Confidence: 0.95},
+		},
+	}
+	mw := GuardianMiddleware(eval, GuardianMiddlewareConfig{
+		CheckInput:  true,
+		BlockOnFlag: false,
+	})
+
+	inner := echoHandler("allowed through")
+	handler := mw(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", chatBody(t, "bad stuff"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (BlockOnFlag=false), got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if got := rec.Header().Get("X-Guardian-Flagged"); got != "true" {
+		t.Fatalf("expected X-Guardian-Flagged: true, got %q", got)
+	}
+}
+
+func TestGuardianMiddleware_NilEvaluatorPassesThrough(t *testing.T) {
+	mw := GuardianMiddleware(nil, GuardianMiddlewareConfig{
+		CheckInput:  true,
+		BlockOnFlag: true,
+	})
+
+	inner := echoHandler("no guardian")
+	handler := mw(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", chatBody(t, "anything"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (nil evaluator), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGuardianMiddleware_NonChatPathPassesThrough(t *testing.T) {
+	eval := &mockGuardEvaluator{
+		verdicts: []guardian.Verdict{
+			{Risk: "harm", Unsafe: true, Confidence: 0.95},
+		},
+	}
+	mw := GuardianMiddleware(eval, GuardianMiddlewareConfig{
+		CheckInput:  true,
+		BlockOnFlag: true,
+	})
+
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := mw(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/completions", chatBody(t, "bad stuff"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("inner handler was not called for non-chat path")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for non-chat path, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
Wraps /v1/chat/completions with input/output safety checks. 7 tests. GG-T3.3.