### PR TITLE
docs: v1.36.0 release notes — WithTieredKV, audio transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,29 @@ result, _ := m.Generate(ctx, prompt,
 )
 ```
 
+### Tiered KV Cache
+
+Automatically spill KV cache across three storage tiers as sequences grow — no OOM, no manual tuning:
+
+- **Hot**: uncompressed tensors in GPU/CPU memory (recent tokens)
+- **Warm**: compressed in CPU memory via block quantization
+- **Cold**: serialized to disk as binary files (oldest tokens)
+
+Layers are promoted and demoted automatically based on access frequency. Async prefetch moves cold layers back to hot before the decoder needs them.
+
+```go
+result, _ := m.Generate(ctx, prompt,
+    zerfoo.WithTieredKV(generate.TieredKVStoreConfig{
+        ChunkSize:        64,  // warm-tier compression chunk size
+        DemoteThreshold:  2,   // demote layers accessed < 2 times
+        PromoteThreshold: 8,   // promote layers accessed > 8 times
+        // ColdDir: "/var/cache/kv" // optional: persist cold tier across calls
+    }),
+)
+```
+
+Enable it on the Model API via `zerfoo.WithTieredKV` (wraps `generate.WithTieredKV`). Useful for long-context inference where the KV cache exceeds GPU memory.
+
 ### TransMLA — MHA-to-MLA Conversion
 
 Convert any MHA/GQA model to Multi-Head Latent Attention via SVD decomposition. Reduces KV cache by 80%+. Based on [TransMLA](https://arxiv.org/abs/2502.07864).
@@ -125,6 +148,22 @@ Hardware-aligned three-path sparse attention: coarse compression, fine-grained s
 ### Hybrid CPU/GPU MoE
 
 Place shared MoE experts on GPU, offload routed experts to CPU with SIMD kernels. Predictive prefetching achieves 98% hit rate. Based on [KTransformers](https://arxiv.org/abs/2501.14018).
+
+### Audio Transcription
+
+Transcribe WAV audio to text using Whisper or Voxtral speech-to-text models. Audio is chunked into 30-second segments, mel spectrograms are extracted, and each chunk is decoded in parallel:
+
+```go
+wavData, _ := os.ReadFile("speech.wav")
+
+m, _ := zerfoo.Load("openai/whisper-large-v3")
+defer m.Close()
+
+text, err := m.Transcribe(context.Background(), wavData)
+fmt.Println(text)
+```
+
+Supports 16 kHz mono WAV input. Whisper uses 80 mel bins; Voxtral uses 128. Long audio is automatically chunked into 30-second segments and concatenated.
 
 ## Quick Start
 
@@ -349,6 +388,7 @@ zerfoo eagle-train --model m.gguf --corpus data.txt --output eagle.gguf  # train
 zerfoo transmla --input m.gguf --output m-mla.gguf  # MHA→MLA conversion
 zerfoo transmla-validate --original m.gguf --converted m-mla.gguf  # perplexity comparison
 zerfoo train -backend tabular ...      # train a tabular model
+zerfoo transcribe speech.wav --model whisper-large-v3  # speech to text
 zerfoo list                             # list cached models
 ```
 

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,5 +1,23 @@
 # Updates
 
+## 2026-03-29: v1.36.0 — Audio transcription, tiered KV cache, MiniMax-M2 fixes
+
+### zerfoo v1.36.0 / ztensor v0.15.0
+
+**New features:**
+- **`Model.Transcribe`**: Speech-to-text via Whisper or Voxtral. WAV input, mel spectrogram extraction, 30-second chunking, parallel greedy decode. CLI: `zerfoo transcribe`.
+- **`WithTieredKV`**: Hot/warm/cold tiered KV cache. Layers auto-demote to warm (compressed) or cold (disk) based on access frequency. Async prefetch for cold→hot. Unblocks long-context inference beyond GPU memory.
+- **ztensor: `MmapStorage.SliceElements`**: Zero-copy expert weight slicing for mmap'd MoE stacked weights.
+- **ztensor: Streaming GEMM**: Streaming GEMM for mmap'd tensors, enabling over-RAM CPU inference at scale.
+
+**Bug fixes:**
+- `fix(generate): Close() skips deletion of user-provided ColdDir` — TieredKVStore no longer removes a caller-supplied cold directory on close.
+- `fix(attention): QK norms applied before head reshape` — fixes MiniMax-M2 output quality.
+- `fix(inference): OOM eliminated during MoE graph build` — `NewFFNFromDense` removes ~857 GB phantom allocation for 256-expert models.
+- `fix(inference): Zero-copy expert slicing` — `buildExpertFFN` uses pre-existing weight slices via `NewFFNFromDense`.
+
+**Releases:** [zerfoo v1.36.0](https://github.com/zerfoo/zerfoo/releases/tag/v1.36.0) · [ztensor v0.15.0](https://github.com/zerfoo/ztensor/releases/tag/v0.15.0)
+
 ## 2026-03-29: E45 verification remediation shipped (PR #274)
 
 Resolved all gaps found by /verify audit. `WithTieredKV` GeneratorOption now exposes


### PR DESCRIPTION
## Summary

- Add `### Tiered KV Cache` section to README with `WithTieredKV` example and hot/warm/cold tier description
- Add `### Audio Transcription` section to README with `Model.Transcribe` example and `zerfoo transcribe` CLI usage
- Add `zerfoo transcribe` to the CLI commands block
- Add v1.36.0 / ztensor v0.15.0 entry to `docs/updates.md`

## Test plan

- [ ] README renders correctly on GitHub (check headings, code blocks)
- [ ] `go build ./...` passes (no code changes, docs only)