### PR TITLE
fix(timeseries): PatchTST GPU convergence — use Reshape return value

### DIFF
--- a/.claude/scratch/wave-7-localization.md
+++ b/.claude/scratch/wave-7-localization.md
@@ -1,0 +1,54 @@
+# Wave 7 — Localization
+
+## Smoking gun (from `.claude/scratch/wave-7-probe-logs.txt`)
+
+```
+post-dFlat-matmul         ptr=0x69325628c000 l2=0.0833596 allZero=false
+post-dFlat-reshape-dX     ptr=0x69324f244000 l2=0         allZero=true
+pre-encoderBackward:dX    ptr=0x69324f244000 l2=0         allZero=true
+encBwd:entry:dX           ptr=0x69324f244000 l2=0         allZero=true
+encBwd:layer-1:dX-out     l2=0 allZero=true  (every downstream op is zero)
+```
+
+MatMul wrote real gradient data into `fc.dFlat` (l2=0.0836, non-zero). The
+very next call, `engine.Reshape(ctx, fc.dFlat, [1600,64], fc.dX)`, produced an
+all-zero `fc.dX` whose storage pointer does NOT match `fc.dFlat`'s new ptr.
+That zero dX cascades through every encoder-layer backward, every patch-emb
+grad op, and every pos-emb grad — exactly matching the frozen-loss symptom.
+
+## Root cause
+
+`ztensor/compute/gpu_engine_memory.go:614` `GPUEngine.Reshape`:
+
+```go
+// GPUStorage[T]: zero-copy reshape.
+if gs, ok := a.GetStorage().(*tensor.GPUStorage[T]); ok && isFloat32[T]() && newSize == currentSize {
+    return tensor.NewWithStorage[T](inferredShape, gs.View(gs.Len()))
+}
+```
+
+This branch **ignores the `dst ...*tensor.TensorNumeric[T]` parameter entirely**.
+It returns a brand-new tensor aliasing `a`'s storage and never touches `dst`.
+Any caller that discards the return value and relies on `dst` being the
+reshaped view gets stale pre-allocated zero storage.
+
+zerfoo hit this at `timeseries/patchtst_gpu_train.go:999`:
+
+```go
+if _, err = m.engine.Reshape(ctx, fc.dFlat, []int{totalRows, dModel}, fc.dX); err != nil {
+    return nil, err
+}
+// ...
+dX, err := encoderBackward(ctx, m.engine, fc.dX, ...)  // fc.dX is stale zeros
+```
+
+## Fix (routed to E2d-ish — zerfoo call-site fix, minimal/surgical)
+
+Capture the return value of Reshape and pass it into encoderBackward instead
+of `fc.dX`. One-line change. `fc.dX` is retained as a pre-allocation slot for
+its buffer identity but the returned reshaped view is the authoritative tensor.
+
+Follow-up (separate issue/PR): fix ztensor `GPUEngine.Reshape` to honor `dst`
+when provided (either copy data into dst's storage or SetStorage dst to alias
+the view). Current behavior silently violates the compute.Engine contract
+shared with the CPU engine.

--- a/.claude/scratch/wave-7-probe-logs.txt
+++ b/.claude/scratch/wave-7-probe-logs.txt
@@ -1,0 +1,24 @@
+e0b87e426cf7 2026/04/09 19:30:50 engine: GPU (CUDA)
+e0b87e426cf7 2026/04/09 19:30:50 config: 500 samples x 5 channels x 24 input_len x 1 epochs (batch=64, lr=1.0e-03)
+e0b87e426cf7 2026/04/09 19:30:50 model: dModel=64 nHeads=4 nLayers=2 patchLen=8 stride=4
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] pre-dFlat-zero shape=[320 320] len=102400 ptr=0x69324f1e0000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-dFlat-zero shape=[320 320] len=102400 ptr=0x69324f1e0000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-dFlat-matmul shape=[320 320] len=102400 ptr=0x69325628c000 head=[-2.3931732e-05 3.8702197e-05 0.00028016558 -7.5736316e-05] l2=0.0833596 allZero=false
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-dFlat-reshape-dX shape=[1600 64] len=102400 ptr=0x69324f244000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] pre-encoderBackward:dX shape=[1600 64] len=102400 ptr=0x69324f244000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] encBwd:entry:dX shape=[1600 64] len=102400 ptr=0x69324f244000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] encBwd:layer-1:dX-out shape=[1600 64] len=102400 ptr=0x693256400000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] encBwd:layer-0:dX-out shape=[1600 64] len=102400 ptr=0x693256464000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-encoderBackward:dX shape=[1600 64] len=102400 ptr=0x6932564c8000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] pre-posEmb-cpu-loop:grads.posEmb shape=[5 64] len=320 ptr=0x69324ec51400 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] pre-posEmb-cpu-loop:dX shape=[1600 64] len=102400 ptr=0x69325652c000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-posEmb-cpu-loop:grads.posEmb shape=[5 64] len=320 ptr=0x69324ec51400 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-Transpose:patchesT shape=[8 1600] len=12800 ptr=0x69324ebd8000 head=[-0.42462668 0.22997873 0.36986378 0.60369486] l2=105.945 allZero=false
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-Zero:dPEW shape=[8 64] len=512 ptr=0x69324ef74800 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-MatMul:dPEW shape=[8 64] len=512 ptr=0x69324ef75000 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-Add:patchEmbW shape=[8 64] len=512 ptr=0x69324ef75800 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-Sum:dPEB shape=[64] len=64 ptr=0x69324ed0e500 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-Reshape:dPEBR shape=[1 64] len=64 ptr=0x69324ec90200 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 2026/04/09 19:30:50 [gpuProbe] post-Add:patchEmbB shape=[1 64] len=64 ptr=0x69324ed0e600 head=[0 0 0 0] l2=0 allZero=true
+e0b87e426cf7 epoch  1: loss=0.285881 ok
+e0b87e426cf7 2026/04/09 19:30:50 total: 326.754603ms (326.754603ms/epoch)

--- a/.claude/scratch/wave-7-validation.md
+++ b/.claude/scratch/wave-7-validation.md
@@ -1,0 +1,21 @@
+# Wave 7 — Validation
+
+**Commit**: 73d14342 (fix/wave-7-gpu-reshape-dst)
+**DGX pod**: bench-patchtst-20260409-235603-s5000-c10-e3
+**Shapes**: samples=5000, channels=10, epochs=3 (default production bench)
+
+```
+engine: GPU (CUDA)
+config: 5000 samples x 10 channels x 24 input_len x 3 epochs (batch=64, lr=1.0e-03)
+model:  dModel=64 nHeads=4 nLayers=2 patchLen=8 stride=4
+total:  4.24267115s (1.414223716s/epoch)
+
+epoch 1: loss=0.027676 ok
+epoch 2: loss=0.019176 ok
+epoch 3: loss=0.018603 ok
+
+convergence: OK (0.027676 -> 0.018603, 32.8% reduction)
+```
+
+Loss strictly decreases across all 3 epochs. Frozen-loss symptom
+(0.268357 across all epochs) is gone. Definition of done met.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,61 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-04-09: RESOLVED — PatchTST GPU convergence regression (Wave 7 in-situ instrumentation)
+
+**Type:** investigation
+**Tags:** patchtst, gpu, training, convergence, ztensor, reshape
+
+**Problem:** PatchTST GPU training loss frozen at 0.268357 across all epochs
+on DGX GB10. Prior waves (ztensor#79) ruled out primitive-level bugs at both
+small and production shapes. Wave 7 instrumented `trainWindowedGPU` and
+`encoderBackward` with a first-batch `gpuProbe` helper logging device pointer,
+shape, head values, L2 norm, and allZero flag for every op in the backward
+chain, gated by `ZERFOO_DIAG_PROBE=1`.
+
+**Root cause:** `ztensor/compute/gpu_engine_memory.go:614` `GPUEngine.Reshape`
+takes a variadic `dst ...*tensor.TensorNumeric[T]` parameter (shared contract
+with the CPU engine) but its zero-copy GPUStorage fast-path at line 644
+**ignores `dst` entirely**:
+
+    if gs, ok := a.GetStorage().(*tensor.GPUStorage[T]); ok && isFloat32[T]() && newSize == currentSize {
+        return tensor.NewWithStorage[T](inferredShape, gs.View(gs.Len()))
+    }
+
+It returns a brand-new tensor aliasing the source storage and never touches
+`dst`. PatchTST's GPU backward discarded the return value and fed the stale
+pre-allocated `fc.dX` (all zeros) into `encoderBackward`:
+
+    if _, err = m.engine.Reshape(ctx, fc.dFlat, []int{totalRows, dModel}, fc.dX); err != nil { ... }
+    dX, err := encoderBackward(ctx, m.engine, fc.dX, ...)  // stale zeros
+
+Probe evidence from the first batch (samples=500 c=5 e=1 on DGX, full log at
+`.claude/scratch/wave-7-probe-logs.txt`):
+
+    post-dFlat-matmul       ptr=0x...628c000 l2=0.0833596 allZero=false
+    post-dFlat-reshape-dX   ptr=0x...f244000 l2=0         allZero=true
+    encBwd:entry:dX         ptr=0x...f244000 l2=0         allZero=true
+
+The zero dX propagated through every encoder layer's backward and every
+downstream grad op, producing identical zero gradients batch after batch.
+
+**Fix:** zerfoo commit 73d14342 on `fix/wave-7-gpu-reshape-dst`: capture the
+return value of `engine.Reshape` and pass it into `encoderBackward`. One-line
+behavioral change; `fc.dX` retained as a pre-alloc slot.
+
+**Impact:** DGX GPU bench (samples=5000 c=10 e=3) — loss goes from frozen
+at 0.268357 across all epochs to strictly decreasing:
+
+    epoch 1: loss=0.027676
+    epoch 2: loss=0.019176
+    epoch 3: loss=0.018603
+    convergence: OK (0.027676 -> 0.018603, 32.8% reduction)
+    total: 4.24s (1.41s/epoch)
+
+**Follow-up:** file a ztensor issue to make `GPUEngine.Reshape` honor `dst`
+per the compute.Engine contract, so the next caller that discards the return
+value doesn't re-hit this silent-zero trap.
+
 ## 2026-04-08: FINAL — PatchTST GPU convergence regression localized to ztensor GPU engine
 
 **Type:** investigation closeout

--- a/timeseries/patchtst_gpu_train.go
+++ b/timeseries/patchtst_gpu_train.go
@@ -996,13 +996,20 @@ func (m *PatchTST) trainWindowedGPU(windows [][][]float64, labels []float64, con
 			}
 
 			// Reshape dFlat from [bsC, headIn] to [totalRows, dModel].
-			if _, err = m.engine.Reshape(ctx, fc.dFlat, []int{totalRows, dModel}, fc.dX); err != nil {
+			// NOTE: ztensor GPUEngine.Reshape ignores the dst arg for the
+			// zero-copy GPUStorage fast-path — it returns a fresh tensor
+			// aliasing fc.dFlat's storage. Callers MUST use the return
+			// value; `fc.dX` here is kept only as a pre-alloc slot for its
+			// shape metadata but its backing storage is stale zeros. See
+			// docs/devlog.md 2026-04-09 Wave 7 root cause entry.
+			dXReshaped, err := m.engine.Reshape(ctx, fc.dFlat, []int{totalRows, dModel}, fc.dX)
+			if err != nil {
 				return nil, err
 			}
 
 			// Backward through encoder layers in reverse (single pass).
-			// encoderBackward may return a different tensor than fc.dX; use its return value.
-			dX, err := encoderBackward(ctx, m.engine, fc.dX, params.layers, grads.layers,
+			// encoderBackward may return a different tensor than its input; use its return value.
+			dX, err := encoderBackward(ctx, m.engine, dXReshaped, params.layers, grads.layers,
 				fc.layerCaches, fc.layerWTs, bsC, numPatches, totalRows, dModel, nHeads, headDim, ffnDim)
 			if err != nil {
 				return nil, fmt.Errorf("gpu encoder bwd: %w", err)


### PR DESCRIPTION
## Summary
- Restores PatchTST GPU training convergence on DGX GB10. Loss was frozen at 0.268357 across every epoch; after fix it strictly decreases (0.0277 → 0.0192 → 0.0186, 32.8% reduction over 3 epochs on 5000×10).
- Root cause: `ztensor/compute/gpu_engine_memory.go:614` `GPUEngine.Reshape` takes a variadic `dst` parameter but its zero-copy GPUStorage fast-path ignores it entirely — returns a fresh tensor aliasing source storage and never touches `dst`. `patchtst_gpu_train.go` was discarding the return value and feeding the stale pre-allocated `fc.dX` (all zeros) into `encoderBackward`, zeroing every downstream gradient.
- Fix: capture the Reshape return value (`dXReshaped`) and pass it into `encoderBackward`. One-line behavioral change.

## Evidence
Wave 7 `gpuProbe` instrumentation on `debug/wave-7-trainwindowed-probe` caught the first-batch smoking gun on DGX (full log in `.claude/scratch/wave-7-probe-logs.txt`):

```
post-dFlat-matmul      ptr=0x...628c000 l2=0.0833596 allZero=false
post-dFlat-reshape-dX  ptr=0x...f244000 l2=0         allZero=true
encBwd:entry:dX        ptr=0x...f244000 l2=0         allZero=true
```

MatMul wrote real gradient data; Reshape handed back an untouched pre-alloc slot with zeros; encoderBackward and every downstream op saw zeros → frozen loss.

## Validation on DGX (Spark, fix branch built on host)
```
engine: GPU (CUDA)
config: 5000 samples x 10 channels x 24 input_len x 3 epochs (batch=64, lr=1.0e-03)
epoch 1: loss=0.027676
epoch 2: loss=0.019176
epoch 3: loss=0.018603
convergence: OK (0.027676 -> 0.018603, 32.8% reduction)
total:   4.24s (1.41s/epoch)
```

## Follow-up
- File ztensor issue: `GPUEngine.Reshape` should honor `dst` per the `compute.Engine` contract so the next caller that discards the return value doesn't re-hit this silent-zero trap.
- Closes ztensor#79 (root cause sits at the ztensor/zerfoo boundary; this PR fixes the zerfoo side).

## Test plan
- [x] `go build ./...` clean on fix branch
- [x] `go vet ./timeseries/...` clean
- [x] DGX bench (5000×10×3) — loss strictly decreases, pod bench-patchtst-20260409-235603-s5000-c10-e3
- [ ] CI green

## Refs
- Plan: `docs/plans/gpu-convergence-wave-7-instrument.md`
- Devlog: `docs/devlog.md` 2026-04-09 RESOLVED entry
- Localization: `.claude/scratch/wave-7-localization.md`
- Validation: `.claude/scratch/wave-7-validation.md`