### PR TITLE
feat: Gemma 4 Wave E92-1 config, GELU FFN, K=V projection

### DIFF
--- a/docs/adr/085-gemma4-architecture-support.md
+++ b/docs/adr/085-gemma4-architecture-support.md
@@ -1,0 +1,77 @@
+# ADR 085: Gemma 4 Architecture Support
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-13
+
+## Context
+
+Gemma 4 is Google's latest open model family (Apache-2.0, released 2026-03-02).
+It introduces several new features over Gemma 3:
+
+1. **MoE variant** (26B-A4B): 128 experts, top-8 routing, 3.8B active params.
+2. **Hybrid attention**: Interleaved sliding-window + global attention with
+   different KV head counts and head dimensions per layer type.
+3. **Dual RoPE**: Standard RoPE (theta=10K) for sliding layers, proportional
+   RoPE (theta=1M, partial_rotary_factor=0.25) for global layers.
+4. **Unified K=V**: Global attention layers share K and V projections (31B, 26B).
+5. **Per-Layer Embeddings (PLE)**: Edge variants (E2B, E4B) use per-layer input
+   embeddings for parameter-efficient layer specialization.
+6. **KV-shared layers**: Edge variants share KV projections across groups of layers.
+7. **GELU activation** (gelu_pytorch_tanh) instead of Gemma 3's SwiGLU.
+8. **256K context** (31B/26B), 128K (E variants).
+9. **262K vocabulary** (up from 256K in Gemma 3).
+10. **Vision encoder** (SigLIP-style) on all variants; audio encoder on E variants.
+
+Four model variants: 31B (dense), 26B-A4B (MoE), E4B (edge+audio), E2B (edge+audio).
+
+GGUF conversions are widely available from Unsloth, LM Studio, and bartowski.
+
+## Decision
+
+Implement Gemma 4 support in three phases:
+
+**Phase 1 (text-only, dense):** Build `arch_gemma4.go` for the 31B dense variant.
+This covers: hybrid attention with per-layer KV head counts and head dims, dual
+RoPE configuration, K=V in global layers, GELU activation, 4 norms per layer,
+logit softcapping, and tied embeddings. Extend `transformerGraphOpts` with fields
+for per-layer attention configuration rather than single global values. Register
+as "gemma4" in the architecture registry.
+
+**Phase 2 (MoE):** Add MoE FFN routing for the 26B-A4B variant. Reuse the
+existing `core.MixtureOfExperts` and `core.MoEGate` (proven in DeepSeek, Mixtral,
+DBRX, Kimi, LFM2). The per-layer FFN becomes conditional: dense SwiGLU for layers
+that are not MoE, `MixtureOfExperts` for MoE layers. Register as "gemma4moe".
+
+**Phase 3 (edge):** Add PLE and KV-shared layer support for E4B/E2B. Register
+as "gemma4e". Vision and audio encoders are deferred (multimodal is out of scope
+for this epic).
+
+## Consequences
+
+**Positive:**
+- Gemma 4 is the most-downloaded open model family on HuggingFace; supporting it
+  keeps Zerfoo competitive with llama.cpp and Ollama.
+- The dual RoPE and hybrid attention patterns are reusable for future architectures
+  (Llama 4, Mistral variants).
+- MoE reuse validates the existing `MixtureOfExperts` layer at 128 experts (largest
+  expert count in any supported model).
+
+**Negative:**
+- Per-layer varying KV heads and head dims requires breaking the assumption in
+  `buildTransformerGraph` that all layers share the same `cfg.NumKVHeads` and
+  `headDim`. This will be handled in the Gemma 4 builder rather than modifying
+  the shared function, keeping other architectures unchanged.
+- The K=V optimization (shared K/V projection) is a new attention variant that
+  may need a GQA extension or a thin wrapper.
+- Edge variants (PLE, KV-shared layers) are architecturally novel and may need
+  new abstractions.
+
+**Deferred:**
+- Vision encoder (SigLIP): deferred to a future multimodal epic.
+- Audio encoder: deferred to a future multimodal epic.
+- Video frame extraction: deferred.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -58,6 +58,7 @@ Task statuses updated 2026-04-10 based on merged PRs and git history.
 - E83: Serve handler refactoring (5/5 COMPLETE -- PRs #334, #336, #338, #341)
 - E84: ModeLDSL composition (8/8 COMPLETE -- PRs #334, #336, #338, #341)
 - E85: Fix GPU training memory leak in PatchTST encoder bwd (COMPLETE -- ztensor#84/#85 dst-memory reuse, 28K×20×10 40.3s, no OOM)
+- E92: Gemma 4 architecture support (0/25 -- 3 phases: dense text, MoE, edge variants)
 - GPU status: Q5_0 GEMV alignment fix shipped (ztensor 5f19e54). Q4_0 re-quantization restored for 231 tok/s decode. Pool-backed GPUStorage prevents arena corruption.
 
 ---
@@ -775,6 +776,297 @@ Deps: Wave E90-2.
 
 ---
 
+## E92: Gemma 4 Architecture Support
+
+### Context
+
+Gemma 4 is Google's latest open model family (Apache-2.0, released 2026-03-02),
+built from Gemini 3 research. It introduces significant architectural changes
+over Gemma 3 that prevent the existing `buildGemmaGraph` builder from handling
+Gemma 4 models. GGUF conversions are widely available from Unsloth and others
+with millions of downloads.
+
+Four variants exist:
+- **31B (dense)**: 60 layers, 32 QH / 16 sliding KV / 4 global KV heads, 256K context
+- **26B-A4B (MoE)**: 30 layers, 128 experts top-8, 3.8B active params, 256K context
+- **E4B (edge)**: 42 layers, PLE, KV-shared layers, audio+vision, 128K context
+- **E2B (edge)**: 35 layers, PLE, KV-shared, double-wide MLP, audio+vision, 128K context
+
+Key architectural differences from Gemma 3:
+1. **Hybrid attention**: Interleaved sliding-window + global layers (pattern: 5 sliding + 1 global).
+   Sliding and global layers have DIFFERENT KV head counts and head dimensions.
+2. **Dual RoPE**: Sliding layers use theta=10K; global layers use theta=1M with
+   partial_rotary_factor=0.25 (proportional RoPE).
+3. **K=V in global layers** (31B, 26B): Keys and values share the same projection,
+   halving KV cache for global layers.
+4. **GELU activation** (gelu_pytorch_tanh) instead of SwiGLU.
+5. **MoE** (26B-A4B): 128 experts, top-8 routing per token.
+6. **Per-Layer Embeddings** (E variants): Each layer has its own 256-dim input embedding.
+7. **KV-shared layers** (E variants): Multiple layers share the same KV projections.
+8. **262K vocab** (up from 256K), logit softcapping at 30.0, 4 norms per layer.
+
+Decision rationale: docs/adr/085-gemma4-architecture-support.md
+
+### Approach
+
+The existing `buildTransformerGraph` assumes all layers share the same KV head
+count and head dimension. Gemma 4 breaks this assumption: sliding layers use
+16 KV heads with headDim=256, while global layers use 4 KV heads with headDim=512.
+
+Rather than making `buildTransformerGraph` more complex (risking regressions for
+all 20+ supported architectures), the Gemma 4 builder will construct its own
+per-layer loop calling the same layer primitives (GQA, RMSNorm, FFN, MoE) that
+`buildTransformerGraph` uses. This is the same pattern used by `arch_deepseek.go`
+which also has per-layer variation (MoE on some layers, dense on others).
+
+Existing components reused without modification:
+- `attention.GroupedQueryAttention` (with per-layer KV head counts)
+- `normalization.RMSNormFromParam` (RMSNorm with eps=1e-6)
+- `core.MixtureOfExperts` + `core.MoEGate` (for 26B-A4B MoE variant)
+- `embeddings.RotaryPositionalEmbedding` (with per-layer theta and partial factor)
+- Logit softcapping (existing `lmHeadNode`)
+- Tied embedding (existing `newEmbeddingNode`)
+- Merged QKV and Gate+Up optimizations (existing patterns in `arch_common.go`)
+
+New code needed:
+- `arch_gemma4.go`: Dense builder with per-layer GQA configuration
+- `arch_gemma4_moe.go`: MoE variant with conditional MoE/dense FFN per layer
+- `arch_gemma4_edge.go`: Edge variant with PLE and KV-shared layers
+- GGUF metadata parsing for Gemma 4's new config keys
+- GELU FFN option (Gemma 4 uses GELU instead of SwiGLU)
+- K=V attention support (shared K/V projection in global layers)
+
+### Acceptance Criteria
+
+- All 4 Gemma 4 variants load from GGUF and produce coherent text output.
+- Gemma 4 31B Q4_K_M generates coherent responses on DGX Spark.
+- Gemma 4 26B-A4B Q4_K_M generates coherent responses with MoE routing.
+- Architecture test passes (no raw .Data() or loop violations).
+- Parity test: Gemma 4 E2B output matches llama.cpp/Ollama on same prompt.
+- All existing architecture tests remain green (no regressions).
+
+### Work Breakdown
+
+#### E92.1: GGUF Metadata and Configuration (ModelConfig extensions)
+
+- [ ] T92.1.1 Extend ModelConfig with Gemma 4 fields  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  File: model/gguf/arch.go
+  Add fields to ModelConfig:
+  - `GlobalNumKVHeads int` -- KV head count for global attention layers (0 = use NumKVHeads)
+  - `GlobalHeadDim int` -- head dimension for global attention layers (0 = use HeadDim)
+  - `SlidingNumKVHeads int` -- KV head count for sliding attention layers (0 = use NumKVHeads)
+  - `SlidingHeadDim int` -- head dimension for sliding attention layers (0 = use HeadDim)
+  - `GlobalPartialRotaryFactor float32` -- partial rotary factor for global layers (0 = full)
+  - `AttentionKEqV bool` -- if true, K and V share the same projection in global layers
+  - `KVSharedLayers int` -- number of layers sharing KV projections (edge variants)
+  - `PLEHiddenSize int` -- per-layer embedding hidden size (0 = disabled)
+  - `DoubleWideMLP bool` -- if true, use double-width MLP (E2B variant)
+  Parse from GGUF metadata keys in the gemma4 architecture detection block.
+  AC: `go test ./model/gguf/...` passes. New fields populated from Gemma 4 GGUF files.
+
+- [ ] T92.1.2 Add Gemma 4 architecture detection in GGUF parser  Owner: TBD  Est: 30m  verifies: [infrastructure]
+  File: model/gguf/arch.go
+  Add `case "gemma4":` block to populate the new fields from GGUF metadata.
+  Set defaults: `SlidingWindowPattern = 6` (5 sliding + 1 global), vocabulary=262144.
+  AC: Parsing a Gemma 4 GGUF populates all config fields correctly.
+
+- [ ] T92.1.3 Add unit tests for Gemma 4 config parsing  Owner: TBD  Est: 30m  verifies: [infrastructure]
+  File: model/gguf/arch_test.go
+  Test all 4 variant configs: 31B, 26B-A4B, E4B, E2B.
+  AC: Tests pass with correct field values for each variant.
+
+#### E92.2: Dense Builder (31B -- text-only, Phase 1)
+
+- [ ] T92.2.1 Create arch_gemma4.go with per-layer GQA configuration  Owner: TBD  Est: 3h  verifies: [UC-001]
+  File: inference/arch_gemma4.go
+  Build function `buildGemma4Graph` that:
+  1. Loads embedding weights (tied LM head, sqrt(hidden_size) scaling).
+  2. Iterates layers 0..N-1, determining per-layer attention config:
+     - `isGlobal := (i+1) % slidingWindowPattern == 0`
+     - Global: `globalNumKVHeads`, `globalHeadDim`, theta=1M, partialRotaryFactor=0.25
+     - Sliding: `slidingNumKVHeads`, `slidingHeadDim`, theta=10K, full RoPE
+  3. Creates GQA per layer with the appropriate KV head count and head dim.
+  4. For global layers with `attentionKEqV`, passes the K projection weight
+     for both K and V (shared projection).
+  5. Uses GELU FFN (not SwiGLU) -- add `core.WithGELU[float32]()` FFN option.
+  6. Applies 4 norms per layer: input, post-attn, pre-FFN, post-FFN.
+  7. Q/K norms after projection.
+  8. Logit softcapping (30.0).
+  9. Final RMSNorm + tied LM head.
+  Reuse: `newTensorLookup`, `newParamWrapper`, `newEmbeddingNode`, `newLMHeadNode`,
+  `transposeWeight2D`, merged QKV optimization, merged Gate+Up optimization.
+  AC: Graph builds without error from Gemma 4 31B tensor fixtures.
+
+- [ ] T92.2.2 Add GELU FFN option to core.FFN  Owner: TBD  Est: 45m  verifies: [UC-001]
+  File: layers/core/ffn.go
+  Add `WithGELU[T]()` option that uses `gelu_pytorch_tanh` activation instead of SwiGLU.
+  The GELU variant has gate+up as a single projection (no separate gate_proj), or
+  keeps gate+up separate with GELU replacing SiLU. Check Gemma 4 GGUF weight names
+  to determine the exact FFN structure.
+  AC: `go test ./layers/core/...` passes. GELU FFN produces correct output.
+
+- [ ] T92.2.3 Add K=V shared projection support to GQA  Owner: TBD  Est: 1h  verifies: [UC-001]
+  File: layers/attention/grouped_query_attention.go
+  Add `SetKEqV()` method that configures GQA to use the K projection weight for
+  both K and V (shared projection). When enabled, the V projection is skipped and
+  the K output is used directly as V.
+  AC: `go test ./layers/attention/...` passes. K=V produces same output as
+  separate K/V when K and V weights are identical.
+
+- [ ] T92.2.4 Register "gemma4" in architecture registry  Owner: TBD  Est: 15m  verifies: [UC-001]
+  File: inference/registry_init.go
+  Add `RegisterArchitecture("gemma4", buildGemma4Graph)`.
+  AC: `GetArchitecture("gemma4")` returns the builder.
+
+- [ ] T92.2.5 Create test fixtures and structural tests  Owner: TBD  Est: 1h  verifies: [UC-001]
+  File: inference/arch_gemma4_test.go
+  Create `makeGemma4_31BTestTensors(cfg)` fixture with per-layer varying KV weights.
+  Tests: graph builds, forward produces non-NaN output, tied embedding verified,
+  layer count correct, hybrid attention pattern verified.
+  AC: All tests pass.
+
+- [ ] T92.2.6 Run go vet + golangci-lint on changed files  Owner: TBD  Est: 15m  verifies: [infrastructure]
+  AC: Zero warnings.
+
+#### E92.3: MoE Variant (26B-A4B -- Phase 2)
+
+- [ ] T92.3.1 Create arch_gemma4_moe.go with conditional MoE/dense FFN  Owner: TBD  Est: 2h  verifies: [UC-001]
+  File: inference/arch_gemma4_moe.go
+  Deps: T92.2.1
+  Build function `buildGemma4MoEGraph` that extends the dense builder:
+  1. Inherits all hybrid attention, dual RoPE, K=V, GELU, 4-norm config.
+  2. For MoE layers: replaces dense FFN with `core.MixtureOfExperts` (128 experts, top-8).
+     Each expert is a small GELU FFN (intermediate_size=704).
+  3. Dense MLP layers use intermediate_size=2112.
+  4. Gate weights loaded from `model.layers.{i}.mlp.gate.weight`.
+  5. Expert weights loaded from `model.layers.{i}.mlp.experts.{j}.{gate,up,down}_proj.weight`.
+  Follow the pattern in `arch_deepseek.go` lines 300-330 for MoE wiring.
+  AC: Graph builds from 26B-A4B tensor fixtures. MoE routing produces valid output.
+
+- [ ] T92.3.2 Register "gemma4moe" in architecture registry  Owner: TBD  Est: 15m  verifies: [UC-001]
+  File: inference/registry_init.go
+  AC: `GetArchitecture("gemma4moe")` returns the builder.
+
+- [ ] T92.3.3 Create test fixtures and structural tests for MoE  Owner: TBD  Est: 1h  verifies: [UC-001]
+  File: inference/arch_gemma4_test.go
+  Create `makeGemma4_26BTestTensors(cfg)` fixture with expert weights.
+  Tests: graph builds, MoE routing active, expert count correct, forward non-NaN.
+  AC: All tests pass.
+
+- [ ] T92.3.4 Run go vet + golangci-lint  Owner: TBD  Est: 15m  verifies: [infrastructure]
+  AC: Zero warnings.
+
+#### E92.4: Edge Variants (E4B/E2B -- Phase 3)
+
+- [ ] T92.4.1 Add Per-Layer Embedding (PLE) support  Owner: TBD  Est: 2h  verifies: [UC-001]
+  File: inference/arch_gemma4_edge.go
+  Deps: T92.2.1
+  PLE adds a per-layer input embedding projection: for each layer, a small
+  (256-dim) per-token embedding is projected to hidden_size and added to the
+  layer input. Weight tensor: `model.layers.{i}.ple.weight` [vocab, 256].
+  Projection: `model.layers.{i}.ple_proj.weight` [256, hidden_size].
+  AC: PLE tensors loaded and applied per layer. Forward output non-NaN.
+
+- [ ] T92.4.2 Add KV-shared layer support  Owner: TBD  Est: 2h  verifies: [UC-001]
+  File: inference/arch_gemma4_edge.go
+  Deps: T92.2.1
+  E4B shares KV projections across 18 layers; E2B across 20 layers.
+  Implementation: identify which layers share KV weights (from GGUF metadata or
+  weight name deduplication). When building GQA for a shared layer, pass the
+  same K/V weight parameters as the source layer.
+  AC: Shared layers use identical K/V weight pointers. Forward output non-NaN.
+
+- [ ] T92.4.3 Add double-wide MLP option (E2B)  Owner: TBD  Est: 30m  verifies: [UC-001]
+  File: inference/arch_gemma4_edge.go
+  E2B uses `use_double_wide_mlp: true` which doubles the intermediate size.
+  Read from ModelConfig and apply when constructing FFN.
+  AC: E2B FFN uses doubled intermediate size.
+
+- [ ] T92.4.4 Create buildGemma4EdgeGraph builder  Owner: TBD  Est: 1h  verifies: [UC-001]
+  File: inference/arch_gemma4_edge.go
+  Deps: T92.4.1, T92.4.2, T92.4.3
+  Compose PLE + KV-shared + edge-specific config into a complete builder.
+  Register as "gemma4e" in registry_init.go.
+  AC: Graph builds from E4B and E2B tensor fixtures.
+
+- [ ] T92.4.5 Create test fixtures and structural tests for edge variants  Owner: TBD  Est: 1h  verifies: [UC-001]
+  File: inference/arch_gemma4_test.go
+  Tests for E4B and E2B: PLE active, KV sharing correct, double-wide MLP for E2B.
+  AC: All tests pass.
+
+- [ ] T92.4.6 Run go vet + golangci-lint  Owner: TBD  Est: 15m  verifies: [infrastructure]
+  AC: Zero warnings.
+
+#### E92.5: Integration Testing and Validation
+
+- [ ] T92.5.1 Download Gemma 4 E2B Q4_K_M GGUF for CI testing  Owner: TBD  Est: 30m  verifies: [infrastructure]
+  Smallest variant (~1.5GB Q4_K_M) for fast CI testing.
+  Store path in test as `GEMMA4_GGUF_PATH` env var (skip if not set).
+  AC: GGUF file available on dev machine.
+
+- [ ] T92.5.2 End-to-end inference test: load GGUF + generate text  Owner: TBD  Est: 1h  verifies: [UC-001]
+  Deps: T92.2.1, T92.5.1
+  File: tests/integration/gemma4_test.go
+  Load Gemma 4 E2B GGUF, generate 50 tokens, verify coherent output.
+  Compare with llama.cpp/Ollama output on same prompt for sanity.
+  AC: Test produces coherent text. No panics, no NaN.
+
+- [ ] T92.5.3 Benchmark Gemma 4 E2B on DGX Spark  Owner: TBD  Est: 1h  verifies: [UC-001]
+  Deps: T92.5.2
+  Run bench-compare-ollama.sh on DGX for Gemma 4 E2B Q4_K_M.
+  Record tok/s for decode and prefill. Compare against Ollama.
+  AC: Results documented in docs/devlog.md. Target: within 20% of Ollama.
+  BLOCKED: same purego cross-compile blocker as T86.5.8.
+
+- [ ] T92.5.4 Add Gemma 4 to supported architectures table in CLAUDE.md  Owner: TBD  Est: 15m  verifies: [infrastructure]
+  Deps: T92.5.2
+  Update the "Supported Architectures" table.
+  AC: Table includes Gemma 4 with status and features noted.
+
+- [ ] T92.5.5 Run full test suite: go test ./...  Owner: TBD  Est: 15m  verifies: [infrastructure]
+  Deps: all E92 tasks
+  AC: All tests pass including existing architecture tests (no regressions).
+
+### E92 Parallel Tracks
+
+| Track | Tasks | Description | Dependencies |
+|-------|-------|-------------|-------------|
+| A: Config | T92.1.1-T92.1.3 | GGUF metadata parsing | None |
+| B: Dense | T92.2.1-T92.2.6 | 31B dense builder | A (T92.1.1) |
+| C: MoE | T92.3.1-T92.3.4 | 26B-A4B MoE builder | B (T92.2.1) |
+| D: Edge | T92.4.1-T92.4.6 | E4B/E2B edge builder | B (T92.2.1) |
+| E: Validation | T92.5.1-T92.5.5 | Integration testing | B, C, D |
+
+### E92 Waves
+
+#### Wave E92-1: Config + GELU + K=V primitives (3 agents)
+All independent -- different files, no shared code.
+
+- [ ] Agent 1: T92.1.1 + T92.1.2 + T92.1.3 (GGUF config extensions)
+- [ ] Agent 2: T92.2.2 (GELU FFN option in layers/core/)
+- [ ] Agent 3: T92.2.3 (K=V support in layers/attention/)
+
+#### Wave E92-2: Dense builder + tests (2 agents)
+Deps: Wave E92-1
+
+- [ ] Agent 1: T92.2.1 + T92.2.4 + T92.2.6 (dense builder + registry + lint)
+- [ ] Agent 2: T92.2.5 (test fixtures and structural tests)
+
+#### Wave E92-3: MoE + Edge (2 agents)
+Deps: Wave E92-2 (need dense builder as base)
+MoE and Edge builders are independent of each other.
+
+- [ ] Agent 1: T92.3.1 + T92.3.2 + T92.3.3 + T92.3.4 (MoE variant)
+- [ ] Agent 2: T92.4.1 + T92.4.2 + T92.4.3 + T92.4.4 + T92.4.5 + T92.4.6 (edge variants)
+
+#### Wave E92-4: Integration and validation (2 agents)
+Deps: Wave E92-3
+
+- [ ] Agent 1: T92.5.1 + T92.5.2 + T92.5.5 (GGUF download + e2e test + full suite)
+- [ ] Agent 2: T92.5.3 + T92.5.4 (DGX benchmark + docs update)
+
+---
+
 ## Backlog
 
 ### Community and DevRel
@@ -995,6 +1287,7 @@ Task details removed during /tidy --apply. See git history for full lists.
 | M-COMP-3 | Composition Remediation Phase 3 | E74-E76 | All backward passes compose from functional backward ops; inference .Data() eliminated; timeseries/ removed from arch test allowlist | 2026-Q3 |
 | M-COMP-4 | Composition Remediation Phase 4 | E77-E84 | dirty-architecture.md violations reduced from ~9,800 to <2,000 lines; tabular/, layers/, generate/, inference/, training/, serve/, modeldsl/ all compose from layers/ or Engine | 2026-Q3 |
 | M-E86 | PyTorch Parity Complete | E86 | 100% layer forward parity, 100% backward parity, all model architectures, GPU kernel parity on DGX | 2026-Q3 |
+| M-E92 | Gemma 4 Support | E92 | All 4 variants load from GGUF and produce coherent text; parity with Ollama on E2B | 2026-Q2 |
 
 ---
 
@@ -1044,6 +1337,10 @@ Task details removed during /tidy --apply. See git history for full lists.
 | R69 | ModeLDSL composition changes DSL compilation behavior (E84) | Medium | Medium | Run full modeldsl test suite; compare compiled model structure before/after; validate layer-type registration |
 | R70 | PyTorch golden files may not match Zerfoo's intended semantics for some ops (E86) | Medium | Medium | When PyTorch and Zerfoo disagree, investigate which is correct rather than blindly matching PyTorch. Document intentional differences in the golden file description field. |
 | R71 | GPU parity tests may show larger tolerance than CPU due to non-deterministic kernel execution order (E86) | Low | High | Use 1e-3 tolerance for GPU tests (vs 1e-5 for CPU). If larger divergence, investigate specific kernel. |
+| R75 | Gemma 4 per-layer varying KV heads breaks buildTransformerGraph assumptions (E92) | Medium | Low | Gemma 4 builder constructs its own per-layer loop (same pattern as arch_deepseek.go) rather than modifying shared function. No regression risk for other architectures. |
+| R76 | K=V shared projection produces wrong attention output (E92) | Medium | Medium | Validate by comparing GQA output with K=V enabled vs disabled when K and V weights are identical. Add dedicated parity test. |
+| R77 | 128-expert MoE exceeds memory on consumer GPUs (E92) | Low | High | Only affects 26B-A4B variant. Target Q4_K_M quantization (~16GB). Recommend GPU with 24GB+ VRAM. Edge variants (E2B/E4B) are the consumer targets. |
+| R78 | Gemma 4 GGUF metadata keys change across converter versions (E92) | Low | Medium | Test against Unsloth (most popular), LM Studio, and bartowski GGUFs. Add fallback parsing for alternative key names. |
 | R72 | Float32 conversion in crossasset changes training accuracy (E90) | Medium | Medium | Run 10-epoch training before/after; compare loss curves within 1e-3; final accuracy within 2%. Float32 has sufficient precision for DModel=256. |
 | R73 | GPU engine stability on Grace Hopper unified memory (E90) | Medium | High | E60 noted CUDA launch timeouts and illegal memory access. Test with ZERFOO_DISABLE_CUDA_GRAPH=1. If issues persist, use fused kernels only for matmul (largest speedup). |
 | R74 | CrossAsset public API break from float64-to-float32 migration (E90) | High | High | This is a breaking change. Update all callers (wolf integration). Document in CHANGELOG.md. |
@@ -1140,6 +1437,17 @@ Task details removed during /tidy --apply. See git history for full lists.
 ---
 
 ## Progress Log
+
+### 2026-04-13: E92 added -- Gemma 4 architecture support
+
+- Added E92 (25 tasks, 4 waves) for Gemma 4 architecture support across all 4 variants.
+- Phase 1: Dense 31B builder with hybrid attention, dual RoPE, K=V, GELU FFN.
+- Phase 2: MoE 26B-A4B with 128 experts top-8 routing (reuses existing MoE layer).
+- Phase 3: Edge E4B/E2B with PLE and KV-shared layers.
+- Created ADR-085 (docs/adr/085-gemma4-architecture-support.md).
+- Vision and audio encoders deferred to future multimodal epic.
+- Added risks R75-R78 for per-layer KV, K=V, MoE memory, GGUF metadata.
+- Trimmed plan: collapsed E50, E51, E74, E85, E87, E89, pruned 7 branches, fixed DGX IP.
 
 ### 2026-04-11: E86.5 GPU parity complete + E90 added
 
@@ -1313,6 +1621,12 @@ E77-E84 phase 4. See git history for full changelog.
   high-level composition but E84 goes deeper into the individual layer implementations.
   The LayerType constant reconciliation (T84.1.6) should make layers/registry the single
   source of truth.
+- E92 (Gemma 4): The builder uses its own per-layer loop (like arch_deepseek.go)
+  because Gemma 4 has per-layer varying KV head counts and head dims. Does NOT
+  modify buildTransformerGraph. Reuses GQA, MoE, RMSNorm, FFN, RoPE layers.
+  Key differences from Gemma 3: GELU (not SwiGLU), K=V in global layers,
+  hybrid attention with 2 RoPE configs per model, MoE variant with 128 experts.
+  Vision and audio encoders are deferred (multimodal epic). ADR-085.
 - E86 (PyTorch parity): The golden file generator is tests/golden/generate_golden.py.
   Run `python3 tests/golden/generate_golden.py` to regenerate all golden files.
   Go tests are in tests/parity/layer_parity_test.go. Pattern for adding a new layer:

--- a/layers/attention/grouped_query_attention.go
+++ b/layers/attention/grouped_query_attention.go
@@ -70,6 +70,10 @@ type GroupedQueryAttention[T tensor.Numeric] struct {
 	// every other position (encoder-style attention).
 	bidirectional bool
 
+	// kEqV, when true, uses the K projection output as V (shared K=V).
+	// Gemma 4 global attention layers use this optimization.
+	kEqV bool
+
 	// Cached tensors for backward pass
 	qProj           *tensor.TensorNumeric[T] // Projected Q
 	kProj           *tensor.TensorNumeric[T] // Projected K
@@ -272,6 +276,13 @@ func (gqa *GroupedQueryAttention[T]) SetBidirectional(bidirectional bool) {
 	gqa.bidirectional = bidirectional
 }
 
+// SetKEqV configures GQA to use the K projection output for both K and V.
+// When enabled, the V projection (wv) is skipped and K output is used as V.
+// This implements Gemma 4's unified K=V projection for global attention layers.
+func (gqa *GroupedQueryAttention[T]) SetKEqV(v bool) {
+	gqa.kEqV = v
+}
+
 // OutputShape returns the output shape of the GroupedQueryAttention.
 func (gqa *GroupedQueryAttention[T]) OutputShape() []int {
 	return gqa.outputShape
@@ -391,9 +402,13 @@ func (gqa *GroupedQueryAttention[T]) Forward(ctx context.Context, inputs ...*ten
 		if err != nil {
 			return nil, err
 		}
-		vProj, err = gqa.wv.Forward(ctx, input)
-		if err != nil {
-			return nil, err
+		if gqa.kEqV {
+			vProj = kProj
+		} else {
+			vProj, err = gqa.wv.Forward(ctx, input)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/layers/attention/grouped_query_attention_test.go
+++ b/layers/attention/grouped_query_attention_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/zerfoo/zerfoo/layers/core"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
@@ -130,6 +131,145 @@ func TestGroupedQueryAttention_Forward_NoRoPE(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGroupedQueryAttention_KEqV_Forward(t *testing.T) {
+	engine := compute.NewCPUEngine(numeric.Float32Ops{})
+
+	batchSize := 1
+	seqLen := 5
+	modelDim := 16
+	numQueryHeads := 4
+	numKeyValueHeads := 2
+
+	gqa, err := NewGroupedQueryAttention[float32](
+		engine,
+		numeric.Float32Ops{},
+		modelDim,
+		numQueryHeads,
+		numKeyValueHeads,
+		WithRopeBase[float32](10000.0),
+		WithMaxSeqLen[float32](seqLen),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct GQA: %v", err)
+	}
+
+	gqa.SetKEqV(true)
+
+	inp, err := tensor.New[float32]([]int{batchSize, seqLen, modelDim}, nil)
+	if err != nil {
+		t.Fatalf("failed creating input: %v", err)
+	}
+	for i := range inp.Data() {
+		inp.Data()[i] = float32(i%13) / 10.0
+	}
+
+	out, err := gqa.Forward(context.Background(), inp)
+	if err != nil {
+		t.Fatalf("KEqV Forward failed: %v", err)
+	}
+
+	expected := []int{batchSize, seqLen, modelDim}
+	if !testutils.IntSliceEqual(expected, out.Shape()) {
+		t.Fatalf("unexpected output shape: got %v want %v", out.Shape(), expected)
+	}
+
+	for i, v := range out.Data() {
+		if v != v {
+			t.Fatalf("output contains NaN at idx %d", i)
+		}
+	}
+}
+
+func TestGroupedQueryAttention_KEqV_MatchesIdenticalWeights(t *testing.T) {
+	engine := compute.NewCPUEngine(numeric.Float32Ops{})
+
+	batchSize := 1
+	seqLen := 5
+	modelDim := 16
+	numQueryHeads := 4
+	numKeyValueHeads := 2
+
+	// Create the K=V GQA.
+	gqaKEqV, err := NewGroupedQueryAttention[float32](
+		engine,
+		numeric.Float32Ops{},
+		modelDim,
+		numQueryHeads,
+		numKeyValueHeads,
+		WithRopeBase[float32](10000.0),
+		WithMaxSeqLen[float32](seqLen),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct K=V GQA: %v", err)
+	}
+	gqaKEqV.SetKEqV(true)
+
+	// Create the separate GQA sharing the same Q, K, O weights but with V = K weights.
+	// Copy K weight data into V weight so both paths compute the same thing.
+	gqaSeparate, err := NewGroupedQueryAttention[float32](
+		engine,
+		numeric.Float32Ops{},
+		modelDim,
+		numQueryHeads,
+		numKeyValueHeads,
+		WithRopeBase[float32](10000.0),
+		WithMaxSeqLen[float32](seqLen),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct separate GQA: %v", err)
+	}
+
+	// Copy all weights from K=V GQA to separate GQA so they share the same
+	// random initialization, then set separate's V weight = K weight.
+	copyDenseWeights(t, gqaSeparate.wq, gqaKEqV.wq)
+	copyDenseWeights(t, gqaSeparate.wk, gqaKEqV.wk)
+	copyDenseWeights(t, gqaSeparate.wo, gqaKEqV.wo)
+	copyDenseWeights(t, gqaSeparate.wv, gqaKEqV.wk) // V = K
+
+	inp, err := tensor.New[float32]([]int{batchSize, seqLen, modelDim}, nil)
+	if err != nil {
+		t.Fatalf("failed creating input: %v", err)
+	}
+	for i := range inp.Data() {
+		inp.Data()[i] = float32(i%13) / 10.0
+	}
+
+	outKEqV, err := gqaKEqV.Forward(context.Background(), inp)
+	if err != nil {
+		t.Fatalf("KEqV Forward failed: %v", err)
+	}
+
+	outSep, err := gqaSeparate.Forward(context.Background(), inp)
+	if err != nil {
+		t.Fatalf("Separate Forward failed: %v", err)
+	}
+
+	if !testutils.IntSliceEqual(outKEqV.Shape(), outSep.Shape()) {
+		t.Fatalf("shape mismatch: K=V %v vs separate %v", outKEqV.Shape(), outSep.Shape())
+	}
+
+	const tol = 1e-5
+	for i := range outKEqV.Data() {
+		diff := outKEqV.Data()[i] - outSep.Data()[i]
+		if diff < -tol || diff > tol {
+			t.Fatalf("output mismatch at idx %d: K=V=%f separate=%f diff=%f",
+				i, outKEqV.Data()[i], outSep.Data()[i], diff)
+		}
+	}
+}
+
+// copyDenseWeights copies parameter data from src Dense to dst Dense.
+func copyDenseWeights(t *testing.T, dst, src *core.Dense[float32]) {
+	t.Helper()
+	srcParams := src.Parameters()
+	dstParams := dst.Parameters()
+	for i, dp := range dstParams {
+		if i < len(srcParams) {
+			copy(dp.Value.Data(), srcParams[i].Value.Data())
+		}
 	}
 }
 

--- a/layers/core/ffn.go
+++ b/layers/core/ffn.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
@@ -16,6 +17,7 @@ import (
 type FFN[T tensor.Numeric] struct {
 	name         string
 	noBias       bool
+	useGELU      bool
 	w1           *Dense[T]
 	w2           *Dense[T]
 	w3           *Dense[T]
@@ -39,6 +41,14 @@ type FFNOpt[T tensor.Numeric] func(*FFN[T])
 func WithSwiGLU[T tensor.Numeric]() FFNOpt[T] {
 	return func(f *FFN[T]) {
 		f.swiglu = activations.NewSwiGLU[T](f.w1.linear.engine, f.w1.linear.ops)
+	}
+}
+
+// WithGELU enables GELU activation instead of SwiGLU.
+// The FFN computes: output = W2(GELU(W1(x)) * W3(x))
+func WithGELU[T tensor.Numeric]() FFNOpt[T] {
+	return func(f *FFN[T]) {
+		f.useGELU = true
 	}
 }
 
@@ -187,33 +197,46 @@ func (f *FFN[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]
 	f.w1Output = w1Output // Cache for backward pass
 	f.w3Output = w3Output // Cache for backward pass
 
-	// Try fused GPU SwiGLU path: single kernel replaces Concat + Split + sigmoid + Mul + Mul.
-	// Unwrap EngineProxy to detect the real engine type.
-	var swiGLUOutput *tensor.TensorNumeric[T]
-	realEngine := compute.Engine[T](f.w1.linear.engine)
-	if proxy, ok := f.w1.linear.engine.(*compute.EngineProxy[T]); ok {
-		realEngine = proxy.Real()
-	}
-	if provider, ok := realEngine.(compute.FusedSwiGLUProvider[T]); ok {
-		out, err := provider.GPUFusedSwiGLU(w1Output, w3Output)
-		if err == nil {
-			swiGLUOutput = out
+	var activationOutput *tensor.TensorNumeric[T]
+	if f.useGELU {
+		// GELU path: output = GELU(W1(x)) * W3(x)
+		geluOutput, geluErr := geluForward(ctx, f.w1.linear.engine, f.w1.linear.ops, w1Output)
+		if geluErr != nil {
+			return nil, fmt.Errorf("GELU activation: %w", geluErr)
+		}
+		gated, mulErr := f.w1.linear.engine.Mul(ctx, geluOutput, w3Output)
+		if mulErr != nil {
+			return nil, fmt.Errorf("GELU gate multiply: %w", mulErr)
+		}
+		activationOutput = gated
+	} else {
+		// SwiGLU path: try fused GPU path first, fall back to CPU.
+		// Unwrap EngineProxy to detect the real engine type.
+		realEngine := compute.Engine[T](f.w1.linear.engine)
+		if proxy, ok := f.w1.linear.engine.(*compute.EngineProxy[T]); ok {
+			realEngine = proxy.Real()
+		}
+		if provider, ok := realEngine.(compute.FusedSwiGLUProvider[T]); ok {
+			out, fusedErr := provider.GPUFusedSwiGLU(w1Output, w3Output)
+			if fusedErr == nil {
+				activationOutput = out
+			}
+		}
+		if activationOutput == nil {
+			swigluInput, concatErr := f.w1.linear.engine.Concat(ctx, []*tensor.TensorNumeric[T]{w1Output, w3Output}, -1)
+			if concatErr != nil {
+				return nil, fmt.Errorf("failed to concatenate tensors for SwiGLU input: %w", concatErr)
+			}
+			swigluOut, swigluErr := f.swiglu.Forward(ctx, swigluInput)
+			if swigluErr != nil {
+				return nil, swigluErr
+			}
+			activationOutput = swigluOut
 		}
 	}
-	if swiGLUOutput == nil {
-		swigluInput, err := f.w1.linear.engine.Concat(ctx, []*tensor.TensorNumeric[T]{w1Output, w3Output}, -1)
-		if err != nil {
-			return nil, fmt.Errorf("failed to concatenate tensors for SwiGLU input: %w", err)
-		}
+	f.swiGLUOutput = activationOutput // Cache for backward pass
 
-		swiGLUOutput, err = f.swiglu.Forward(ctx, swigluInput)
-		if err != nil {
-			return nil, err
-		}
-	}
-	f.swiGLUOutput = swiGLUOutput // Cache for backward pass
-
-	w2Output, err := f.w2.Forward(ctx, swiGLUOutput)
+	w2Output, err := f.w2.Forward(ctx, activationOutput)
 	if err != nil {
 		return nil, err
 	}
@@ -307,6 +330,44 @@ func (f *FFN[T]) Parameters() []*graph.Parameter[T] {
 		params = append(params, p)
 	}
 	return params
+}
+
+// geluForward applies GELU activation using engine primitives.
+// GELU(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+func geluForward[T tensor.Numeric](ctx context.Context, engine compute.Engine[T], ops numeric.Arithmetic[T], x *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	x2, err := engine.Mul(ctx, x, x)
+	if err != nil {
+		return nil, err
+	}
+	x3, err := engine.Mul(ctx, x2, x)
+	if err != nil {
+		return nil, err
+	}
+	cubicTerm, err := engine.MulScalar(ctx, x3, ops.FromFloat64(0.044715))
+	if err != nil {
+		return nil, err
+	}
+	inner, err := engine.Add(ctx, x, cubicTerm)
+	if err != nil {
+		return nil, err
+	}
+	scaled, err := engine.MulScalar(ctx, inner, ops.FromFloat64(math.Sqrt(2/math.Pi)))
+	if err != nil {
+		return nil, err
+	}
+	tanhResult, err := engine.Tanh(ctx, scaled)
+	if err != nil {
+		return nil, err
+	}
+	onePlusTanh, err := engine.AddScalar(ctx, tanhResult, ops.One())
+	if err != nil {
+		return nil, err
+	}
+	xTimesOnePlusTanh, err := engine.Mul(ctx, x, onePlusTanh)
+	if err != nil {
+		return nil, err
+	}
+	return engine.MulScalar(ctx, xTimesOnePlusTanh, ops.FromFloat64(0.5))
 }
 
 // splitMergedGateUp splits a merged gate+up output into separate gate and up tensors.

--- a/layers/core/ffn_test.go
+++ b/layers/core/ffn_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"reflect"
 	"testing"
 
@@ -238,4 +240,77 @@ func TestFFN_WithSwiGLUAndNoBias(t *testing.T) {
 	testutils.AssertNoError(t, err, "Forward with SwiGLU+NoBias")
 	testutils.AssertNotNil(t, output, "Output should not be nil")
 	testutils.AssertEqual(t, output.Shape()[1], 4, "Output dim should be 4")
+}
+
+// TestFFN_WithGELU tests that GELU FFN builds and produces valid output.
+func TestFFN_WithGELU(t *testing.T) {
+	engine := compute.NewCPUEngine[float32](&numeric.Float32Ops{})
+	ops := &numeric.Float32Ops{}
+
+	ffn, err := NewFFN[float32]("test_gelu", engine, ops, 4, 8, 4,
+		WithGELU[float32](),
+		WithFFNNoBias[float32](),
+	)
+	testutils.AssertNoError(t, err, "NewFFN with GELU")
+	testutils.AssertNotNil(t, ffn, "FFN should not be nil")
+
+	input, _ := tensor.New[float32]([]int{1, 4}, []float32{1, 2, 3, 4})
+	output, err := ffn.Forward(context.Background(), input)
+	testutils.AssertNoError(t, err, "Forward with GELU")
+	testutils.AssertNotNil(t, output, "Output should not be nil")
+	testutils.AssertEqual(t, output.Shape()[1], 4, "Output dim should be 4")
+
+	// Verify no NaN values in output.
+	for i, v := range output.Data() {
+		testutils.AssertTrue(t, !math.IsNaN(float64(v)), fmt.Sprintf("output[%d] is NaN", i))
+	}
+}
+
+// TestFFN_GELUDiffersFromSwiGLU verifies GELU FFN produces different output than SwiGLU FFN.
+func TestFFN_GELUDiffersFromSwiGLU(t *testing.T) {
+	engine := compute.NewCPUEngine[float64](&numeric.Float64Ops{})
+	ops := &numeric.Float64Ops{}
+
+	inputDim, hiddenDim, outputDim := 4, 8, 4
+
+	// Create SwiGLU FFN.
+	swigluFFN, err := NewFFN[float64]("swiglu", engine, ops, inputDim, hiddenDim, outputDim,
+		WithFFNNoBias[float64](),
+	)
+	testutils.AssertNoError(t, err, "NewFFN SwiGLU")
+
+	// Create GELU FFN.
+	geluFFN, err := NewFFN[float64]("gelu", engine, ops, inputDim, hiddenDim, outputDim,
+		WithGELU[float64](),
+		WithFFNNoBias[float64](),
+	)
+	testutils.AssertNoError(t, err, "NewFFN GELU")
+
+	// Copy weights from SwiGLU to GELU so the only difference is the activation.
+	geluFFN.w1.linear.weights.Value = swigluFFN.w1.linear.weights.Value
+	geluFFN.w2.linear.weights.Value = swigluFFN.w2.linear.weights.Value
+	geluFFN.w3.linear.weights.Value = swigluFFN.w3.linear.weights.Value
+
+	input, _ := tensor.New[float64]([]int{1, inputDim}, []float64{1, 2, 3, 4})
+
+	ctx := context.Background()
+	swigluOut, err := swigluFFN.Forward(ctx, input)
+	testutils.AssertNoError(t, err, "SwiGLU forward")
+
+	geluOut, err := geluFFN.Forward(ctx, input)
+	testutils.AssertNoError(t, err, "GELU forward")
+
+	// Outputs should differ because different activations are used.
+	swigluData := swigluOut.Data()
+	geluData := geluOut.Data()
+	testutils.AssertEqual(t, len(swigluData), len(geluData), "Output lengths should match")
+
+	differs := false
+	for i := range swigluData {
+		if math.Abs(swigluData[i]-geluData[i]) > 1e-10 {
+			differs = true
+			break
+		}
+	}
+	testutils.AssertTrue(t, differs, "GELU and SwiGLU outputs should differ")
 }

--- a/layers/core/matmul.go
+++ b/layers/core/matmul.go
@@ -227,24 +227,64 @@ func (m *MatMul[T]) Backward(ctx context.Context, mode types.BackwardMode, outpu
 	a := inputs[0]
 	b := inputs[1]
 
-	// Gradient w.r.t. a: outputGradient @ b^T
-	bT, err := m.engine.Transpose(ctx, b, []int{1, 0})
-	if err != nil {
-		return nil, fmt.Errorf("MatMul backward: transpose b: %w", err)
-	}
-	gradA, err := m.engine.MatMul(ctx, outputGradient, bT)
-	if err != nil {
-		return nil, err
+	aShape := a.Shape()
+	bShape := b.Shape()
+
+	// transposeAxes returns axes that swap the last two dimensions.
+	transposeAxes := func(ndim int) []int {
+		axes := make([]int, ndim)
+		for i := range axes {
+			axes[i] = i
+		}
+		axes[ndim-2], axes[ndim-1] = axes[ndim-1], axes[ndim-2]
+		return axes
 	}
 
-	// Gradient w.r.t. b: a^T @ outputGradient
-	aT, err := m.engine.Transpose(ctx, a, []int{1, 0})
-	if err != nil {
-		return nil, fmt.Errorf("MatMul backward: transpose a: %w", err)
-	}
-	gradB, err := m.engine.MatMul(ctx, aT, outputGradient)
-	if err != nil {
-		return nil, err
+	// Detect whether Forward used the transposed-B path (C = A @ B^T).
+	// This mirrors the shape check in Forward: inner dims don't match
+	// but B is 2D and A's last dim equals B's last dim.
+	bTransposedPath := aShape[len(aShape)-1] != bShape[len(bShape)-2] &&
+		len(bShape) == 2 && aShape[len(aShape)-1] == bShape[1]
+
+	var gradA, gradB *tensor.TensorNumeric[T]
+	var err error
+
+	if bTransposedPath {
+		// Forward was: C = A @ B^T
+		// dA = dOut @ B
+		gradA, err = m.engine.MatMul(ctx, outputGradient, b)
+		if err != nil {
+			return nil, err
+		}
+		// dB = dOut^T @ A
+		dOutT, err := m.engine.Transpose(ctx, outputGradient, transposeAxes(len(outputGradient.Shape())))
+		if err != nil {
+			return nil, fmt.Errorf("MatMul backward: failed to transpose outputGradient: %w", err)
+		}
+		gradB, err = m.engine.MatMul(ctx, dOutT, a)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Forward was: C = A @ B
+		// dA = dOut @ B^T
+		bT, err := m.engine.Transpose(ctx, b, transposeAxes(len(bShape)))
+		if err != nil {
+			return nil, fmt.Errorf("MatMul backward: failed to transpose b: %w", err)
+		}
+		gradA, err = m.engine.MatMul(ctx, outputGradient, bT)
+		if err != nil {
+			return nil, err
+		}
+		// dB = A^T @ dOut
+		aT, err := m.engine.Transpose(ctx, a, transposeAxes(len(aShape)))
+		if err != nil {
+			return nil, fmt.Errorf("MatMul backward: failed to transpose a: %w", err)
+		}
+		gradB, err = m.engine.MatMul(ctx, aT, outputGradient)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return []*tensor.TensorNumeric[T]{gradA, gradB}, nil

--- a/model/gguf/arch.go
+++ b/model/gguf/arch.go
@@ -63,6 +63,17 @@ type ModelConfig struct {
 	// MoE expert gating configuration.
 	ScoringFunc string // expert gating scoring function ("softmax" or "sigmoid"; default: "softmax")
 
+	// Gemma 4 per-layer attention configuration.
+	GlobalNumKVHeads          int     // KV head count for global attention layers (0 = use NumKVHeads)
+	GlobalHeadDim             int     // head dimension for global attention layers (0 = use HeadDim)
+	SlidingNumKVHeads         int     // KV head count for sliding attention layers (0 = use NumKVHeads)
+	SlidingHeadDim            int     // head dimension for sliding attention layers (0 = use HeadDim)
+	GlobalPartialRotaryFactor float32 // partial rotary factor for global layers (0 = full rotation)
+	AttentionKEqV             bool    // if true, K and V share the same projection in global layers
+	KVSharedLayers            int     // number of layers sharing KV projections (edge variants)
+	PLEHiddenSize             int     // per-layer embedding hidden size (0 = disabled)
+	DoubleWideMLP             bool    // if true, use double-width MLP (E2B variant)
+
 	// Vision encoder fields (LLaVA, multimodal models).
 	VisionImageSize  int    // vision encoder input image size (e.g. 336)
 	VisionPatchSize  int    // vision encoder patch size (e.g. 14)
@@ -329,6 +340,52 @@ func ExtractModelConfig(f *File) (*ModelConfig, error) {
 	// ExpertSharedCount is populated for nemotron_h_moe models.
 	if v, ok := f.GetUint32(prefix + "expert_shared_count"); ok {
 		cfg.ExpertSharedCount = int(v)
+	}
+
+	// Extract Gemma 4 per-layer attention fields.
+	if v, ok := f.GetUint32(prefix + "attention.global.head_count_kv"); ok {
+		cfg.GlobalNumKVHeads = int(v)
+	}
+	if v, ok := f.GetUint32(prefix + "attention.global.key_length"); ok {
+		cfg.GlobalHeadDim = int(v)
+	}
+	if v, ok := f.GetUint32(prefix + "attention.sliding.head_count_kv"); ok {
+		cfg.SlidingNumKVHeads = int(v)
+	}
+	if v, ok := f.GetUint32(prefix + "attention.sliding.key_length"); ok {
+		cfg.SlidingHeadDim = int(v)
+	}
+	if v, ok := f.GetFloat32(prefix + "rope.global.dimension_fraction"); ok {
+		cfg.GlobalPartialRotaryFactor = v
+	}
+	if v, ok := f.GetString(prefix + "attention.k_eq_v"); ok && v == "true" {
+		cfg.AttentionKEqV = true
+	}
+	// Also check for boolean metadata.
+	if v, ok := f.GetUint32(prefix + "attention.k_eq_v"); ok && v == 1 {
+		cfg.AttentionKEqV = true
+	}
+	if v, ok := f.GetUint32(prefix + "kv_shared_layers"); ok {
+		cfg.KVSharedLayers = int(v)
+	}
+	if v, ok := f.GetUint32(prefix + "ple.hidden_size"); ok {
+		cfg.PLEHiddenSize = int(v)
+	}
+	if v, ok := f.GetString(prefix + "mlp.double_wide"); ok && v == "true" {
+		cfg.DoubleWideMLP = true
+	}
+	if v, ok := f.GetUint32(prefix + "mlp.double_wide"); ok && v == 1 {
+		cfg.DoubleWideMLP = true
+	}
+
+	// Gemma 4 defaults: SlidingWindowPattern=6, vocabulary=262144.
+	if strings.HasPrefix(arch, "gemma4") {
+		if cfg.SlidingWindowPattern == 0 {
+			cfg.SlidingWindowPattern = 6
+		}
+		if cfg.VocabSize == 0 {
+			cfg.VocabSize = 262144
+		}
 	}
 
 	// Detect the actual architecture — e.g. Mistral models that declare "llama".

--- a/model/gguf/arch_test.go
+++ b/model/gguf/arch_test.go
@@ -525,3 +525,207 @@ func TestExtractModelConfig_KVHeadsDefaultsToHeads(t *testing.T) {
 		t.Errorf("NumKVHeads = %d, want 32 (default to NumHeads)", cfg.NumKVHeads)
 	}
 }
+
+func TestExtractModelConfig_Gemma4(t *testing.T) {
+	t.Run("31B dense", func(t *testing.T) {
+		meta := map[string]any{
+			"general.architecture":                          "gemma4",
+			"general.name":                                  "Gemma 4 31B",
+			"gemma4.embedding_length":                       uint32(4096),
+			"gemma4.block_count":                            uint32(48),
+			"gemma4.attention.head_count":                   uint32(32),
+			"gemma4.attention.head_count_kv":                uint32(8),
+			"gemma4.feed_forward_length":                    uint32(16384),
+			"gemma4.context_length":                         uint32(131072),
+			"gemma4.attention.global.head_count_kv":         uint32(4),
+			"gemma4.attention.global.key_length":            uint32(256),
+			"gemma4.attention.sliding.head_count_kv":        uint32(2),
+			"gemma4.attention.sliding.key_length":           uint32(256),
+			"gemma4.attention.k_eq_v":                       "true",
+		}
+		f := &File{Metadata: meta}
+		cfg, err := ExtractModelConfig(f)
+		if err != nil {
+			t.Fatalf("ExtractModelConfig: %v", err)
+		}
+		if cfg.Architecture != "gemma4" {
+			t.Errorf("Architecture = %q, want gemma4", cfg.Architecture)
+		}
+		if cfg.GlobalNumKVHeads != 4 {
+			t.Errorf("GlobalNumKVHeads = %d, want 4", cfg.GlobalNumKVHeads)
+		}
+		if cfg.GlobalHeadDim != 256 {
+			t.Errorf("GlobalHeadDim = %d, want 256", cfg.GlobalHeadDim)
+		}
+		if cfg.SlidingNumKVHeads != 2 {
+			t.Errorf("SlidingNumKVHeads = %d, want 2", cfg.SlidingNumKVHeads)
+		}
+		if cfg.SlidingHeadDim != 256 {
+			t.Errorf("SlidingHeadDim = %d, want 256", cfg.SlidingHeadDim)
+		}
+		if !cfg.AttentionKEqV {
+			t.Error("AttentionKEqV = false, want true")
+		}
+		// Gemma 4 defaults.
+		if cfg.SlidingWindowPattern != 6 {
+			t.Errorf("SlidingWindowPattern = %d, want 6 (default)", cfg.SlidingWindowPattern)
+		}
+		if cfg.VocabSize != 262144 {
+			t.Errorf("VocabSize = %d, want 262144 (default)", cfg.VocabSize)
+		}
+	})
+
+	t.Run("26B-A4B MoE", func(t *testing.T) {
+		meta := map[string]any{
+			"general.architecture":                          "gemma4",
+			"gemma4.embedding_length":                       uint32(3072),
+			"gemma4.block_count":                            uint32(36),
+			"gemma4.attention.head_count":                   uint32(24),
+			"gemma4.attention.head_count_kv":                uint32(8),
+			"gemma4.feed_forward_length":                    uint32(12288),
+			"gemma4.context_length":                         uint32(131072),
+			"gemma4.attention.global.head_count_kv":         uint32(4),
+			"gemma4.attention.global.key_length":            uint32(256),
+			"gemma4.attention.sliding.head_count_kv":        uint32(2),
+			"gemma4.attention.sliding.key_length":           uint32(256),
+			"gemma4.attention.k_eq_v":                       "true",
+			"gemma4.expert_count":                           uint32(128),
+			"gemma4.expert_used_count":                      uint32(8),
+		}
+		f := &File{Metadata: meta}
+		cfg, err := ExtractModelConfig(f)
+		if err != nil {
+			t.Fatalf("ExtractModelConfig: %v", err)
+		}
+		if cfg.GlobalNumKVHeads != 4 {
+			t.Errorf("GlobalNumKVHeads = %d, want 4", cfg.GlobalNumKVHeads)
+		}
+		if !cfg.AttentionKEqV {
+			t.Error("AttentionKEqV = false, want true")
+		}
+		if cfg.NumExperts != 128 {
+			t.Errorf("NumExperts = %d, want 128", cfg.NumExperts)
+		}
+		if cfg.NumExpertsPerToken != 8 {
+			t.Errorf("NumExpertsPerToken = %d, want 8", cfg.NumExpertsPerToken)
+		}
+	})
+
+	t.Run("E4B edge", func(t *testing.T) {
+		meta := map[string]any{
+			"general.architecture":                   "gemma4",
+			"gemma4.embedding_length":                uint32(2048),
+			"gemma4.block_count":                     uint32(24),
+			"gemma4.attention.head_count":            uint32(16),
+			"gemma4.attention.head_count_kv":         uint32(4),
+			"gemma4.feed_forward_length":             uint32(8192),
+			"gemma4.context_length":                  uint32(8192),
+			"gemma4.ple.hidden_size":                 uint32(256),
+			"gemma4.kv_shared_layers":                uint32(4),
+		}
+		f := &File{Metadata: meta}
+		cfg, err := ExtractModelConfig(f)
+		if err != nil {
+			t.Fatalf("ExtractModelConfig: %v", err)
+		}
+		if cfg.PLEHiddenSize != 256 {
+			t.Errorf("PLEHiddenSize = %d, want 256", cfg.PLEHiddenSize)
+		}
+		if cfg.KVSharedLayers != 4 {
+			t.Errorf("KVSharedLayers = %d, want 4", cfg.KVSharedLayers)
+		}
+		if cfg.DoubleWideMLP {
+			t.Error("DoubleWideMLP = true, want false for E4B")
+		}
+	})
+
+	t.Run("E2B edge", func(t *testing.T) {
+		meta := map[string]any{
+			"general.architecture":                   "gemma4",
+			"gemma4.embedding_length":                uint32(1536),
+			"gemma4.block_count":                     uint32(18),
+			"gemma4.attention.head_count":            uint32(12),
+			"gemma4.attention.head_count_kv":         uint32(4),
+			"gemma4.feed_forward_length":             uint32(6144),
+			"gemma4.context_length":                  uint32(8192),
+			"gemma4.ple.hidden_size":                 uint32(128),
+			"gemma4.kv_shared_layers":                uint32(4),
+			"gemma4.mlp.double_wide":                 "true",
+		}
+		f := &File{Metadata: meta}
+		cfg, err := ExtractModelConfig(f)
+		if err != nil {
+			t.Fatalf("ExtractModelConfig: %v", err)
+		}
+		if cfg.PLEHiddenSize != 128 {
+			t.Errorf("PLEHiddenSize = %d, want 128", cfg.PLEHiddenSize)
+		}
+		if cfg.KVSharedLayers != 4 {
+			t.Errorf("KVSharedLayers = %d, want 4", cfg.KVSharedLayers)
+		}
+		if !cfg.DoubleWideMLP {
+			t.Error("DoubleWideMLP = false, want true for E2B")
+		}
+		// Verify defaults still apply.
+		if cfg.SlidingWindowPattern != 6 {
+			t.Errorf("SlidingWindowPattern = %d, want 6 (default)", cfg.SlidingWindowPattern)
+		}
+		if cfg.VocabSize != 262144 {
+			t.Errorf("VocabSize = %d, want 262144 (default)", cfg.VocabSize)
+		}
+	})
+
+	t.Run("k_eq_v as uint32", func(t *testing.T) {
+		meta := map[string]any{
+			"general.architecture":         "gemma4",
+			"gemma4.embedding_length":      uint32(4096),
+			"gemma4.block_count":           uint32(48),
+			"gemma4.attention.head_count":  uint32(32),
+			"gemma4.attention.k_eq_v":      uint32(1),
+		}
+		f := &File{Metadata: meta}
+		cfg, err := ExtractModelConfig(f)
+		if err != nil {
+			t.Fatalf("ExtractModelConfig: %v", err)
+		}
+		if !cfg.AttentionKEqV {
+			t.Error("AttentionKEqV = false, want true (from uint32)")
+		}
+	})
+
+	t.Run("double_wide as uint32", func(t *testing.T) {
+		meta := map[string]any{
+			"general.architecture":         "gemma4",
+			"gemma4.embedding_length":      uint32(1536),
+			"gemma4.block_count":           uint32(18),
+			"gemma4.attention.head_count":  uint32(12),
+			"gemma4.mlp.double_wide":       uint32(1),
+		}
+		f := &File{Metadata: meta}
+		cfg, err := ExtractModelConfig(f)
+		if err != nil {
+			t.Fatalf("ExtractModelConfig: %v", err)
+		}
+		if !cfg.DoubleWideMLP {
+			t.Error("DoubleWideMLP = false, want true (from uint32)")
+		}
+	})
+
+	t.Run("explicit vocab overrides default", func(t *testing.T) {
+		meta := map[string]any{
+			"general.architecture":         "gemma4",
+			"gemma4.embedding_length":      uint32(4096),
+			"gemma4.block_count":           uint32(48),
+			"gemma4.attention.head_count":  uint32(32),
+			"gemma4.vocab_size":            uint32(300000),
+		}
+		f := &File{Metadata: meta}
+		cfg, err := ExtractModelConfig(f)
+		if err != nil {
+			t.Fatalf("ExtractModelConfig: %v", err)
+		}
+		if cfg.VocabSize != 300000 {
+			t.Errorf("VocabSize = %d, want 300000 (explicit overrides default)", cfg.VocabSize)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Wave E92-1 of Gemma 4 architecture support (E92). Adds three independent
primitives that the Gemma 4 graph builder will use in Wave E92-2:

- **T92.1.1-3**: Extend GGUF `ModelConfig` with 9 Gemma 4 fields
  (per-layer KV heads/dims, K=V flag, PLE, KV sharing, double-wide MLP).
  Add parser block and architecture defaults. 7 unit tests covering all 4
  Gemma 4 variants (31B, 26B-A4B, E4B, E2B).

- **T92.2.2**: Add `WithGELU[T]()` FFN option using tanh-approximation GELU
  (`gelu_pytorch_tanh`). Implemented via engine primitives to support both
  CPU and GPU. 2 unit tests.

- **T92.2.3**: Add `SetKEqV()` to GQA that reuses K projection output as V,
  skipping the V projection entirely. 2 unit tests including equivalence
  check with identical K/V weights.

Decision rationale: docs/adr/085-gemma4-architecture-support.md

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./model/gguf/... ./layers/core/... ./layers/attention/... -race` passes
- [ ] CI checks pass