### PR TITLE
fix(gguf): add Q4_1/Q5_0/Q5_1 mmap type mappings

### DIFF
--- a/model/gguf/loader_mmap.go
+++ b/model/gguf/loader_mmap.go
@@ -87,6 +87,12 @@ func mapGGMLType(t GGMLType) (tensor.GGMLType, error) {
 		return tensor.GGMLTypeF16, nil
 	case GGMLTypeQ4_0:
 		return tensor.GGMLTypeQ4_0, nil
+	case GGMLTypeQ4_1:
+		return tensor.GGMLTypeQ4_1, nil
+	case GGMLTypeQ5_0:
+		return tensor.GGMLTypeQ5_0, nil
+	case GGMLTypeQ5_1:
+		return tensor.GGMLTypeQ5_1, nil
 	case GGMLTypeQ8_0:
 		return tensor.GGMLTypeQ8_0, nil
 	case GGMLTypeQ4_K:


### PR DESCRIPTION
## Summary
- Add missing Q4_1 (3), Q5_0 (6), Q5_1 (7) type mappings to `mapGGMLType` in `loader_mmap.go`
- Fixes `"unsupported GGML type 6 for mmap loading"` error when loading Q4_K_M GGUFs that contain Q5_0 output/embedding tensors

## Test plan
- [x] `go build ./model/gguf/...` compiles
- [x] `go test ./model/gguf/...` passes
- [ ] Verify mmap loading on DGX with Gemma 3 1B Q4_K_M GGUF