### PR TITLE
fix(attention): skip flash attention during decode with asymmetric Q/K lengths

### DIFF
--- a/layers/attention/flash.go
+++ b/layers/attention/flash.go
@@ -33,6 +33,22 @@ func tryFlashForward[T tensor.Numeric](
 		return nil, nil
 	}
 
+	// The flash prefill kernel assumes Q and K/V share the same sequence
+	// length (it uses a single seq_len for all pointer arithmetic). During
+	// autoregressive decode with KV cache, Q has seqLen=1 while K/V have
+	// seqLen=cachedSeqLen. Using Q's seqLen to index into K/V produces wrong
+	// offsets and garbage output. Bail out so the cuBLAS SDPA path handles it.
+	if q.Shape()[1] != k.Shape()[1] {
+		return nil, nil
+	}
+
+	// The kernel uses Q's batch*heads dimension to index into K and V.
+	// If K/V have a different batch dimension (e.g., single KV head before
+	// repeat), the kernel would read out of bounds. Bail out.
+	if q.Shape()[0] != k.Shape()[0] {
+		return nil, nil
+	}
+
 	// Check that Q is on GPU.
 	if q.GetStorage().DeviceType() != device.CUDA {
 		return nil, nil

--- a/layers/attention/flash_rocm.go
+++ b/layers/attention/flash_rocm.go
@@ -26,6 +26,22 @@ func tryFlashForward[T tensor.Numeric](
 		return nil, nil
 	}
 
+	// The flash prefill kernel assumes Q and K/V share the same sequence
+	// length (it uses a single seq_len for all pointer arithmetic). During
+	// autoregressive decode with KV cache, Q has seqLen=1 while K/V have
+	// seqLen=cachedSeqLen. Using Q's seqLen to index into K/V produces wrong
+	// offsets and garbage output. Bail out so the standard SDPA path handles it.
+	if q.Shape()[1] != k.Shape()[1] {
+		return nil, nil
+	}
+
+	// The kernel uses Q's batch*heads dimension to index into K and V.
+	// If K/V have a different batch dimension (e.g., single KV head before
+	// repeat), the kernel would read out of bounds. Bail out.
+	if q.Shape()[0] != k.Shape()[0] {
+		return nil, nil
+	}
+
 	// Check that Q is on GPU.
 	if q.GetStorage().DeviceType() != device.ROCm {
 		return nil, nil

--- a/layers/attention/flash_test.go
+++ b/layers/attention/flash_test.go
@@ -84,6 +84,65 @@ func TestSDPAFlashFallbackParity(t *testing.T) {
 	}
 }
 
+// TestTryFlashForwardSeqLenMismatch verifies that tryFlashForward bails out
+// (returns nil, nil) when Q and K have different sequence lengths, which
+// happens during autoregressive decode with a KV cache. The flash prefill
+// kernel uses a single seq_len for Q/K/V pointer arithmetic, so mismatched
+// lengths would produce wrong K/V offsets and garbage output.
+func TestTryFlashForwardSeqLenMismatch(t *testing.T) {
+	headDim := 64
+	// Q: decode token (seqLen=1), K/V: cached (seqLen=10)
+	q, _ := tensor.New([]int{4, 1, headDim}, make([]float32, 4*1*headDim))
+	k, _ := tensor.New([]int{4, 10, headDim}, make([]float32, 4*10*headDim))
+	v, _ := tensor.New([]int{4, 10, headDim}, make([]float32, 4*10*headDim))
+
+	result, err := tryFlashForward(q, k, v, headDim, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatal("expected nil result when Q and K have different seq_len")
+	}
+}
+
+// TestTryFlashForwardBatchMismatch verifies that tryFlashForward bails out
+// when Q and K have different batch*heads dimensions (e.g., single KV head
+// without prior repeat expansion).
+func TestTryFlashForwardBatchMismatch(t *testing.T) {
+	headDim := 64
+	// Q: 4 query heads, K/V: 1 KV head (not yet repeated)
+	q, _ := tensor.New([]int{4, 8, headDim}, make([]float32, 4*8*headDim))
+	k, _ := tensor.New([]int{1, 8, headDim}, make([]float32, 1*8*headDim))
+	v, _ := tensor.New([]int{1, 8, headDim}, make([]float32, 1*8*headDim))
+
+	result, err := tryFlashForward(q, k, v, headDim, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatal("expected nil result when Q and K have different batch dimensions")
+	}
+}
+
+// TestTryFlashForwardMatchingDims verifies that tryFlashForward does NOT
+// bail out when Q and K have matching dimensions (prefill scenario).
+// On CPU it still returns nil because CUDA is not available.
+func TestTryFlashForwardMatchingDims(t *testing.T) {
+	headDim := 64
+	q, _ := tensor.New([]int{4, 8, headDim}, make([]float32, 4*8*headDim))
+	k, _ := tensor.New([]int{4, 8, headDim}, make([]float32, 4*8*headDim))
+	v, _ := tensor.New([]int{4, 8, headDim}, make([]float32, 4*8*headDim))
+
+	result, err := tryFlashForward(q, k, v, headDim, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// On CPU, returns nil because CUDA is not available (not because of dim mismatch).
+	if result != nil {
+		t.Fatal("expected nil result on CPU (no CUDA)")
+	}
+}
+
 // naiveSoftmaxAttention computes softmax(Q*K^T / sqrt(d)) * V on CPU.
 // Q, K, V are [batchHeads, seqLen, headDim] in row-major order.
 func naiveSoftmaxAttention(qIn, kIn, vIn []float32, batchHeads, seqLen, headDim int) []float32 {


### PR DESCRIPTION
## Root Cause

Flash attention prefill kernel uses Q's seqLen for K/V pointer arithmetic.
During decode, Q has seqLen=1 but K/V have seqLen=cachedSeqLen, causing
wrong memory access. Gemma was immune (headDim=256 > flash limit of 128).

## Fix

Skip flash attention when Q and K have different sequence lengths or batch
dimensions. Falls through to cuBLAS SDPA which handles these correctly.

## Verified on DGX Spark

| Model | Before | After |
|-------|--------|-------|
| Gemma 3 1B | 233 tok/s coherent | 233 tok/s coherent |
| Llama 3.2 3B | repetitive garbage | **coherent** |
| Mistral 7B | repetitive garbage | **coherent** |
| DeepSeek R1 1.5B | repetitive garbage | **coherent** |
| Phi 3 mini | untested | **coherent** |