### PR TITLE
perf(timeseries): full encoder CUDA graph capture (~1000 ops)

### DIFF
--- a/timeseries/patchtst_encoder.go
+++ b/timeseries/patchtst_encoder.go
@@ -60,15 +60,7 @@ func layerNormForwardWithEngine(ctx context.Context, engine compute.Engine[float
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	onesData := make([]float32, rows)
-	for i := range onesData {
-		onesData[i] = 1.0
-	}
-	ones, err := tensor.New[float32]([]int{rows, 1}, onesData)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	invStd, err = engine.Div(ctx, ones, stddev)
+	invStd, err = engine.UnaryOp(ctx, stddev, func(v float32) float32 { return 1.0 / v })
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -112,10 +104,8 @@ func encoderForward(
 		layer := &layers[li]
 		lc := &layerCaches[li]
 
-		// Save layer input for residual backward.
-		xCopy := make([]float32, len(x.Data()))
-		copy(xCopy, x.Data())
-		lc.xResidual, err = tensor.New[float32]([]int{totalRows, dModel}, xCopy)
+		// Save layer input for residual backward (GPU copy, no .Data()).
+		lc.xResidual, err = engine.MulScalar(ctx, x, 1.0)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -258,10 +248,8 @@ func encoderForward(
 			return nil, nil, err
 		}
 
-		// Save x after attention for residual backward.
-		xAfterCopy := make([]float32, len(x.Data()))
-		copy(xAfterCopy, x.Data())
-		lc.xAfterAttn, err = tensor.New[float32]([]int{totalRows, dModel}, xAfterCopy)
+		// Save x after attention for residual backward (GPU copy, no .Data()).
+		lc.xAfterAttn, err = engine.MulScalar(ctx, x, 1.0)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -343,6 +331,121 @@ func encoderForward(
 	return x, layerCaches, nil
 }
 
+// layerNormBackwardWithEngine computes the layer norm backward pass using engine ops.
+// dOut: [rows, dModel] upstream gradient through the normed output.
+// centered: [rows, dModel] (x - mean) from forward.
+// invStd: [rows, 1] = 1/sqrt(var+eps) from forward.
+// scale: [1, dModel] layer norm scale parameter.
+// dScale: [1, dModel] accumulated scale gradient (accumulated in-place).
+// dBias: [1, dModel] accumulated bias gradient (accumulated in-place).
+// Returns: dInput [rows, dModel].
+func layerNormBackwardWithEngine(
+	ctx context.Context,
+	engine compute.Engine[float32],
+	dOut, centered, invStd, scale, dScale, dBias *tensor.TensorNumeric[float32],
+	rows, dModel int,
+) (dInput *tensor.TensorNumeric[float32], err error) {
+	invD := float32(1.0) / float32(dModel)
+
+	// normVal = centered * invStd  -> [rows, dModel]
+	normVal, err := engine.Mul(ctx, centered, invStd)
+	if err != nil {
+		return nil, err
+	}
+
+	// dScale += Sum(dOut * normVal, axis=0, keepDims=false) reshaped to [1, dModel]
+	dOutNorm, err := engine.Mul(ctx, dOut, normVal)
+	if err != nil {
+		return nil, err
+	}
+	dScaleInc, err := engine.Sum(ctx, dOutNorm, 0, false)
+	if err != nil {
+		return nil, err
+	}
+	dScaleInc, err = engine.Reshape(ctx, dScaleInc, []int{1, dModel})
+	if err != nil {
+		return nil, err
+	}
+	_, err = engine.Add(ctx, dScale, dScaleInc, dScale)
+	if err != nil {
+		return nil, err
+	}
+
+	// dBias += Sum(dOut, axis=0, keepDims=false) reshaped to [1, dModel]
+	dBiasInc, err := engine.Sum(ctx, dOut, 0, false)
+	if err != nil {
+		return nil, err
+	}
+	dBiasInc, err = engine.Reshape(ctx, dBiasInc, []int{1, dModel})
+	if err != nil {
+		return nil, err
+	}
+	_, err = engine.Add(ctx, dBias, dBiasInc, dBias)
+	if err != nil {
+		return nil, err
+	}
+
+	// dNorm = dOut * scale  (broadcast [1, dModel] over [rows, dModel])
+	dNorm, err := engine.Mul(ctx, dOut, scale)
+	if err != nil {
+		return nil, err
+	}
+
+	// dotScaleGrad = Sum(dNorm * centered, axis=1, keepDims=true) -> [rows, 1]
+	dNormCent, err := engine.Mul(ctx, dNorm, centered)
+	if err != nil {
+		return nil, err
+	}
+	dotScaleGrad, err := engine.Sum(ctx, dNormCent, 1, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// dotMeanGrad = Sum(dNorm, axis=1, keepDims=true) -> [rows, 1]
+	dotMeanGrad, err := engine.Sum(ctx, dNorm, 1, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// correction = (dotMeanGrad + centered * invStd^2 * dotScaleGrad) / dModel
+	// invStd^2 = invStd * invStd -> [rows, 1]
+	invStdSq, err := engine.Mul(ctx, invStd, invStd)
+	if err != nil {
+		return nil, err
+	}
+	// centered * invStd^2 -> [rows, dModel] (broadcast [rows,1])
+	centInvSq, err := engine.Mul(ctx, centered, invStdSq)
+	if err != nil {
+		return nil, err
+	}
+	// centInvSq * dotScaleGrad -> [rows, dModel] (broadcast [rows,1])
+	scaleTerm, err := engine.Mul(ctx, centInvSq, dotScaleGrad)
+	if err != nil {
+		return nil, err
+	}
+	// dotMeanGrad + scaleTerm -> [rows, dModel] (broadcast [rows,1] + [rows, dModel])
+	correction, err := engine.Add(ctx, dotMeanGrad, scaleTerm)
+	if err != nil {
+		return nil, err
+	}
+	correction, err = engine.MulScalar(ctx, correction, invD)
+	if err != nil {
+		return nil, err
+	}
+
+	// dInput = (dNorm - correction) * invStd
+	dInput, err = engine.Sub(ctx, dNorm, correction)
+	if err != nil {
+		return nil, err
+	}
+	dInput, err = engine.Mul(ctx, dInput, invStd)
+	if err != nil {
+		return nil, err
+	}
+
+	return dInput, nil
+}
+
 // encoderBackward runs the PatchTST transformer encoder backward pass.
 // dX: [totalRows, dModel] upstream gradient.
 // Returns: gradient with respect to encoder input.
@@ -376,7 +479,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.ffn2W, err = engine.Add(ctx, dg.ffn2W, dFW)
+		_, err = engine.Add(ctx, dg.ffn2W, dFW, dg.ffn2W)
 		if err != nil {
 			return nil, err
 		}
@@ -388,7 +491,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.ffn2B, err = engine.Add(ctx, dg.ffn2B, dFBR)
+		_, err = engine.Add(ctx, dg.ffn2B, dFBR, dg.ffn2B)
 		if err != nil {
 			return nil, err
 		}
@@ -479,7 +582,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.ffn1W, err = engine.Add(ctx, dg.ffn1W, dF1W)
+		_, err = engine.Add(ctx, dg.ffn1W, dF1W, dg.ffn1W)
 		if err != nil {
 			return nil, err
 		}
@@ -491,7 +594,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.ffn1B, err = engine.Add(ctx, dg.ffn1B, dF1BR)
+		_, err = engine.Add(ctx, dg.ffn1B, dF1BR, dg.ffn1B)
 		if err != nil {
 			return nil, err
 		}
@@ -501,22 +604,13 @@ func encoderBackward(
 			return nil, err
 		}
 
-		// LayerNorm2 backward on CPU + residual add.
-		dNormed2Data := matFromTensor(dNormed2, totalRows, dModel)
-		centered2Mat := matFromTensor(lc.centered2, totalRows, dModel)
-		invStd2Flat := lc.invStd2.Data() // [rows*1] flat slice
-		dXAfterAttn := layerNormBackwardF32(dNormed2Data, centered2Mat, invStd2Flat,
-			layer.norm2.Data(), dg.norm2.Data(), dg.bias2.Data(), dModel)
-		// Add residual gradient from FFN path (dX flows through residual 2).
-		dXData := dX.Data()
-		for r := 0; r < totalRows; r++ {
-			for j := 0; j < dModel; j++ {
-				dXAfterAttn[r][j] += dXData[r*dModel+j]
-			}
+		// LayerNorm2 backward via engine ops + residual add.
+		dXAfterAttnT, err := layerNormBackwardWithEngine(ctx, engine, dNormed2, lc.centered2, lc.invStd2, layer.norm2, dg.norm2, dg.bias2, totalRows, dModel)
+		if err != nil {
+			return nil, err
 		}
-
-		// oProj backward: ONE MatMul each.
-		dAttnProjOut, err := tensorFromMat(dXAfterAttn, totalRows, dModel)
+		// Add residual gradient from FFN path (dX flows through residual 2).
+		dAttnProjOut, err := engine.Add(ctx, dXAfterAttnT, dX)
 		if err != nil {
 			return nil, err
 		}
@@ -529,7 +623,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.oW, err = engine.Add(ctx, dg.oW, dOW)
+		_, err = engine.Add(ctx, dg.oW, dOW, dg.oW)
 		if err != nil {
 			return nil, err
 		}
@@ -541,7 +635,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.oB, err = engine.Add(ctx, dg.oB, dOBR)
+		_, err = engine.Add(ctx, dg.oB, dOBR, dg.oB)
 		if err != nil {
 			return nil, err
 		}
@@ -717,7 +811,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.qW, err = engine.Add(ctx, dg.qW, dQW)
+		_, err = engine.Add(ctx, dg.qW, dQW, dg.qW)
 		if err != nil {
 			return nil, err
 		}
@@ -729,7 +823,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.qB, err = engine.Add(ctx, dg.qB, dQBR)
+		_, err = engine.Add(ctx, dg.qB, dQBR, dg.qB)
 		if err != nil {
 			return nil, err
 		}
@@ -738,7 +832,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.kW, err = engine.Add(ctx, dg.kW, dKW)
+		_, err = engine.Add(ctx, dg.kW, dKW, dg.kW)
 		if err != nil {
 			return nil, err
 		}
@@ -750,7 +844,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.kB, err = engine.Add(ctx, dg.kB, dKBR)
+		_, err = engine.Add(ctx, dg.kB, dKBR, dg.kB)
 		if err != nil {
 			return nil, err
 		}
@@ -759,7 +853,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.vW, err = engine.Add(ctx, dg.vW, dVW)
+		_, err = engine.Add(ctx, dg.vW, dVW, dg.vW)
 		if err != nil {
 			return nil, err
 		}
@@ -771,7 +865,7 @@ func encoderBackward(
 		if err != nil {
 			return nil, err
 		}
-		dg.vB, err = engine.Add(ctx, dg.vB, dVBR)
+		_, err = engine.Add(ctx, dg.vB, dVBR, dg.vB)
 		if err != nil {
 			return nil, err
 		}
@@ -798,20 +892,13 @@ func encoderBackward(
 			return nil, err
 		}
 
-		// LayerNorm1 backward on CPU + residual add.
-		dNormed1Data := matFromTensor(dNormed1, totalRows, dModel)
-		centered1Mat := matFromTensor(lc.centered1, totalRows, dModel)
-		invStd1Flat := lc.invStd1.Data() // [rows*1] flat slice
-		dLayerInput := layerNormBackwardF32(dNormed1Data, centered1Mat, invStd1Flat,
-			layer.norm1.Data(), dg.norm1.Data(), dg.bias1.Data(), dModel)
-		// Add residual gradient from attention path.
-		for r := 0; r < totalRows; r++ {
-			for j := 0; j < dModel; j++ {
-				dLayerInput[r][j] += dXAfterAttn[r][j]
-			}
+		// LayerNorm1 backward via engine ops + residual add.
+		dLayerInputT, err := layerNormBackwardWithEngine(ctx, engine, dNormed1, lc.centered1, lc.invStd1, layer.norm1, dg.norm1, dg.bias1, totalRows, dModel)
+		if err != nil {
+			return nil, err
 		}
-
-		dX, err = tensorFromMat(dLayerInput, totalRows, dModel)
+		// Add residual gradient from attention path.
+		dX, err = engine.Add(ctx, dLayerInputT, dAttnProjOut)
 		if err != nil {
 			return nil, err
 		}

--- a/timeseries/patchtst_gpu_train.go
+++ b/timeseries/patchtst_gpu_train.go
@@ -10,14 +10,17 @@ import (
 )
 
 // fwdGraphOutputs holds the output tensors produced during the CUDA graph
-// capture of the forward-prefix block (zero grads + weight transposes +
-// patch embedding + positional embedding). On replay these tensor objects
-// are reused because the graph writes to the same GPU memory addresses.
+// capture of the forward block (zero grads + weight transposes + patch embed +
+// pos embed + encoder forward + flatten + head forward). On replay these
+// tensor objects are reused because the graph writes to the same GPU memory.
 type fwdGraphOutputs struct {
-	headWT   *tensor.TensorNumeric[float32]
-	layerWTs []layerTransposes
-	x        *tensor.TensorNumeric[float32] // [totalRows, dModel] after pos embed
+	headWT      *tensor.TensorNumeric[float32]
+	layerWTs    []layerTransposes
+	headOut     *tensor.TensorNumeric[float32]     // [bsC, outDim] after head forward
+	flatInput   *tensor.TensorNumeric[float32]     // [bsC, headIn] reshaped encoder output
+	layerCaches []gpuBatchLayerCache               // per-layer forward caches for backward
 }
+
 
 // gpuParams holds all PatchTST parameters as float32 tensors for GPU training.
 type gpuParams struct {
@@ -334,82 +337,6 @@ type gpuBatchForwardCache struct {
 	layerCaches []gpuBatchLayerCache
 }
 
-// copyMatToTensor copies a [][]float32 matrix into an existing tensor's data buffer.
-func copyMatToTensor(mat [][]float32, dst *tensor.TensorNumeric[float32]) {
-	data := dst.Data()
-	cols := len(mat[0])
-	for i, row := range mat {
-		copy(data[i*cols:(i+1)*cols], row)
-	}
-}
-
-// layerNormF32WithCache performs layer norm on CPU and returns cached values.
-// x: [seq][dModel], scale/bias: [dModel].
-func layerNormF32WithCache(x [][]float32, scale, bias []float32, dModel int) ([][]float32, [][]float32, []float32) {
-	seq := len(x)
-	normed := make([][]float32, seq)
-	centered := make([][]float32, seq)
-	invStds := make([]float32, seq)
-
-	for s := 0; s < seq; s++ {
-		mean := float32(0)
-		for j := 0; j < dModel; j++ {
-			mean += x[s][j]
-		}
-		mean /= float32(dModel)
-
-		variance := float32(0)
-		centered[s] = make([]float32, dModel)
-		for j := 0; j < dModel; j++ {
-			centered[s][j] = x[s][j] - mean
-			variance += centered[s][j] * centered[s][j]
-		}
-		variance /= float32(dModel)
-		invStd := float32(1.0 / math.Sqrt(float64(variance)+1e-5))
-		invStds[s] = invStd
-
-		normed[s] = make([]float32, dModel)
-		for j := 0; j < dModel; j++ {
-			normed[s][j] = centered[s][j]*invStd*scale[j] + bias[j]
-		}
-	}
-	return normed, centered, invStds
-}
-
-// layerNormForwardEngine delegates to the standalone layerNormForwardWithEngine.
-func (m *PatchTST) layerNormForwardEngine(ctx context.Context, x, scale, bias *tensor.TensorNumeric[float32], rows, dModel int) (normed, centered, invStd *tensor.TensorNumeric[float32], err error) {
-	return layerNormForwardWithEngine(ctx, m.engine, x, scale, bias, rows, dModel)
-}
-
-// layerNormBackwardF32 computes backward pass through layer norm on CPU.
-// Accumulates into dScale, dBias.
-func layerNormBackwardF32(dOut, centered [][]float32, invStd []float32, scale, dScale, dBias []float32, dModel int) [][]float32 {
-	seq := len(dOut)
-	dInput := make([][]float32, seq)
-	d := float32(dModel)
-
-	for s := 0; s < seq; s++ {
-		dInput[s] = make([]float32, dModel)
-		// dScale += dOut * centered * invStd
-		// dBias += dOut
-		dotScaleGrad := float32(0)
-		dotMeanGrad := float32(0)
-		for j := 0; j < dModel; j++ {
-			normVal := centered[s][j] * invStd[s]
-			dScale[j] += dOut[s][j] * normVal
-			dBias[j] += dOut[s][j]
-			// dNorm = dOut * scale
-			dNorm := dOut[s][j] * scale[j]
-			dotScaleGrad += dNorm * centered[s][j]
-			dotMeanGrad += dNorm
-		}
-		for j := 0; j < dModel; j++ {
-			dNorm := dOut[s][j] * scale[j]
-			dInput[s][j] = invStd[s] * (dNorm - (dotMeanGrad+centered[s][j]*invStd[s]*invStd[s]*dotScaleGrad)/d)
-		}
-	}
-	return dInput
-}
 
 
 // trainWindowedGPU runs the full GPU training loop for PatchTST.
@@ -484,7 +411,6 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 
 	// Pre-allocate reusable slices for patch building, flatten, loss, and backward.
 	patchData := make([]float32, totalRows*m.config.PatchLength)
-	flatData := make([]float32, bsC*headIn)
 	predData := make([]float32, batchSize*outDim)
 	dPredData := make([]float32, batchSize*outDim)
 	dChanOutData := make([]float32, bsC*outDim)
@@ -493,10 +419,6 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 	fc.patches, err = tensor.New[float32]([]int{totalRows, m.config.PatchLength}, patchData)
 	if err != nil {
 		return nil, fmt.Errorf("gpu workspace patches: %w", err)
-	}
-	fc.flatInput, err = tensor.New[float32]([]int{bsC, headIn}, flatData)
-	if err != nil {
-		return nil, fmt.Errorf("gpu workspace flatInput: %w", err)
 	}
 	dChanOut, err := tensor.New[float32]([]int{bsC, outDim}, dChanOutData)
 	if err != nil {
@@ -509,11 +431,15 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 	// Drop partial final batch for consistent tensor shapes (required for CUDA graph capture).
 	fullBatches := nSamples - (nSamples % batchSize)
 
-	// CUDA graph capture state for the forward-prefix block.
-	// The forward prefix (zero grads + weight transposes + patch embed + pos embed)
-	// is a contiguous sequence of engine ops with no .Data() calls, making it safe
-	// to capture into a CUDA graph. On replay, all recorded kernels execute in a
-	// single GPU submission with zero intermediate synchronisation.
+	// CUDA graph capture state for the forward and backward blocks.
+	// Both blocks are contiguous sequences of engine ops with no .Data() calls,
+	// making them safe to capture into CUDA graphs. On replay, all recorded
+	// kernels execute in a single GPU submission with zero intermediate sync.
+	//
+	// Forward graph: zero grads + weight transposes + patch embed + pos embed +
+	//   encoderForward + flatten + head forward (~500 ops).
+	// Backward graph: head backward + encoderBackward + pos embed backward +
+	//   patch embed backward (~500 ops).
 	//
 	// Batch 0 = warmup (normal execution, allocates output buffers on GPU).
 	// Batch 1 = capture (BeginCapture, run ops, EndCapture).
@@ -522,9 +448,10 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 	// during BeginCapture, the pool switches to cudaMallocAsync on the
 	// capture stream, so allocations are recorded as graph nodes.
 	gc, canCapture := m.engine.(compute.GraphCapturer)
-	var fwdGraph compute.GraphHandle
+	var fwdGraph, bwdGraph compute.GraphHandle
 	var fwdOut *fwdGraphOutputs
 	fwdCaptured := false
+	bwdCaptured := false
 	batchIter := 0
 
 	for epoch := 0; epoch < config.Epochs; epoch++ {
@@ -551,9 +478,9 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 				}
 			}
 
-			// ----- Forward-prefix: zero grads + transposes + embed -----
+			// ----- Forward graph: zero grads + transposes + embed + encoder + head -----
 			// This block is captured into a CUDA graph on batchIter==1 and
-			// replayed for all subsequent batches.
+			// replayed for all subsequent batches. All engine ops are .Data()-free.
 			if fwdCaptured {
 				// Replay: re-executes all captured GPU kernels in one shot.
 				// Input tensors (params, gradTs, fc.patches) are at fixed addresses;
@@ -566,7 +493,7 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 				// batchIter==1: begin capture (batchIter==0 was the warmup).
 				if canCapture && batchIter == 1 {
 					if err := gc.BeginCapture(); err != nil {
-						return nil, fmt.Errorf("patchtst gpu: begin capture: %w", err)
+						return nil, fmt.Errorf("patchtst gpu: begin capture fwd: %w", err)
 					}
 				}
 
@@ -582,7 +509,6 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 				if err != nil {
 					return nil, err
 				}
-				// layerTransposes is defined at package level in patchtst_encoder.go.
 				layerWTs := make([]layerTransposes, m.config.NLayers)
 				for li := 0; li < m.config.NLayers; li++ {
 					layer := &params.layers[li]
@@ -614,20 +540,16 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 				}
 
 				// Patch embedding: [bsC*numPatches, patchLen] @ [patchLen, dModel] = [bsC*numPatches, dModel].
-				// ONE MatMul for all samples and channels.
 				embedded, err := m.engine.MatMul(ctx, fc.patches, params.patchEmbW)
 				if err != nil {
 					return nil, fmt.Errorf("gpu fwd patch emb: %w", err)
 				}
-				// Add bias: [bsC*numPatches, dModel] + [1, dModel] (broadcast).
 				embedded, err = m.engine.Add(ctx, embedded, params.patchEmbB)
 				if err != nil {
 					return nil, err
 				}
 
-				// Add positional embedding via broadcast:
-				// embedded [bsC*numPatches, dModel] -> [bsC, numPatches, dModel]
-				// posEmb [numPatches, dModel] -> [1, numPatches, dModel] (implicit broadcast)
+				// Add positional embedding via broadcast.
 				emb3d, err := m.engine.Reshape(ctx, embedded, []int{bsC, numPatches, dModel})
 				if err != nil {
 					return nil, err
@@ -645,58 +567,58 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 					return nil, err
 				}
 
-				// End capture on batchIter==1 and save output tensors.
+				// Encoder forward (one pass for all samples x channels).
+				x, layerCaches, err := encoderForward(ctx, m.engine, x, params.layers,
+					bsC, numPatches, totalRows, dModel, nHeads, headDim, ffnDim)
+				if err != nil {
+					return nil, fmt.Errorf("gpu encoder fwd: %w", err)
+				}
+
+				// Flatten for output head: [bsC*numPatches, dModel] -> [bsC, headIn].
+				flatInput, err := m.engine.Reshape(ctx, x, []int{bsC, headIn})
+				if err != nil {
+					return nil, fmt.Errorf("gpu fwd flatten: %w", err)
+				}
+
+				// Output head: ONE MatMul for all samples x channels.
+				headOut, err := m.engine.MatMul(ctx, flatInput, params.headW)
+				if err != nil {
+					return nil, err
+				}
+				headOut, err = m.engine.Add(ctx, headOut, params.headB)
+				if err != nil {
+					return nil, err
+				}
+
+				// End forward capture.
 				if canCapture && batchIter == 1 {
 					fwdGraph, err = gc.EndCapture()
 					if err != nil {
-						return nil, fmt.Errorf("patchtst gpu: end capture: %w", err)
+						return nil, fmt.Errorf("patchtst gpu: end capture fwd: %w", err)
 					}
 					fwdCaptured = true
 				}
 
-				// Save output tensors so they can be reused on replay.
-				// On replay, the CUDA graph writes to the same GPU memory addresses
-				// that these tensor objects reference.
+				// Save output tensors for replay (GPU memory addresses are stable).
 				fwdOut = &fwdGraphOutputs{
-					headWT:   headWT,
-					layerWTs: layerWTs,
-					x:        x,
+					headWT:      headWT,
+					layerWTs:    layerWTs,
+					headOut:     headOut,
+					flatInput:   flatInput,
+					layerCaches: layerCaches,
 				}
 			}
 
-			// Retrieve forward-prefix outputs for use by the rest of the loop.
-			// After replay these tensor objects still point to the correct GPU
-			// memory which was updated in-place by the graph.
+			// Retrieve forward outputs for use by loss computation and backward.
 			headWT := fwdOut.headWT
 			layerWTs := fwdOut.layerWTs
-			x := fwdOut.x
+			fc.flatInput = fwdOut.flatInput
+			fc.layerCaches = fwdOut.layerCaches
 			batchIter++
-
-			// Encoder forward (one pass for all samples x channels).
-			x, fc.layerCaches, err = encoderForward(ctx, m.engine, x, params.layers,
-				bsC, numPatches, totalRows, dModel, nHeads, headDim, ffnDim)
-			if err != nil {
-				return nil, fmt.Errorf("gpu encoder fwd: %w", err)
-			}
-
-			// Flatten for output head: [bsC*numPatches, dModel] -> [bsC, headIn].
-			// Overwrite pre-allocated flatData buffer (backing fc.flatInput).
-			copy(flatData, x.Data())
-
-			// Output head: ONE MatMul for all samples x channels.
-			// [bsC, headIn] @ [headIn, outDim] = [bsC, outDim]
-			headOut, err := m.engine.MatMul(ctx, fc.flatInput, params.headW)
-			if err != nil {
-				return nil, err
-			}
-			headOut, err = m.engine.Add(ctx, headOut, params.headB)
-			if err != nil {
-				return nil, err
-			}
 
 			// Average across channels: reshape [bsC, outDim] -> [bs, channels, outDim],
 			// sum axis=1 -> [bs, outDim], scale by 1/channels.
-			headOutData := headOut.Data()
+			headOutData := fwdOut.headOut.Data()
 			for i := range predData {
 				predData[i] = 0
 			}
@@ -736,88 +658,116 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 				}
 			}
 
-			// Head backward: ONE MatMul for dW, ONE for dX.
-			// dHeadW += flatInput^T @ dChanOut : [headIn, bsC] @ [bsC, outDim] = [headIn, outDim]
-			flatInputT, err := m.engine.Transpose(ctx, fc.flatInput, []int{1, 0})
-			if err != nil {
-				return nil, err
-			}
-			dHW, err := m.engine.MatMul(ctx, flatInputT, dChanOut)
-			if err != nil {
-				return nil, err
-			}
-			grads.headW, err = m.engine.Add(ctx, grads.headW, dHW)
-			if err != nil {
-				return nil, err
-			}
-			// dHeadB += sum(dChanOut, axis=0) : [1, outDim]
-			dHB, err := m.engine.Sum(ctx, dChanOut, 0, false)
-			if err != nil {
-				return nil, err
-			}
-			dHBR, err := m.engine.Reshape(ctx, dHB, []int{1, outDim})
-			if err != nil {
-				return nil, err
-			}
-			grads.headB, err = m.engine.Add(ctx, grads.headB, dHBR)
-			if err != nil {
-				return nil, err
-			}
-
-			// dFlat = dChanOut @ headW^T : [bsC, outDim] @ [outDim, headIn] = [bsC, headIn]
-			dFlat, err := m.engine.MatMul(ctx, dChanOut, headWT)
-			if err != nil {
-				return nil, err
-			}
-
-			// Reshape dFlat from [bsC, headIn] to [bsC*numPatches, dModel].
-			dX, err := m.engine.Reshape(ctx, dFlat, []int{totalRows, dModel})
-			if err != nil {
-				return nil, err
-			}
-
-			// Backward through encoder layers in reverse (single pass).
-			dX, err = encoderBackward(ctx, m.engine, dX, params.layers, grads.layers,
-				fc.layerCaches, layerWTs, bsC, numPatches, totalRows, dModel, nHeads, headDim, ffnDim)
-			if err != nil {
-				return nil, fmt.Errorf("gpu encoder bwd: %w", err)
-			}
-
-			// Positional embedding gradient: sum across all bsC samples.
-			dPosData := grads.posEmb.Data()
-			dXData := dX.Data()
-			for s := 0; s < bsC; s++ {
-				sOff := s * numPatches * dModel
-				for j := 0; j < numPatches*dModel; j++ {
-					dPosData[j] += dXData[sOff+j]
+			// ----- Backward graph: head + encoder + pos emb + patch emb backward -----
+			// Captured into a second CUDA graph on batchIter==2, replayed for 3+.
+			// (batchIter was already incremented after forward, so batchIter==2
+			// corresponds to the second batch's backward pass.)
+			if bwdCaptured {
+				if err := gc.ReplayGraph(bwdGraph); err != nil {
+					return nil, fmt.Errorf("patchtst gpu: replay bwd graph: %w", err)
 				}
-			}
+			} else {
+				if canCapture && batchIter == 2 {
+					if err := gc.BeginCapture(); err != nil {
+						return nil, fmt.Errorf("patchtst gpu: begin capture bwd: %w", err)
+					}
+				}
 
-			// Patch embedding backward: ONE MatMul each.
-			// dW += patches^T @ dX : [patchLen, totalRows] @ [totalRows, dModel]
-			patchesT, err := m.engine.Transpose(ctx, fc.patches, []int{1, 0})
-			if err != nil {
-				return nil, err
-			}
-			dPEW, err := m.engine.MatMul(ctx, patchesT, dX)
-			if err != nil {
-				return nil, err
-			}
-			grads.patchEmbW, err = m.engine.Add(ctx, grads.patchEmbW, dPEW)
-			if err != nil {
-				return nil, err
-			}
-			dPEB, err := m.engine.Sum(ctx, dX, 0, false)
-			if err != nil {
-				return nil, err
-			}
-			dPEBR, err := m.engine.Reshape(ctx, dPEB, []int{1, dModel})
-			if err != nil {
-				return nil, err
-			}
-			grads.patchEmbB, err = m.engine.Add(ctx, grads.patchEmbB, dPEBR)
-			if err != nil {
-				return nil, err
+				// Head backward: ONE MatMul for dW, ONE for dX.
+				flatInputT, err := m.engine.Transpose(ctx, fc.flatInput, []int{1, 0})
+				if err != nil {
+					return nil, err
+				}
+				dHW, err := m.engine.MatMul(ctx, flatInputT, dChanOut)
+				if err != nil {
+					return nil, err
+				}
+				_, err = m.engine.Add(ctx, grads.headW, dHW, grads.headW)
+				if err != nil {
+					return nil, err
+				}
+				dHB, err := m.engine.Sum(ctx, dChanOut, 0, false)
+				if err != nil {
+					return nil, err
+				}
+				dHBR, err := m.engine.Reshape(ctx, dHB, []int{1, outDim})
+				if err != nil {
+					return nil, err
+				}
+				_, err = m.engine.Add(ctx, grads.headB, dHBR, grads.headB)
+				if err != nil {
+					return nil, err
+				}
+
+				// dFlat = dChanOut @ headW^T
+				dFlat, err := m.engine.MatMul(ctx, dChanOut, headWT)
+				if err != nil {
+					return nil, err
+				}
+				dX, err := m.engine.Reshape(ctx, dFlat, []int{totalRows, dModel})
+				if err != nil {
+					return nil, err
+				}
+
+				// Backward through encoder layers in reverse.
+				dX, err = encoderBackward(ctx, m.engine, dX, params.layers, grads.layers,
+					fc.layerCaches, layerWTs, bsC, numPatches, totalRows, dModel, nHeads, headDim, ffnDim)
+				if err != nil {
+					return nil, fmt.Errorf("gpu encoder bwd: %w", err)
+				}
+
+				// Positional embedding gradient: sum dX across batch dimension.
+				dXForPos, err := m.engine.Reshape(ctx, dX, []int{bsC, numPatches * dModel})
+				if err != nil {
+					return nil, fmt.Errorf("gpu bwd pos reshape: %w", err)
+				}
+				dPosFlat, err := m.engine.Sum(ctx, dXForPos, 0, false)
+				if err != nil {
+					return nil, fmt.Errorf("gpu bwd pos sum: %w", err)
+				}
+				dPosReshaped, err := m.engine.Reshape(ctx, dPosFlat, []int{numPatches, dModel})
+				if err != nil {
+					return nil, fmt.Errorf("gpu bwd pos reshape2: %w", err)
+				}
+				_, err = m.engine.Add(ctx, grads.posEmb, dPosReshaped, grads.posEmb)
+				if err != nil {
+					return nil, fmt.Errorf("gpu bwd pos add: %w", err)
+				}
+
+				// Patch embedding backward.
+				patchesT, err := m.engine.Transpose(ctx, fc.patches, []int{1, 0})
+				if err != nil {
+					return nil, err
+				}
+				dPEW, err := m.engine.MatMul(ctx, patchesT, dX)
+				if err != nil {
+					return nil, err
+				}
+				_, err = m.engine.Add(ctx, grads.patchEmbW, dPEW, grads.patchEmbW)
+				if err != nil {
+					return nil, err
+				}
+				dPEB, err := m.engine.Sum(ctx, dX, 0, false)
+				if err != nil {
+					return nil, err
+				}
+				dPEBR, err := m.engine.Reshape(ctx, dPEB, []int{1, dModel})
+				if err != nil {
+					return nil, err
+				}
+				_, err = m.engine.Add(ctx, grads.patchEmbB, dPEBR, grads.patchEmbB)
+				if err != nil {
+					return nil, err
+				}
+
+				// End backward capture.
+				if canCapture && batchIter == 2 {
+					bwdGraph, err = gc.EndCapture()
+					if err != nil {
+						return nil, fmt.Errorf("patchtst gpu: end capture bwd: %w", err)
+					}
+					bwdCaptured = true
+				}
 			}
 
 			batchLoss /= float64(bs * outDim)
@@ -883,6 +833,9 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 	if fwdCaptured {
 		gc.DestroyGraph(fwdGraph)
 	}
+	if bwdCaptured {
+		gc.DestroyGraph(bwdGraph)
+	}
 
 	// Write optimized params back to model tensors.
 	m.writeBackF32FromGPU(params)
@@ -891,24 +844,6 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 	return result, nil
 }
 
-// matFromTensor extracts a [][]float32 from a 2D tensor.
-func matFromTensor(t *tensor.TensorNumeric[float32], rows, cols int) [][]float32 {
-	data := t.Data()
-	result := make([][]float32, rows)
-	for i := 0; i < rows; i++ {
-		result[i] = data[i*cols : (i+1)*cols]
-	}
-	return result
-}
-
-// tensorFromMat creates a 2D tensor from [][]float32.
-func tensorFromMat(m [][]float32, rows, cols int) (*tensor.TensorNumeric[float32], error) {
-	data := make([]float32, rows*cols)
-	for i := 0; i < rows; i++ {
-		copy(data[i*cols:(i+1)*cols], m[i])
-	}
-	return tensor.New[float32]([]int{rows, cols}, data)
-}
 
 // writeBackF32FromGPU writes GPU params back to model float32 tensors.
 func (m *PatchTST) writeBackF32FromGPU(p *gpuParams) {


### PR DESCRIPTION
## Summary

Eliminates all .Data() calls from encoderForward and encoderBackward, enabling
full CUDA graph capture of the entire forward+backward training pass.

**Changes:**
- Residual caching: engine.MulScalar(x, 1.0) GPU copy instead of .Data()+copy
- Layer norm backward: new engine-based layerNormBackwardWithEngine replacing CPU layerNormBackwardF32
- Head input flatten: engine.Reshape (zero-copy) instead of copy(flatData, x.Data())
- Pos embedding gradient: engine.Sum+Add instead of CPU loop with .Data()
- All gradient accumulations converted to in-place engine.Add(dst, inc, dst)
- Two-graph capture: forward graph (~500 ops) + backward graph (~500 ops)

**Dead code removed:** layerNormF32WithCache, layerNormBackwardF32, matFromTensor, tensorFromMat

## Test plan

- [x] `go build ./timeseries/` clean
- [x] `go test -run TestPatchTST` passes
- [ ] DGX Spark benchmark (expecting significant improvement over 32.1s/epoch)