### PR TITLE
refactor(modeldsl): compose DSL layers from layers/ primitives

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -51,8 +51,7 @@ Task statuses updated 2026-04-03 based on merged PRs and git history.
 - E81: Inference custom node replacement (5/7 -- bert+gpt2+falcon+commandr+vision done; validation pending)
 - E82: Training loss engine migration (4/6 -- bce + routing_contrastive + quantile + adamw8bit done)
 - E83: Serve handler refactoring (3/5 -- all 3 extractions done; validation pending)
-- E84: ModeLDSL composition (1/8 -- linearLayer replaced with layers/core.Linear)
-- E84: ModeLDSL composition (0/8 -- rewrite DSL layer implementations to compose from layers/)
+- E84: ModeLDSL composition (6/8 -- linearLayer, rmsnorm, silu, softmax, attention, Xavier init, LayerType constants replaced)
 - GPU status: Q5_0 GEMV alignment fix shipped (ztensor 5f19e54). Q4_0 re-quantization restored for 231 tok/s decode. Pool-backed GPUStorage prevents arena corruption.
 
 ---
@@ -455,16 +454,16 @@ Deps: Wave 13 partial (T79.1.2 for T79.1.4/T79.1.5; T80.1.1-T80.1.3 for T80.1.4-
 
 #### Composition Wave 17: Phase 4 continued (10 agents)
 
-- [ ] T84.1.2 Replace rmsnormLayerT with layers/normalization.RMSNorm (E84)
-- [ ] T84.1.3 Replace siluLayerT, softmaxLayerT with layers/activations (E84)
-- [ ] T84.1.4 Replace attentionLayer with layers/attention (E84)
-- [ ] T84.1.5 Replace Xavier init with layers/components.WeightInitializer (E84)
-- [ ] T84.1.6 Reconcile LayerType constants with layers/registry (E84)
-- [ ] T77.2.1 Run go test ./tabular/... with race (E77)  Deps: T77.1.7
-- [ ] T78.2.1 Run go test ./layers/... with race (E78)  Deps: T78.1.1-T78.1.9
-- [ ] T79.2.1 Run go test ./generate/... with race (E79)  Deps: T79.1.1-T79.1.5
-- [ ] T81.2.1 Run inference parity tests (E81)  Deps: T81.1.1-T81.1.5
-- [ ] T82.2.1 Run go test ./training/... with race (E82)  Deps: T82.1.1-T82.1.4
+- [x] T84.1.2 Replace rmsnormLayerT with layers/normalization.RMSNorm (E84)  2026-04-06
+- [x] T84.1.3 Replace siluLayerT, softmaxLayerT with layers/activations (E84)  2026-04-06
+- [x] T84.1.4 Replace attentionLayer with layers/attention (E84)  2026-04-06
+- [x] T84.1.5 Replace Xavier init with layers/components.WeightInitializer (E84)  2026-04-06
+- [x] T84.1.6 Reconcile LayerType constants with layers/registry (E84)  2026-04-06
+- [x] T77.2.1 Run go test ./tabular/... with race (E77)  Deps: T77.1.7  2026-04-06
+- [x] T78.2.1 Run go test ./layers/... with race (E78)  Deps: T78.1.1-T78.1.9  2026-04-06
+- [x] T79.2.1 Run go test ./generate/... with race (E79)  Deps: T79.1.1-T79.1.5  2026-04-06
+- [x] T81.2.1 Run inference parity tests (E81)  Deps: T81.1.1-T81.1.5  2026-04-06 (pre-existing TSPulse test failure, core inference PASS)
+- [x] T82.2.1 Run go test ./training/... with race (E82)  Deps: T82.1.1-T82.1.4  2026-04-06
 
 #### Composition Wave 18: Phase 4 validation (10 agents)
 
@@ -2282,24 +2281,24 @@ Reconcile LayerType constants with layers/registry.
   Replace the local linearLayer implementation with layers/core.Linear.
   Acceptance: go test -run TestModelDSL passes. Linear layer output matches.
 
-- [ ] T84.1.2 Replace rmsnormLayerT with layers/normalization.RMSNorm  Owner: TBD  Est: 1h  verifies: [infrastructure]
+- [x] T84.1.2 Replace rmsnormLayerT with layers/normalization.RMSNorm  Owner: TBD  Est: 1h  verifies: [infrastructure]
   Replace local RMSNorm with layers/normalization.RMSNorm.
   Acceptance: go test passes. Norm output matches within 1e-6.
 
-- [ ] T84.1.3 Replace siluLayerT, softmaxLayerT with layers/activations  Owner: TBD  Est: 1h  verifies: [infrastructure]
+- [x] T84.1.3 Replace siluLayerT, softmaxLayerT with layers/activations  Owner: TBD  Est: 1h  verifies: [infrastructure]
   Replace local SiLU and Softmax with layers/activations.SiLU and
   layers/activations.Softmax.
   Acceptance: go test passes.
 
-- [ ] T84.1.4 Replace attentionLayer with layers/attention  Owner: TBD  Est: 2h  verifies: [infrastructure]
+- [x] T84.1.4 Replace attentionLayer with layers/attention  Owner: TBD  Est: 2h  verifies: [infrastructure]
   Replace local attention implementation with layers/attention composition.
   Acceptance: go test passes. Attention output matches within 1e-5.
 
-- [ ] T84.1.5 Replace Xavier init with layers/components.WeightInitializer  Owner: TBD  Est: 0.5h  verifies: [infrastructure]
+- [x] T84.1.5 Replace Xavier init with layers/components.WeightInitializer  Owner: TBD  Est: 0.5h  verifies: [infrastructure]
   Replace local Xavier initialization with the canonical initializer.
   Acceptance: go test passes. Weight distribution statistically equivalent.
 
-- [ ] T84.1.6 Reconcile LayerType constants with layers/registry  Owner: TBD  Est: 1h  verifies: [infrastructure]
+- [x] T84.1.6 Reconcile LayerType constants with layers/registry  Owner: TBD  Est: 1h  verifies: [infrastructure]
   Align modeldsl LayerType constants with layers/registry types. Remove
   duplicates. Use layers/registry as the single source of truth.
   Acceptance: go build clean. No duplicate type constants.
@@ -2318,11 +2317,11 @@ Reconcile LayerType constants with layers/registry.
 
 #### Wave E84-1: Independent layer replacements (6 agents)
 - [x] T84.1.1 linearLayer
-- [ ] T84.1.2 rmsnormLayerT
-- [ ] T84.1.3 siluLayerT/softmaxLayerT
-- [ ] T84.1.4 attentionLayer
-- [ ] T84.1.5 Xavier init
-- [ ] T84.1.6 LayerType constants
+- [x] T84.1.2 rmsnormLayerT
+- [x] T84.1.3 siluLayerT/softmaxLayerT
+- [x] T84.1.4 attentionLayer
+- [x] T84.1.5 Xavier init
+- [x] T84.1.6 LayerType constants
 
 #### Wave E84-2: Validation (2 agents)
 Deps: Wave E84-1

--- a/modeldsl/dsl.go
+++ b/modeldsl/dsl.go
@@ -11,12 +11,15 @@ import (
 // LayerType identifies the kind of neural network layer.
 type LayerType string
 
+// LayerType constants use PascalCase to match the registration keys
+// in layers/registry.RegisterAll. The registry is the canonical source
+// of layer names; these constants mirror it for DSL use.
 const (
-	LayerLinear    LayerType = "linear"
-	LayerRMSNorm  LayerType = "rmsnorm"
-	LayerSiLU     LayerType = "silu"
-	LayerSoftmax  LayerType = "softmax"
-	LayerAttention LayerType = "attention"
+	LayerLinear    LayerType = "Linear"
+	LayerRMSNorm   LayerType = "RMSNorm"
+	LayerSiLU      LayerType = "SiLU"
+	LayerSoftmax   LayerType = "Softmax"
+	LayerAttention LayerType = "Attention"
 )
 
 // LayerDef defines a single layer in the model.

--- a/modeldsl/model.go
+++ b/modeldsl/model.go
@@ -3,14 +3,16 @@ package modeldsl
 import (
 	"context"
 	"fmt"
-	"math"
-	"math/rand/v2"
 
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
 
+	"github.com/zerfoo/zerfoo/layers/activations"
+	"github.com/zerfoo/zerfoo/layers/attention"
+	"github.com/zerfoo/zerfoo/layers/components"
 	"github.com/zerfoo/zerfoo/layers/core"
+	"github.com/zerfoo/zerfoo/layers/normalization"
 )
 
 // execLayer is a compiled layer that can run forward inference on float64 vectors.
@@ -70,11 +72,11 @@ func buildLayer(def LayerDef, inDim, outDim int) (execLayer, error) {
 			}
 			eps = f
 		}
-		return &rmsnormLayerT{epsilon: eps}, nil
+		return newRMSNormLayer(inDim, eps)
 	case LayerSiLU:
-		return &siluLayerT{}, nil
+		return newSiLULayer(), nil
 	case LayerSoftmax:
-		return &softmaxLayerT{}, nil
+		return newSoftmaxLayer(), nil
 	case LayerAttention:
 		numHeads := 1
 		if v, ok := def.Params["num_heads"]; ok {
@@ -127,11 +129,11 @@ type linearLayer struct {
 }
 
 func newLinearLayer(inDim, outDim int) *linearLayer {
-	// Xavier initialization.
-	scale := math.Sqrt(2.0 / float64(inDim+outDim))
-	weights := make([]float64, inDim*outDim)
-	for i := range weights {
-		weights[i] = rand.NormFloat64() * scale
+	// Xavier initialization via layers/components.XavierInitializer.
+	xavier := components.NewXavierInitializer[float64](numeric.Float64Ops{})
+	weights, err := xavier.Initialize(inDim, outDim)
+	if err != nil {
+		panic(fmt.Sprintf("modeldsl: newLinearLayer xavier init: %v", err))
 	}
 	bias := make([]float64, outDim)
 
@@ -175,21 +177,85 @@ func (l *linearLayer) forward(input []float64) ([]float64, error) {
 	return sumT.Data(), nil
 }
 
-// NOTE: Element-wise layers (rmsnorm, silu, softmax) operate on raw []float64
-// slices rather than tensors. The layers/activations/ package provides
-// tensor-based equivalents via compute.Engine[T], but the DSL intentionally
-// uses slice-based ops for those because its entire pipeline (forward, backward,
-// parameter updates) operates on []float64. The linear layer delegates to
-// layers/core.Linear for the matrix multiplication.
-//
-// The trainable variants (rmsnormLayerT, siluLayerT, softmaxLayerT) in
-// train.go serve as the single implementations for both inference and
-// training, since they implement the execLayer interface and only cache
-// state needed for backward when forward is called.
+// rmsnormLayer wraps layers/normalization.RMSNorm for inference.
+type rmsnormLayer struct {
+	norm *normalization.RMSNorm[float64]
+	dim  int
+}
 
-// attentionLayer implements a basic single-sequence self-attention.
-// It projects the input into Q, K, V, computes scaled dot-product attention
-// per head, concatenates, and applies an output projection.
+func newRMSNormLayer(dim int, epsilon float64) (*rmsnormLayer, error) {
+	ops := numeric.Float64Ops{}
+	norm, err := normalization.NewRMSNorm[float64](
+		"dsl_rmsnorm", dslEngine, ops, dim,
+		normalization.WithRMSNormEpsilon[float64](epsilon),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("modeldsl: newRMSNormLayer: %w", err)
+	}
+	return &rmsnormLayer{norm: norm, dim: dim}, nil
+}
+
+func (l *rmsnormLayer) forward(input []float64) ([]float64, error) {
+	t, err := tensor.New[float64]([]int{1, l.dim}, input)
+	if err != nil {
+		return nil, err
+	}
+	out, err := l.norm.Forward(context.Background(), t)
+	if err != nil {
+		return nil, err
+	}
+	return out.Data(), nil
+}
+
+// siluLayer wraps layers/activations.Sigmoid to compute SiLU: x * sigmoid(x).
+type siluLayer struct {
+	sigmoid *activations.Sigmoid[float64]
+}
+
+func newSiLULayer() *siluLayer {
+	return &siluLayer{sigmoid: activations.NewSigmoid[float64](dslEngine, numeric.Float64Ops{})}
+}
+
+func (l *siluLayer) forward(input []float64) ([]float64, error) {
+	t, err := tensor.New[float64]([]int{len(input)}, input)
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+	sig, err := l.sigmoid.Forward(ctx, t)
+	if err != nil {
+		return nil, err
+	}
+	out, err := dslEngine.Mul(ctx, t, sig)
+	if err != nil {
+		return nil, err
+	}
+	return out.Data(), nil
+}
+
+// softmaxLayer wraps layers/activations.Softmax for inference.
+type softmaxLayer struct {
+	sm *activations.Softmax[float64]
+}
+
+func newSoftmaxLayer() *softmaxLayer {
+	return &softmaxLayer{sm: activations.NewSoftmax[float64](dslEngine, -1)}
+}
+
+func (l *softmaxLayer) forward(input []float64) ([]float64, error) {
+	t, err := tensor.New[float64]([]int{1, len(input)}, input)
+	if err != nil {
+		return nil, err
+	}
+	out, err := l.sm.Forward(context.Background(), t)
+	if err != nil {
+		return nil, err
+	}
+	return out.Data(), nil
+}
+
+// attentionLayer implements self-attention using core.Linear projections and
+// layers/attention.ScaledDotProductAttention for the score computation.
 type attentionLayer struct {
 	numHeads int
 	headDim  int
@@ -198,6 +264,7 @@ type attentionLayer struct {
 	wk       *linearLayer
 	wv       *linearLayer
 	wo       *linearLayer
+	sdpa     *attention.ScaledDotProductAttention[float64]
 }
 
 func newAttentionLayer(dim, numHeads int) *attentionLayer {
@@ -210,6 +277,7 @@ func newAttentionLayer(dim, numHeads int) *attentionLayer {
 		wk:       newLinearLayer(dim, dim),
 		wv:       newLinearLayer(dim, dim),
 		wo:       newLinearLayer(dim, dim),
+		sdpa:     attention.NewScaledDotProductAttention[float64](dslEngine, headDim),
 	}
 }
 
@@ -227,28 +295,33 @@ func (a *attentionLayer) forward(input []float64) ([]float64, error) {
 		return nil, err
 	}
 
-	// Per-head attention: for a single token, attention(q, k, v) over 1 position
-	// simplifies to just the value vector (softmax of a single score is 1.0).
-	// We still do the full computation for correctness.
-	scale := 1.0 / math.Sqrt(float64(a.headDim))
-	result := make([]float64, a.dim)
-	for h := 0; h < a.numHeads; h++ {
-		offset := h * a.headDim
+	ctx := context.Background()
 
-		// Dot product of q and k for this head.
-		var score float64
-		for d := 0; d < a.headDim; d++ {
-			score += q[offset+d] * k[offset+d]
-		}
-		score *= scale
-
-		// With a single position, softmax(score) = 1.0.
-		// Output is simply v scaled by 1.0.
-		for d := 0; d < a.headDim; d++ {
-			result[offset+d] = v[offset+d]
-		}
-		_ = score // Used in multi-position scenarios.
+	// Reshape Q, K, V from [dim] to [numHeads, 1, headDim] for SDPA.
+	qT, err := tensor.New[float64]([]int{a.numHeads, 1, a.headDim}, q)
+	if err != nil {
+		return nil, err
+	}
+	kT, err := tensor.New[float64]([]int{a.numHeads, 1, a.headDim}, k)
+	if err != nil {
+		return nil, err
+	}
+	vT, err := tensor.New[float64]([]int{a.numHeads, 1, a.headDim}, v)
+	if err != nil {
+		return nil, err
 	}
 
-	return a.wo.forward(result)
+	// ScaledDotProductAttention: for seq_len=1, output = V.
+	outT, err := a.sdpa.Forward(ctx, qT, kT, vT, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reshape back to [dim].
+	flat, err := outT.Reshape([]int{a.dim})
+	if err != nil {
+		return nil, err
+	}
+
+	return a.wo.forward(flat.Data())
 }


### PR DESCRIPTION
## Summary

- Replace local RMSNorm, SiLU, Softmax, Attention, and Xavier init implementations in modeldsl/ with compositions from the layers/ package
- Align LayerType constants to PascalCase registry convention
- Validate tabular, layers, generate, inference, and training test suites with race detector

## Wave 17 Tasks Completed (10/10)

**E84 Implementation (5 tasks):**
- T84.1.2: RMSNorm inference → layers/normalization.RMSNorm
- T84.1.3: SiLU inference → layers/activations.Sigmoid + engine.Mul; Softmax → layers/activations.Softmax
- T84.1.4: Attention score → layers/attention.ScaledDotProductAttention
- T84.1.5: Xavier init → layers/components.XavierInitializer
- T84.1.6: LayerType constants aligned to PascalCase registry convention

**Validation (5 tasks):**
- T77.2.1: tabular PASS (race)
- T78.2.1: layers PASS (19 sub-packages, race)
- T79.2.1: generate PASS (race)
- T81.2.1: inference PASS (core), pre-existing TSPulse classify failure
- T82.2.1: training PASS (9 sub-packages, race)

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./modeldsl/...` clean
- [x] `go test ./modeldsl/... -race` PASS
- [x] `go test ./tabular/... -race` PASS
- [x] `go test ./layers/... -race` PASS
- [x] `go test ./generate/... -race` PASS
- [x] `go test ./inference/... -race` PASS (core; pre-existing TSPulse failure)
- [x] `go test ./training/... -race` PASS