### PR TITLE
perf(timeseries): enable CUDA graph capture with capture-aware pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ exclude google.golang.org/genproto v0.0.0-20220401170504-314d38edb7de
 exclude google.golang.org/genproto v0.0.0-20220324131243-acbaeb5b85eb
 
 require (
-	github.com/zerfoo/ztensor v1.0.1-0.20260330231915-1f37c699ccae
+	github.com/zerfoo/ztensor v1.0.1-0.20260330235452-e39b31850637
 	github.com/zerfoo/ztoken v0.3.4
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/zerfoo/ztensor v0.14.2-0.20260329061715-0a40e11c6984 h1:4PXZbHuUMRpMR
 github.com/zerfoo/ztensor v0.14.2-0.20260329061715-0a40e11c6984/go.mod h1:icFer0fMw2ugD744QLHSdXmiVCDwm6c4OS8LT7xvdXw=
 github.com/zerfoo/ztensor v1.0.1-0.20260330231915-1f37c699ccae h1:U6TJAyxR+M+hIw4kCmHIBfkm/HF55BkrS/d1fKaElBs=
 github.com/zerfoo/ztensor v1.0.1-0.20260330231915-1f37c699ccae/go.mod h1:icFer0fMw2ugD744QLHSdXmiVCDwm6c4OS8LT7xvdXw=
+github.com/zerfoo/ztensor v1.0.1-0.20260330235452-e39b31850637 h1:55s2CCqISxvqOzEVTxcMSM7GB5HnxfVqJUP9j2GnQDs=
+github.com/zerfoo/ztensor v1.0.1-0.20260330235452-e39b31850637/go.mod h1:icFer0fMw2ugD744QLHSdXmiVCDwm6c4OS8LT7xvdXw=
 github.com/zerfoo/ztoken v0.3.4 h1:cxz/uy6THsz2fYW5LQ196dNDnEKu22RU1Zre9iw9oy8=
 github.com/zerfoo/ztoken v0.3.4/go.mod h1:qRWZODtPHOoI+Jfia6o7A0aMnM92O9jnaBHqd+atdh0=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=

--- a/timeseries/patchtst_gpu_train.go
+++ b/timeseries/patchtst_gpu_train.go
@@ -518,17 +518,10 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 	// Batch 0 = warmup (normal execution, allocates output buffers on GPU).
 	// Batch 1 = capture (BeginCapture, run ops, EndCapture).
 	// Batch 2+ = replay (ReplayGraph reuses same GPU memory addresses).
-	// NOTE: Graph capture is disabled until ztensor's GPU memory pool is
-	// capture-aware. Engine ops allocate output tensors internally via
-	// cudaMalloc/arena, which conflicts with stream capture (error 901:
-	// "operation would make the legacy stream depend on a capturing
-	// blocking stream"). Enabling this requires either (a) pre-allocating
-	// ALL intermediate tensors and passing dst to every engine op, or
-	// (b) making ztensor's pool allocate on the capture stream.
-	// See ADR-077 and issue #278 for context.
+	// ztensor's GPU memory pool is now capture-aware (ztensor PR #48):
+	// during BeginCapture, the pool switches to cudaMallocAsync on the
+	// capture stream, so allocations are recorded as graph nodes.
 	gc, canCapture := m.engine.(compute.GraphCapturer)
-	_ = gc
-	canCapture = false // disabled: engine ops allocate during capture
 	var fwdGraph compute.GraphHandle
 	var fwdOut *fwdGraphOutputs
 	fwdCaptured := false


### PR DESCRIPTION
## Summary

Re-enables CUDA graph capture in PatchTST GPU training. The blocker (ztensor pool allocating on default stream during capture) is fixed by ztensor PR #48 which adds cudaMallocAsync and capture-aware pool mode.

**Changes:**
- Update ztensor to v1.0.1 with capture-aware GPU memory pool
- Remove the `canCapture = false` disable flag
- Graph capture now active: batch 0 warmup, batch 1 capture, batch 2+ replay

## Test plan

- [x] `go build ./timeseries/` clean
- [x] `go test -run TestPatchTST` passes (CPU engine, no GPU capture locally)
- [ ] DGX Spark benchmark: 28K x 20ch x 10 epochs (target <60s)