### PR TITLE
fix(generate): prepend BOS in speculative decoding paths

### DIFF
--- a/generate/generator.go
+++ b/generate/generator.go
@@ -712,6 +712,11 @@ func (gen *Generator[T]) generateSpeculative(ctx context.Context, prompt string,
 		return "", fmt.Errorf("prompt produced no tokens")
 	}
 
+	// Prepend BOS token if configured.
+	if gen.config.BOSTokenID > 0 {
+		promptIDs = append([]int{gen.config.BOSTokenID}, promptIDs...)
+	}
+
 	stopSet := make(map[int]bool, len(sc.StopTokenIDs)+1)
 	for _, id := range sc.StopTokenIDs {
 		stopSet[id] = true

--- a/generate/speculative.go
+++ b/generate/speculative.go
@@ -73,6 +73,11 @@ func (sg *SpeculativeGenerator[T]) Generate(ctx context.Context, prompt string, 
 		return "", fmt.Errorf("prompt produced no tokens")
 	}
 
+	// Prepend BOS token if configured.
+	if sg.targetCfg.BOSTokenID > 0 {
+		promptIDs = append([]int{sg.targetCfg.BOSTokenID}, promptIDs...)
+	}
+
 	stopSet := make(map[int]bool, len(sc.StopTokenIDs)+1)
 	for _, id := range sc.StopTokenIDs {
 		stopSet[id] = true


### PR DESCRIPTION
Speculative decoding paths were missing BOS prepend. Non-speculative paths already correct. MFP-T3.