### PR TITLE
perf(attention): fused softmax+V and repeat-interleave for Gemma3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ exclude google.golang.org/genproto v0.0.0-20220401170504-314d38edb7de
 exclude google.golang.org/genproto v0.0.0-20220324131243-acbaeb5b85eb
 
 require (
-	github.com/zerfoo/ztensor v1.0.1-0.20260331020144-efc8b42c4ba1
+	github.com/zerfoo/ztensor v1.0.1-0.20260331032609-d906cc031e6b
 	github.com/zerfoo/ztoken v0.3.4
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/zerfoo/ztensor v1.0.1-0.20260331005412-b36b7ed88455 h1:ZEwqVwIOILEIIL
 github.com/zerfoo/ztensor v1.0.1-0.20260331005412-b36b7ed88455/go.mod h1:icFer0fMw2ugD744QLHSdXmiVCDwm6c4OS8LT7xvdXw=
 github.com/zerfoo/ztensor v1.0.1-0.20260331020144-efc8b42c4ba1 h1:yvxcH8mELW4wL0qXpE7a97O2hFzBiITW2YoehfA/pTs=
 github.com/zerfoo/ztensor v1.0.1-0.20260331020144-efc8b42c4ba1/go.mod h1:icFer0fMw2ugD744QLHSdXmiVCDwm6c4OS8LT7xvdXw=
+github.com/zerfoo/ztensor v1.0.1-0.20260331032609-d906cc031e6b h1:l4DIrDz5lh5iutvxyNWZsxJKfwy0m2ZTKWjkYrvZmMI=
+github.com/zerfoo/ztensor v1.0.1-0.20260331032609-d906cc031e6b/go.mod h1:icFer0fMw2ugD744QLHSdXmiVCDwm6c4OS8LT7xvdXw=
 github.com/zerfoo/ztoken v0.3.4 h1:cxz/uy6THsz2fYW5LQ196dNDnEKu22RU1Zre9iw9oy8=
 github.com/zerfoo/ztoken v0.3.4/go.mod h1:qRWZODtPHOoI+Jfia6o7A0aMnM92O9jnaBHqd+atdh0=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=

--- a/layers/attention/grouped_query_attention.go
+++ b/layers/attention/grouped_query_attention.go
@@ -841,35 +841,60 @@ func (gqa *GroupedQueryAttention[T]) Forward(ctx context.Context, inputs ...*ten
 		// then merge the repeated dimension back into the head axis.
 		if gqa.numQueryHeads != gqa.numKeyValueHeads && gqa.numKeyValueHeads > 1 {
 			replicationFactor := gqa.numQueryHeads / gqa.numKeyValueHeads
-			kSeqLen := kHeadsRoPE.Shape()[2]
-			// [batch, numKV, seqLen, headDim] -> [batch, numKV, 1, seqLen, headDim]
-			kr, err := gqa.engine.Reshape(ctx, kHeadsRoPE, []int{batchSize, gqa.numKeyValueHeads, 1, kSeqLen, gqa.headDim})
-			if err != nil {
-				return nil, err
-			}
-			// Repeat on axis 2: [batch, numKV, reps, seqLen, headDim]
-			kr, err = gqa.engine.Repeat(ctx, kr, 2, replicationFactor)
-			if err != nil {
-				return nil, err
-			}
-			// Merge: [batch, numKV*reps, seqLen, headDim]
-			kHeadsRoPE, err = gqa.engine.Reshape(ctx, kr, []int{batchSize, gqa.numQueryHeads, kSeqLen, gqa.headDim})
-			if err != nil {
-				return nil, err
-			}
 
-			vSeqLen := vHeads.Shape()[2]
-			vr, err := gqa.engine.Reshape(ctx, vHeads, []int{batchSize, gqa.numKeyValueHeads, 1, vSeqLen, gqa.headDim})
-			if err != nil {
-				return nil, err
+			// Check for fused repeat-interleave (GPU optimization).
+			// RepeatInterleave expands [B, numKV, S, D] -> [B, numQ, S, D] in a
+			// single kernel launch, replacing the Reshape+Repeat+Reshape chain.
+			realEngine := compute.Engine[T](gqa.engine)
+			if proxy, ok := gqa.engine.(*compute.EngineProxy[T]); ok {
+				realEngine = proxy.Real()
 			}
-			vr, err = gqa.engine.Repeat(ctx, vr, 2, replicationFactor)
-			if err != nil {
-				return nil, err
+			type repeatInterleaver[U tensor.Numeric] interface {
+				RepeatInterleave(ctx context.Context, a *tensor.TensorNumeric[U], axis int, reps int, dst ...*tensor.TensorNumeric[U]) (*tensor.TensorNumeric[U], error)
 			}
-			vHeads, err = gqa.engine.Reshape(ctx, vr, []int{batchSize, gqa.numQueryHeads, vSeqLen, gqa.headDim})
-			if err != nil {
-				return nil, err
+			if ri, ok := realEngine.(repeatInterleaver[T]); ok {
+				kHeadsRoPE, err = ri.RepeatInterleave(ctx, kHeadsRoPE, 1, replicationFactor)
+				if err != nil {
+					return nil, err
+				}
+				vHeads, err = ri.RepeatInterleave(ctx, vHeads, 1, replicationFactor)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// Fallback: reshape + repeat + reshape.
+				// We insert a size-1 dimension per head, Repeat that (tiling 1
+				// element = correct), then merge back into the head axis.
+				kSeqLen := kHeadsRoPE.Shape()[2]
+				// [batch, numKV, seqLen, headDim] -> [batch, numKV, 1, seqLen, headDim]
+				kr, err := gqa.engine.Reshape(ctx, kHeadsRoPE, []int{batchSize, gqa.numKeyValueHeads, 1, kSeqLen, gqa.headDim})
+				if err != nil {
+					return nil, err
+				}
+				// Repeat on axis 2: [batch, numKV, reps, seqLen, headDim]
+				kr, err = gqa.engine.Repeat(ctx, kr, 2, replicationFactor)
+				if err != nil {
+					return nil, err
+				}
+				// Merge: [batch, numKV*reps, seqLen, headDim]
+				kHeadsRoPE, err = gqa.engine.Reshape(ctx, kr, []int{batchSize, gqa.numQueryHeads, kSeqLen, gqa.headDim})
+				if err != nil {
+					return nil, err
+				}
+
+				vSeqLen := vHeads.Shape()[2]
+				vr, err := gqa.engine.Reshape(ctx, vHeads, []int{batchSize, gqa.numKeyValueHeads, 1, vSeqLen, gqa.headDim})
+				if err != nil {
+					return nil, err
+				}
+				vr, err = gqa.engine.Repeat(ctx, vr, 2, replicationFactor)
+				if err != nil {
+					return nil, err
+				}
+				vHeads, err = gqa.engine.Reshape(ctx, vr, []int{batchSize, gqa.numQueryHeads, vSeqLen, gqa.headDim})
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 

--- a/layers/attention/scaled_dot_product_attention.go
+++ b/layers/attention/scaled_dot_product_attention.go
@@ -159,14 +159,28 @@ func (sdpa *ScaledDotProductAttention[T]) Forward(ctx context.Context, q, k, v, 
 	// If not, we can fuse MulScalar + Softmax into a single kernel launch.
 	needsMasking := mask != nil || (sdpa.causal && len(attentionScores.Shape()) >= 2 && attentionScores.Shape()[len(attentionScores.Shape())-2] > 1)
 
+	// Unwrap EngineProxy to detect the real engine type for fused paths.
+	realEngine := compute.Engine[T](sdpa.engine)
+	if proxy, ok := sdpa.engine.(*compute.EngineProxy[T]); ok {
+		realEngine = proxy.Real()
+	}
+
+	// Try fused softmax + V multiply for decode (seqQ == 1, no masking needed).
+	// This replaces both softmax and the subsequent MatMul with a single GPU
+	// kernel launch, eliminating the intermediate attention weights tensor.
+	querySeqLen := q.Shape()[1]
+	if !needsMasking && querySeqLen == 1 {
+		if fuser, ok := realEngine.(compute.FusedSoftmaxVMulProvider[T]); ok {
+			output, fusedErr := fuser.GPUFusedSoftmaxVMul(attentionScores, v, scale)
+			if fusedErr == nil {
+				return output, nil
+			}
+		}
+	}
+
 	var attentionWeights *tensor.TensorNumeric[T]
 	if !needsMasking {
 		// Try fused scaled softmax path: single kernel replaces MulScalar + Softmax.
-		// Unwrap EngineProxy to detect the real engine type.
-		realEngine := compute.Engine[T](sdpa.engine)
-		if proxy, ok := sdpa.engine.(*compute.EngineProxy[T]); ok {
-			realEngine = proxy.Real()
-		}
 		if provider, ok := realEngine.(compute.FusedScaledSoftmaxProvider[T]); ok {
 			out, fusedErr := provider.GPUScaledSoftmax(attentionScores, scale, -1)
 			if fusedErr == nil {


### PR DESCRIPTION
## Summary

Wires ztensor fused CUDA kernels into Gemma3 attention path:

- **Fused softmax+V multiply** (SDPA): For decode (seqQ=1), replaces separate Softmax + MatMul(weights, V) with single GPUFusedSoftmaxVMul kernel. Eliminates intermediate attention weights tensor.

- **Fused repeat-interleave** (GQA): Replaces Reshape+Repeat+Reshape (3 ops) with single RepeatInterleave kernel for K/V head expansion. Saves 6 kernel launches per layer.

Both fall back to separate ops on CPU engine.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./layers/attention/` passes
- [ ] DGX Spark: compile kernels + benchmark Gemma3-1B decode tok/s