### PR TITLE
fix(cuda): sync Repeat kernel to repeat-each semantics

### DIFF
--- a/internal/cuda/kernels/elementwise.cu
+++ b/internal/cuda/kernels/elementwise.cu
@@ -614,7 +614,7 @@ __global__ void kernel_repeat(const float* src, float* dst,
     int outer = temp / (axisDim * reps);
 
     // Map to source: strip out the repetition
-    int srcAxis = repAxis % axisDim;
+    int srcAxis = repAxis / reps;
     int srcIdx = (outer * axisDim + srcAxis) * innerSize + inner;
     dst[idx] = src[srcIdx];
 }

--- a/internal/cuda/kernels/megakernel_ops.cu
+++ b/internal/cuda/kernels/megakernel_ops.cu
@@ -249,12 +249,12 @@ __device__ void dev_slice(float* out, const float* in,
 // ============================================================
 
 // dev_repeat replicates input along an axis (GQA K/V head replication).
-// For last-axis repeat: out[r*dim + i] = in[i] for r in [0, reps).
+// Uses repeat-each semantics: [a,b,c] x3 -> [a,a,a,b,b,b,c,c,c].
 __device__ void dev_repeat(float* out, const float* in,
                             int axis, int reps, int dim) {
     int total = dim * reps;
     for (int i = threadIdx.x; i < total; i += blockDim.x) {
-        out[i] = in[i % dim];
+        out[i] = in[i / reps];
     }
     __syncthreads();
 }


### PR DESCRIPTION
GPU kernel still had tile semantics. Fixes GPU inference for Llama/Mistral/Qwen/Phi.