### PR TITLE
feat(inference): Gemma 4 MoE + edge variant builders

### DIFF
--- a/inference/arch_gemma4_edge.go
+++ b/inference/arch_gemma4_edge.go
@@ -1,0 +1,383 @@
+package inference
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/zerfoo/layers/attention"
+	"github.com/zerfoo/zerfoo/layers/core"
+	"github.com/zerfoo/zerfoo/layers/embeddings"
+	"github.com/zerfoo/zerfoo/layers/normalization"
+	"github.com/zerfoo/zerfoo/model/gguf"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// buildGemma4EdgeGraph constructs a computation graph for the Gemma 4 edge
+// variants (E4B and E2B) from pre-loaded GGUF tensors. It extends the dense
+// Gemma 4 builder with three features:
+//
+//  1. Per-Layer Embeddings (PLE): Each layer adds a per-layer token embedding
+//     projected to hidden_size before the input layernorm.
+//  2. KV-Shared Layers: Groups of consecutive layers share K/V weight
+//     projections to reduce parameter count.
+//  3. Double-Wide MLP: The E2B variant uses IntermediateSize*2 for the FFN.
+//
+// The architecture is:
+//
+//	Embed*sqrt(d) -> [PLE+Add -> RMSNorm -> GQA(KV-shared) -> PostNorm -> FusedAdd+RMSNorm -> FFN(GELU,double?) -> FusedNorm+Add] x N -> RMSNorm -> LMHead(tied)
+func buildGemma4EdgeGraph(
+	tensors map[string]*tensor.TensorNumeric[float32],
+	cfg *gguf.ModelConfig,
+	engine compute.Engine[float32],
+) (*graph.Graph[float32], *tensor.TensorNumeric[float32], error) {
+	ops := numeric.Float32Ops{}
+
+	rmsEps := float32(1e-5)
+	if cfg.RMSNormEps > 0 {
+		rmsEps = cfg.RMSNormEps
+	}
+
+	tl := newTensorLookup(tensors)
+	pw := newParamWrapper[float32]()
+
+	_, isGPUEngine := engine.(compute.WeightUploader)
+	tw := func(name string, t *tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error) {
+		return transposeWeight2D(engine, isGPUEngine, name, t)
+	}
+
+	embedWeight, err := tl.Lookup("model.embed_tokens.weight")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	finalNormWeight, err := tl.Lookup("model.norm.weight")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	proxy := compute.NewEngineProxy[float32](engine)
+	builder := graph.NewBuilder[float32](proxy)
+	input := builder.Input([]int{1, 1})
+
+	// Embedding lookup with sqrt(hidden_size) scaling (Gemma family convention).
+	scale := float32(math.Sqrt(float64(cfg.HiddenSize)))
+	embNode := newEmbeddingNode(proxy, embedWeight, scale)
+	hidden := builder.AddNode(embNode, input)
+
+	defaultHeadDim := cfg.HiddenSize / cfg.NumHeads
+	if cfg.HeadDim > 0 {
+		defaultHeadDim = cfg.HeadDim
+	}
+
+	// Determine FFN intermediate size (double-wide for E2B variant).
+	intermediateSize := cfg.IntermediateSize
+	if cfg.DoubleWideMLP {
+		intermediateSize = cfg.IntermediateSize * 2
+	}
+
+	for i := 0; i < cfg.NumLayers; i++ {
+		prefix := fmt.Sprintf("model.layers.%d.", i)
+
+		// --- Per-Layer Embeddings (PLE) ---
+		// PLE adds a per-layer token embedding projected to hidden_size
+		// before the input layernorm.
+		if cfg.PLEHiddenSize > 0 {
+			// Look up PLE embedding weight for this layer.
+			var pleWeight *tensor.TensorNumeric[float32]
+			pleWeight, err = tl.Lookup(prefix + "ple.weight")
+			if err != nil {
+				// Try alternate naming convention.
+				pleWeight, err = tl.Lookup(prefix + "ple_embedding.weight")
+				if err != nil {
+					return nil, nil, fmt.Errorf("layer %d: missing PLE weight: %w", i, err)
+				}
+			}
+
+			// PLE embedding lookup (no scaling, unlike the main embedding).
+			pleEmbNode := newEmbeddingNode(proxy, pleWeight, 0)
+			pleEmb := builder.AddNode(pleEmbNode, input)
+
+			// Project PLE embedding to hidden_size.
+			pleProjW, err := tl.Lookup(prefix + "ple_proj.weight")
+			if err != nil {
+				return nil, nil, fmt.Errorf("layer %d: missing PLE projection weight: %w", i, err)
+			}
+			pleProjWT, err := tw(prefix+"ple_proj.weight", pleProjW)
+			if err != nil {
+				return nil, nil, err
+			}
+			pleProj := core.NewDenseFromParams(
+				core.NewLinearFromParam(proxy, pw.Wrap(prefix+"ple_proj.weight", pleProjWT)), nil,
+			)
+			pleProjOut := builder.AddNode(pleProj, pleEmb)
+
+			// Add PLE projection to hidden state.
+			pleAdd := &elementwiseAddNode[float32]{engine: proxy}
+			hidden = builder.AddNode(pleAdd, hidden, pleProjOut)
+		}
+
+		// Determine if this is a global or sliding layer.
+		isGlobal := cfg.SlidingWindowPattern > 0 && (i+1)%cfg.SlidingWindowPattern == 0
+
+		// Select per-layer attention configuration.
+		var numKVHeads, headDim int
+		var ropeTheta float64
+		var partialRotaryFactor float32
+
+		if isGlobal {
+			numKVHeads = cfg.GlobalNumKVHeads
+			if numKVHeads == 0 {
+				numKVHeads = cfg.NumKVHeads
+			}
+			headDim = cfg.GlobalHeadDim
+			if headDim == 0 {
+				headDim = defaultHeadDim
+			}
+			ropeTheta = cfg.RopeTheta
+			partialRotaryFactor = cfg.GlobalPartialRotaryFactor
+		} else {
+			numKVHeads = cfg.SlidingNumKVHeads
+			if numKVHeads == 0 {
+				numKVHeads = cfg.NumKVHeads
+			}
+			headDim = cfg.SlidingHeadDim
+			if headDim == 0 {
+				headDim = defaultHeadDim
+			}
+			if cfg.LocalRopeTheta > 0 {
+				ropeTheta = cfg.LocalRopeTheta
+			} else {
+				ropeTheta = cfg.RopeTheta
+			}
+			// Sliding layers use full RoPE.
+		}
+
+		// --- Input LayerNorm ---
+		inputNormW, err := tl.Lookup(prefix + "input_layernorm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		inputNorm, err := normalization.NewRMSNormFromParam[float32](
+			proxy, ops, rmsEps, pw.Wrap(prefix+"input_layernorm.weight", inputNormW),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		normed := builder.AddNode(inputNorm, hidden)
+
+		// --- Self-Attention (GQA) with optional KV sharing ---
+		// For KV-shared layers, load K/V weights from the source layer.
+		kvPrefix := prefix
+		if cfg.KVSharedLayers > 0 {
+			kvSourceLayer := (i / cfg.KVSharedLayers) * cfg.KVSharedLayers
+			kvPrefix = fmt.Sprintf("model.layers.%d.", kvSourceLayer)
+		}
+
+		qW, err := tl.Lookup(prefix + "self_attn.q_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		kW, err := tl.Lookup(kvPrefix + "self_attn.k_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		vW, err := tl.Lookup(kvPrefix + "self_attn.v_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		oW, err := tl.Lookup(prefix + "self_attn.o_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+
+		qWT, err := tw(prefix+"self_attn.q_proj.weight", qW)
+		if err != nil {
+			return nil, nil, err
+		}
+		kWT, err := tw(kvPrefix+"self_attn.k_proj.weight", kW)
+		if err != nil {
+			return nil, nil, err
+		}
+		vWT, err := tw(kvPrefix+"self_attn.v_proj.weight", vW)
+		if err != nil {
+			return nil, nil, err
+		}
+		oWT, err := tw(prefix+"self_attn.o_proj.weight", oW)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		wq := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.q_proj.weight", qWT)), nil,
+		)
+		wk := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(kvPrefix+"self_attn.k_proj.weight", kWT)), nil,
+		)
+		wv := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(kvPrefix+"self_attn.v_proj.weight", vWT)), nil,
+		)
+		wo := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.o_proj.weight", oWT)), nil,
+		)
+
+		// RoPE with per-layer theta and optional partial rotation.
+		ropeOpts := []embeddings.RotaryPositionalEmbeddingOption{
+			embeddings.WithRotaryBase(ropeTheta),
+		}
+		if partialRotaryFactor > 0 && partialRotaryFactor < 1 {
+			ropeOpts = append(ropeOpts, embeddings.WithRotaryDimFraction(float64(partialRotaryFactor)))
+		}
+		rope, err := embeddings.NewRotaryPositionalEmbedding[float32](
+			context.Background(), proxy, headDim, cfg.MaxSeqLen, ropeOpts...,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d rope: %w", i, err)
+		}
+
+		gqa, err := attention.NewGroupedQueryAttentionFromParams[float32](
+			proxy, ops, cfg.HiddenSize, cfg.NumHeads, numKVHeads,
+			wq, wk, wv, wo, rope, headDim,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d gqa: %w", i, err)
+		}
+		gqa.LayerIndex = i
+
+		// Sliding window attention for non-global layers.
+		if !isGlobal && cfg.SlidingWindow > 0 {
+			gqa.SlidingWindowSize = cfg.SlidingWindow
+		}
+
+		// K=V optimization for global layers.
+		if isGlobal && cfg.AttentionKEqV {
+			gqa.SetKEqV(true)
+		}
+
+		// Q/K norms (always on for Gemma 4).
+		qNormW, err := tl.Lookup(prefix + "self_attn.q_norm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		qNorm, err := normalization.NewRMSNormFromParam[float32](
+			proxy, ops, rmsEps, pw.Wrap(prefix+"self_attn.q_norm.weight", qNormW),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		kNormW, err := tl.Lookup(prefix + "self_attn.k_norm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		kNorm, err := normalization.NewRMSNormFromParam[float32](
+			proxy, ops, rmsEps, pw.Wrap(prefix+"self_attn.k_norm.weight", kNormW),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		gqa.SetQKNorms(qNorm, kNorm)
+		gqa.SetQKNormWeights(qNormW, kNormW, rmsEps)
+
+		attnOut := builder.AddNode(gqa, normed)
+
+		// --- Post-Attention Norm (Gemma 4 always has post-norms) ---
+		postAttnNormW, err := tl.Lookup(prefix + "post_attention_layernorm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		postAttnNorm, err := normalization.NewRMSNormFromParam[float32](
+			proxy, ops, rmsEps, pw.Wrap(prefix+"post_attention_layernorm.weight", postAttnNormW),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		attnOut = builder.AddNode(postAttnNorm, attnOut)
+
+		// --- Fused Residual Add + Pre-FFN LayerNorm ---
+		preFfnNormW, err := tl.Lookup(prefix + "pre_feedforward_layernorm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		fusedNode := &fusedAddRMSNormNode[float32]{engine: proxy, weight: preFfnNormW, eps: rmsEps}
+		normed2 := builder.AddNode(fusedNode, attnOut, hidden)
+
+		// --- FFN (GELU) ---
+		gateW, err := tl.Lookup(prefix + "mlp.gate_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		upW, err := tl.Lookup(prefix + "mlp.up_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		downW, err := tl.Lookup(prefix + "mlp.down_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ffn, err := core.NewFFN[float32](
+			prefix+"mlp", proxy, ops,
+			cfg.HiddenSize, intermediateSize, cfg.HiddenSize,
+			core.WithGELU[float32](),
+			core.WithFFNNoBias[float32](),
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d ffn: %w", i, err)
+		}
+
+		gateWT, err := tw(prefix+"mlp.gate_proj.weight", gateW)
+		if err != nil {
+			return nil, nil, err
+		}
+		upWT, err := tw(prefix+"mlp.up_proj.weight", upW)
+		if err != nil {
+			return nil, nil, err
+		}
+		downWT, err := tw(prefix+"mlp.down_proj.weight", downW)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ffnParams := ffn.Parameters()
+		ffnParams[0].Value = gateWT // w1 = gate_proj
+		ffnParams[1].Value = downWT // w2 = down_proj
+		ffnParams[2].Value = upWT   // w3 = up_proj
+
+		ffnOut := builder.AddNode(ffn, normed2)
+
+		// --- Fused Post-FFN Norm + Residual Add ---
+		postFfnNormW, err := tl.Lookup(prefix + "post_feedforward_layernorm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		fusedNormAdd := &fusedNormAddNode[float32]{engine: proxy, weight: postFfnNormW, eps: rmsEps}
+		resNode := &residualRefNode[float32]{source: fusedNode}
+		residualRef := builder.AddNode(resNode)
+		hidden = builder.AddNode(fusedNormAdd, ffnOut, residualRef)
+	}
+
+	// --- Final RMSNorm ---
+	finalNorm, err := normalization.NewRMSNormFromParam[float32](
+		proxy, ops, rmsEps, pw.Wrap("model.norm.weight", finalNormWeight),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	normedFinal := builder.AddNode(finalNorm, hidden)
+
+	// --- LM Head (tied to embedding) ---
+	lmHead := newLMHeadNode(proxy, embedWeight, cfg.LogitSoftcap)
+	output := builder.AddNode(lmHead, normedFinal)
+
+	g, err := builder.Build(output)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build graph: %w", err)
+	}
+
+	g.SetEngineProxy(proxy)
+	return g, embedWeight, nil
+}
+

--- a/inference/arch_gemma4_moe.go
+++ b/inference/arch_gemma4_moe.go
@@ -1,0 +1,513 @@
+package inference
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/zerfoo/layers/attention"
+	"github.com/zerfoo/zerfoo/layers/core"
+	"github.com/zerfoo/zerfoo/layers/embeddings"
+	"github.com/zerfoo/zerfoo/layers/normalization"
+	"github.com/zerfoo/zerfoo/model/gguf"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// buildGemma4MoEGraph constructs a computation graph for the Gemma 4 26B-A4B
+// MoE architecture from pre-loaded GGUF tensors. It extends the dense Gemma 4
+// builder with Mixture of Experts routing for FFN layers.
+//
+// Gemma 4 26B-A4B has MoE on some layers and dense FFN on others. MoE layers
+// are detected by the presence of "model.layers.{i}.mlp.gate.weight" in the
+// tensor map. Dense layers use the standard gate_proj/up_proj/down_proj weights.
+//
+// The architecture is:
+//
+//	Embed*sqrt(d) -> [RMSNorm -> GQA -> PostNorm -> FusedAdd+RMSNorm -> MoE/FFN(GELU) -> FusedNorm+Add] x N -> RMSNorm -> LMHead(tied)
+func buildGemma4MoEGraph(
+	tensors map[string]*tensor.TensorNumeric[float32],
+	cfg *gguf.ModelConfig,
+	engine compute.Engine[float32],
+) (*graph.Graph[float32], *tensor.TensorNumeric[float32], error) {
+	ops := numeric.Float32Ops{}
+
+	rmsEps := float32(1e-5)
+	if cfg.RMSNormEps > 0 {
+		rmsEps = cfg.RMSNormEps
+	}
+
+	tl := newTensorLookup(tensors)
+	pw := newParamWrapper[float32]()
+
+	_, isGPUEngine := engine.(compute.WeightUploader)
+	tw := func(name string, t *tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error) {
+		return transposeWeight2D(engine, isGPUEngine, name, t)
+	}
+
+	embedWeight, err := tl.Lookup("model.embed_tokens.weight")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	finalNormWeight, err := tl.Lookup("model.norm.weight")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	proxy := compute.NewEngineProxy[float32](engine)
+	builder := graph.NewBuilder[float32](proxy)
+	input := builder.Input([]int{1, 1})
+
+	// Embedding lookup with sqrt(hidden_size) scaling (Gemma family convention).
+	scale := float32(math.Sqrt(float64(cfg.HiddenSize)))
+	embNode := newEmbeddingNode(proxy, embedWeight, scale)
+	hidden := builder.AddNode(embNode, input)
+
+	defaultHeadDim := cfg.HiddenSize / cfg.NumHeads
+	if cfg.HeadDim > 0 {
+		defaultHeadDim = cfg.HeadDim
+	}
+
+	for i := 0; i < cfg.NumLayers; i++ {
+		prefix := fmt.Sprintf("model.layers.%d.", i)
+
+		// Determine if this is a global or sliding layer.
+		isGlobal := cfg.SlidingWindowPattern > 0 && (i+1)%cfg.SlidingWindowPattern == 0
+
+		// Select per-layer attention configuration.
+		var numKVHeads, headDim int
+		var ropeTheta float64
+		var partialRotaryFactor float32
+
+		if isGlobal {
+			numKVHeads = cfg.GlobalNumKVHeads
+			if numKVHeads == 0 {
+				numKVHeads = cfg.NumKVHeads
+			}
+			headDim = cfg.GlobalHeadDim
+			if headDim == 0 {
+				headDim = defaultHeadDim
+			}
+			ropeTheta = cfg.RopeTheta
+			partialRotaryFactor = cfg.GlobalPartialRotaryFactor
+		} else {
+			numKVHeads = cfg.SlidingNumKVHeads
+			if numKVHeads == 0 {
+				numKVHeads = cfg.NumKVHeads
+			}
+			headDim = cfg.SlidingHeadDim
+			if headDim == 0 {
+				headDim = defaultHeadDim
+			}
+			if cfg.LocalRopeTheta > 0 {
+				ropeTheta = cfg.LocalRopeTheta
+			} else {
+				ropeTheta = cfg.RopeTheta
+			}
+			// Sliding layers use full RoPE.
+		}
+
+		// --- Input LayerNorm ---
+		inputNormW, err := tl.Lookup(prefix + "input_layernorm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		inputNorm, err := normalization.NewRMSNormFromParam[float32](
+			proxy, ops, rmsEps, pw.Wrap(prefix+"input_layernorm.weight", inputNormW),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		normed := builder.AddNode(inputNorm, hidden)
+
+		// --- Self-Attention (GQA) ---
+		qW, err := tl.Lookup(prefix + "self_attn.q_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		kW, err := tl.Lookup(prefix + "self_attn.k_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		vW, err := tl.Lookup(prefix + "self_attn.v_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		oW, err := tl.Lookup(prefix + "self_attn.o_proj.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+
+		qWT, err := tw(prefix+"self_attn.q_proj.weight", qW)
+		if err != nil {
+			return nil, nil, err
+		}
+		kWT, err := tw(prefix+"self_attn.k_proj.weight", kW)
+		if err != nil {
+			return nil, nil, err
+		}
+		vWT, err := tw(prefix+"self_attn.v_proj.weight", vW)
+		if err != nil {
+			return nil, nil, err
+		}
+		oWT, err := tw(prefix+"self_attn.o_proj.weight", oW)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		wq := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.q_proj.weight", qWT)), nil,
+		)
+		wk := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.k_proj.weight", kWT)), nil,
+		)
+		wv := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.v_proj.weight", vWT)), nil,
+		)
+		wo := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.o_proj.weight", oWT)), nil,
+		)
+
+		// RoPE with per-layer theta and optional partial rotation.
+		ropeOpts := []embeddings.RotaryPositionalEmbeddingOption{
+			embeddings.WithRotaryBase(ropeTheta),
+		}
+		if partialRotaryFactor > 0 && partialRotaryFactor < 1 {
+			ropeOpts = append(ropeOpts, embeddings.WithRotaryDimFraction(float64(partialRotaryFactor)))
+		}
+		rope, err := embeddings.NewRotaryPositionalEmbedding[float32](
+			context.Background(), proxy, headDim, cfg.MaxSeqLen, ropeOpts...,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d rope: %w", i, err)
+		}
+
+		gqa, err := attention.NewGroupedQueryAttentionFromParams[float32](
+			proxy, ops, cfg.HiddenSize, cfg.NumHeads, numKVHeads,
+			wq, wk, wv, wo, rope, headDim,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d gqa: %w", i, err)
+		}
+		gqa.LayerIndex = i
+
+		// Sliding window attention for non-global layers.
+		if !isGlobal && cfg.SlidingWindow > 0 {
+			gqa.SlidingWindowSize = cfg.SlidingWindow
+		}
+
+		// K=V optimization for global layers.
+		if isGlobal && cfg.AttentionKEqV {
+			gqa.SetKEqV(true)
+		}
+
+		// Q/K norms (always on for Gemma 4).
+		qNormW, err := tl.Lookup(prefix + "self_attn.q_norm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		qNorm, err := normalization.NewRMSNormFromParam[float32](
+			proxy, ops, rmsEps, pw.Wrap(prefix+"self_attn.q_norm.weight", qNormW),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		kNormW, err := tl.Lookup(prefix + "self_attn.k_norm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		kNorm, err := normalization.NewRMSNormFromParam[float32](
+			proxy, ops, rmsEps, pw.Wrap(prefix+"self_attn.k_norm.weight", kNormW),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		gqa.SetQKNorms(qNorm, kNorm)
+		gqa.SetQKNormWeights(qNormW, kNormW, rmsEps)
+
+		// Merged QKV for Q4 quantized weights.
+		if qQ4, ok := any(qW.GetStorage()).(*tensor.Q4Storage); ok {
+			if kQ4, ok := any(kW.GetStorage()).(*tensor.Q4Storage); ok {
+				if vQ4, ok := any(vW.GetStorage()).(*tensor.Q4Storage); ok {
+					mergedQ4 := tensor.MergeQ4Storage(qQ4, kQ4, vQ4)
+					qShape := qW.Shape()
+					kShape := kW.Shape()
+					vShape := vW.Shape()
+					nMerged := qShape[0] + kShape[0] + vShape[0]
+					mergedT, mergeErr := tensor.NewWithStorage[float32]([]int{qShape[1], nMerged}, mergedQ4)
+					if mergeErr == nil {
+						gqa.SetMergedQKV(mergedT, qShape[0], kShape[0], vShape[0])
+					}
+				}
+			}
+		}
+		// Merged QKV for Q4_K quantized weights.
+		if qQ4K, ok := any(qW.GetStorage()).(*tensor.Q4KStorage); ok {
+			if kQ4K, ok := any(kW.GetStorage()).(*tensor.Q4KStorage); ok {
+				if vQ4K, ok := any(vW.GetStorage()).(*tensor.Q4KStorage); ok {
+					mergedQ4K := tensor.MergeQ4KStorage(qQ4K, kQ4K, vQ4K)
+					qShape := qW.Shape()
+					kShape := kW.Shape()
+					vShape := vW.Shape()
+					nMerged := qShape[0] + kShape[0] + vShape[0]
+					mergedT, mergeErr := tensor.NewWithStorage[float32]([]int{qShape[1], nMerged}, mergedQ4K)
+					if mergeErr == nil {
+						gqa.SetMergedQKV(mergedT, qShape[0], kShape[0], vShape[0])
+					}
+				}
+			}
+		}
+
+		attnOut := builder.AddNode(gqa, normed)
+
+		// --- Post-Attention Norm (Gemma 4 always has post-norms) ---
+		postAttnNormW, err := tl.Lookup(prefix + "post_attention_layernorm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		postAttnNorm, err := normalization.NewRMSNormFromParam[float32](
+			proxy, ops, rmsEps, pw.Wrap(prefix+"post_attention_layernorm.weight", postAttnNormW),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		attnOut = builder.AddNode(postAttnNorm, attnOut)
+
+		// --- Fused Residual Add + Pre-FFN LayerNorm ---
+		preFfnNormW, err := tl.Lookup(prefix + "pre_feedforward_layernorm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		fusedNode := &fusedAddRMSNormNode[float32]{engine: proxy, weight: preFfnNormW, eps: rmsEps}
+		normed2 := builder.AddNode(fusedNode, attnOut, hidden)
+
+		// --- FFN: MoE or Dense (GELU) ---
+		var ffnOut graph.Node[float32]
+
+		// Detect MoE layer: if router weight exists, this is a MoE layer.
+		if _, isMoE := tensors[prefix+"mlp.gate.weight"]; isMoE {
+			ffnOut, err = buildGemma4MoE(tensors, cfg, proxy, ops, builder, normed2, i, prefix, pw, tw)
+			if err != nil {
+				return nil, nil, fmt.Errorf("layer %d moe: %w", i, err)
+			}
+		} else {
+			ffnOut, err = buildGemma4DenseFFN(tensors, cfg, proxy, ops, builder, normed2, prefix, pw, tw)
+			if err != nil {
+				return nil, nil, fmt.Errorf("layer %d ffn: %w", i, err)
+			}
+		}
+
+		// --- Fused Post-FFN Norm + Residual Add ---
+		postFfnNormW, err := tl.Lookup(prefix + "post_feedforward_layernorm.weight")
+		if err != nil {
+			return nil, nil, err
+		}
+		fusedNormAdd := &fusedNormAddNode[float32]{engine: proxy, weight: postFfnNormW, eps: rmsEps}
+		resNode := &residualRefNode[float32]{source: fusedNode}
+		residualRef := builder.AddNode(resNode)
+		hidden = builder.AddNode(fusedNormAdd, ffnOut, residualRef)
+	}
+
+	// --- Final RMSNorm ---
+	finalNorm, err := normalization.NewRMSNormFromParam[float32](
+		proxy, ops, rmsEps, pw.Wrap("model.norm.weight", finalNormWeight),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	normedFinal := builder.AddNode(finalNorm, hidden)
+
+	// --- LM Head (tied to embedding) ---
+	lmHead := newLMHeadNode(proxy, embedWeight, cfg.LogitSoftcap)
+	output := builder.AddNode(lmHead, normedFinal)
+
+	g, err := builder.Build(output)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build graph: %w", err)
+	}
+
+	g.SetEngineProxy(proxy)
+	return g, embedWeight, nil
+}
+
+// buildGemma4MoE constructs the MoE sub-graph for a single Gemma 4 layer.
+// Expert weights are stored per-expert (model.layers.{i}.mlp.experts.{j}.{gate,up,down}_proj.weight).
+func buildGemma4MoE(
+	tensors map[string]*tensor.TensorNumeric[float32],
+	cfg *gguf.ModelConfig,
+	proxy *compute.EngineProxy[float32],
+	ops numeric.Float32Ops,
+	builder *graph.Builder[float32],
+	normed graph.Node[float32],
+	layerIdx int,
+	prefix string,
+	pw paramWrapper[float32],
+	tw func(string, *tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error),
+) (graph.Node[float32], error) {
+	numExperts := cfg.NumExperts
+	topK := cfg.NumExpertsPerToken
+	if topK == 0 {
+		topK = 2
+	}
+
+	tl := newTensorLookup(tensors)
+
+	// Load router weight: [num_experts, hidden_size].
+	routerW, err := tl.Lookup(prefix + "mlp.gate.weight")
+	if err != nil {
+		return nil, err
+	}
+
+	// Build expert FFNs with per-expert weights.
+	experts := make([]graph.Node[float32], numExperts)
+	for j := 0; j < numExperts; j++ {
+		expertPrefix := fmt.Sprintf("%smlp.experts.%d.", prefix, j)
+		name := fmt.Sprintf("layer%d_expert%d", layerIdx, j)
+
+		gateW, err := tl.Lookup(expertPrefix + "gate_proj.weight")
+		if err != nil {
+			return nil, fmt.Errorf("expert %d gate_proj: %w", j, err)
+		}
+		upW, err := tl.Lookup(expertPrefix + "up_proj.weight")
+		if err != nil {
+			return nil, fmt.Errorf("expert %d up_proj: %w", j, err)
+		}
+		downW, err := tl.Lookup(expertPrefix + "down_proj.weight")
+		if err != nil {
+			return nil, fmt.Errorf("expert %d down_proj: %w", j, err)
+		}
+
+		gateWT, err := tw(expertPrefix+"gate_proj.weight", gateW)
+		if err != nil {
+			return nil, err
+		}
+		upWT, err := tw(expertPrefix+"up_proj.weight", upW)
+		if err != nil {
+			return nil, err
+		}
+		downWT, err := tw(expertPrefix+"down_proj.weight", downW)
+		if err != nil {
+			return nil, err
+		}
+
+		gateParam := pw.Wrap(name+"_gate", gateWT)
+		upParam := pw.Wrap(name+"_up", upWT)
+		downParam := pw.Wrap(name+"_down", downWT)
+
+		w1 := core.NewDenseFromParams(core.NewLinearFromParam(proxy, gateParam), nil)
+		w2 := core.NewDenseFromParams(core.NewLinearFromParam(proxy, downParam), nil)
+		w3 := core.NewDenseFromParams(core.NewLinearFromParam(proxy, upParam), nil)
+
+		expertFFN, err := core.NewFFNFromDense[float32](name, proxy, ops, w1, w2, w3,
+			core.WithGELU[float32](), core.WithFFNNoBias[float32]())
+		if err != nil {
+			return nil, fmt.Errorf("expert %d: %w", j, err)
+		}
+		experts[j] = expertFFN
+	}
+
+	gate := core.NewMoEGate[float32](proxy, ops, topK)
+	moe := core.NewMixtureOfExperts[float32](proxy, ops, gate, experts, numExperts, topK)
+
+	// Reshape [batch, seqLen, hidden] -> [seqLen, hidden] for MoE.
+	reshapeNode := &deepSeekReshapeNode[float32]{engine: proxy, flatten: true}
+	flat := builder.AddNode(reshapeNode, normed)
+
+	// Router weight as constant node.
+	routerNode := &deepSeekConstNode[float32]{value: routerW}
+	routerOut := builder.AddNode(routerNode)
+
+	moeOut := builder.AddNode(moe, flat, routerOut)
+
+	// Reshape back to [batch, seqLen, hidden].
+	unreshapeNode := &deepSeekReshapeNode[float32]{engine: proxy, flatten: false}
+	return builder.AddNode(unreshapeNode, moeOut, normed), nil
+}
+
+// buildGemma4DenseFFN builds a standard GELU FFN for dense layers in the MoE model.
+func buildGemma4DenseFFN(
+	tensors map[string]*tensor.TensorNumeric[float32],
+	cfg *gguf.ModelConfig,
+	proxy *compute.EngineProxy[float32],
+	ops numeric.Float32Ops,
+	builder *graph.Builder[float32],
+	normed graph.Node[float32],
+	prefix string,
+	pw paramWrapper[float32],
+	tw func(string, *tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error),
+) (graph.Node[float32], error) {
+	tl := newTensorLookup(tensors)
+
+	gateW, err := tl.Lookup(prefix + "mlp.gate_proj.weight")
+	if err != nil {
+		return nil, err
+	}
+	upW, err := tl.Lookup(prefix + "mlp.up_proj.weight")
+	if err != nil {
+		return nil, err
+	}
+	downW, err := tl.Lookup(prefix + "mlp.down_proj.weight")
+	if err != nil {
+		return nil, err
+	}
+
+	ffn, err := core.NewFFN[float32](
+		prefix+"mlp", proxy, ops,
+		cfg.HiddenSize, cfg.IntermediateSize, cfg.HiddenSize,
+		core.WithGELU[float32](),
+		core.WithFFNNoBias[float32](),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	gateWT, err := tw(prefix+"mlp.gate_proj.weight", gateW)
+	if err != nil {
+		return nil, err
+	}
+	upWT, err := tw(prefix+"mlp.up_proj.weight", upW)
+	if err != nil {
+		return nil, err
+	}
+	downWT, err := tw(prefix+"mlp.down_proj.weight", downW)
+	if err != nil {
+		return nil, err
+	}
+
+	ffnParams := ffn.Parameters()
+	ffnParams[0].Value = gateWT // w1 = gate_proj
+	ffnParams[1].Value = downWT // w2 = down_proj
+	ffnParams[2].Value = upWT   // w3 = up_proj
+
+	// Merged Gate+Up for Q4 quantized weights.
+	if gateQ4, ok := any(gateW.GetStorage()).(*tensor.Q4Storage); ok {
+		if upQ4, ok := any(upW.GetStorage()).(*tensor.Q4Storage); ok {
+			mergedGateUpQ4 := tensor.MergeQ4Storage(gateQ4, upQ4)
+			gateShape := gateW.Shape()
+			upShape := upW.Shape()
+			nMerged := gateShape[0] + upShape[0]
+			mergedT, mergeErr := tensor.NewWithStorage[float32]([]int{gateShape[1], nMerged}, mergedGateUpQ4)
+			if mergeErr == nil {
+				ffn.SetMergedGateUp(mergedT, gateShape[0], upShape[0])
+			}
+		}
+	}
+	// Merged Gate+Up for Q4_K quantized weights.
+	if gateQ4K, ok := any(gateW.GetStorage()).(*tensor.Q4KStorage); ok {
+		if upQ4K, ok := any(upW.GetStorage()).(*tensor.Q4KStorage); ok {
+			mergedGateUpQ4K := tensor.MergeQ4KStorage(gateQ4K, upQ4K)
+			gateShape := gateW.Shape()
+			upShape := upW.Shape()
+			nMerged := gateShape[0] + upShape[0]
+			mergedT, mergeErr := tensor.NewWithStorage[float32]([]int{gateShape[1], nMerged}, mergedGateUpQ4K)
+			if mergeErr == nil {
+				ffn.SetMergedGateUp(mergedT, gateShape[0], upShape[0])
+			}
+		}
+	}
+
+	return builder.AddNode(ffn, normed), nil
+}

--- a/inference/arch_gemma4_test.go
+++ b/inference/arch_gemma4_test.go
@@ -207,6 +207,204 @@ func TestBuildGemma4Graph_HybridAttention(t *testing.T) {
 	assertGraphForwardNonNaN(t, g, cfg.VocabSize)
 }
 
+// makeGemma4_26BTestTensors creates a minimal set of Gemma 4 MoE architecture
+// tensors. Layers at even indices (0, 2, ...) are MoE layers; odd indices are
+// dense FFN layers. This mirrors the real Gemma 4 26B-A4B pattern where some
+// layers have MoE and others use dense FFN.
+func makeGemma4_26BTestTensors(cfg *gguf.ModelConfig) map[string]*tensor.TensorNumeric[float32] {
+	hidden := cfg.HiddenSize
+	headDim := cfg.HiddenSize / cfg.NumHeads
+	if cfg.HeadDim > 0 {
+		headDim = cfg.HeadDim
+	}
+	inter := cfg.IntermediateSize
+
+	fill := func(shape []int) *tensor.TensorNumeric[float32] {
+		size := 1
+		for _, d := range shape {
+			size *= d
+		}
+		data := make([]float32, size)
+		for i := range data {
+			data[i] = 0.02 * float32(i%7+1) * 0.1
+		}
+		t, _ := tensor.New(shape, data)
+		return t
+	}
+	ones := func(shape []int) *tensor.TensorNumeric[float32] {
+		size := 1
+		for _, d := range shape {
+			size *= d
+		}
+		data := make([]float32, size)
+		for i := range data {
+			data[i] = 1.0
+		}
+		t, _ := tensor.New(shape, data)
+		return t
+	}
+
+	tensors := make(map[string]*tensor.TensorNumeric[float32])
+	tensors["model.embed_tokens.weight"] = fill([]int{cfg.VocabSize, hidden})
+	tensors["model.norm.weight"] = ones([]int{hidden})
+
+	kvDim := headDim * cfg.NumKVHeads
+	for i := 0; i < cfg.NumLayers; i++ {
+		prefix := "model.layers." + itoa(i) + "."
+
+		// Attention weights (same for all layers).
+		tensors[prefix+"input_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"self_attn.q_proj.weight"] = fill([]int{hidden, hidden})
+		tensors[prefix+"self_attn.k_proj.weight"] = fill([]int{kvDim, hidden})
+		tensors[prefix+"self_attn.v_proj.weight"] = fill([]int{kvDim, hidden})
+		tensors[prefix+"self_attn.o_proj.weight"] = fill([]int{hidden, hidden})
+		tensors[prefix+"post_attention_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"pre_feedforward_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"post_feedforward_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"self_attn.q_norm.weight"] = ones([]int{headDim})
+		tensors[prefix+"self_attn.k_norm.weight"] = ones([]int{headDim})
+
+		// Even layers are MoE, odd layers are dense.
+		if i%2 == 0 {
+			// MoE layer: router + per-expert weights.
+			tensors[prefix+"mlp.gate.weight"] = fill([]int{cfg.NumExperts, hidden})
+			for j := 0; j < cfg.NumExperts; j++ {
+				ep := prefix + "mlp.experts." + itoa(j) + "."
+				tensors[ep+"gate_proj.weight"] = fill([]int{inter, hidden})
+				tensors[ep+"up_proj.weight"] = fill([]int{inter, hidden})
+				tensors[ep+"down_proj.weight"] = fill([]int{hidden, inter})
+			}
+		} else {
+			// Dense FFN layer.
+			tensors[prefix+"mlp.gate_proj.weight"] = fill([]int{inter, hidden})
+			tensors[prefix+"mlp.up_proj.weight"] = fill([]int{inter, hidden})
+			tensors[prefix+"mlp.down_proj.weight"] = fill([]int{hidden, inter})
+		}
+	}
+
+	return tensors
+}
+
+func TestBuildGemma4MoEGraph_Builds(t *testing.T) {
+	cfg := &gguf.ModelConfig{
+		Architecture:         "gemma4moe",
+		VocabSize:            32,
+		HiddenSize:           16,
+		NumLayers:            4,
+		NumHeads:             4,
+		NumKVHeads:           2,
+		IntermediateSize:     32,
+		MaxSeqLen:            64,
+		RopeTheta:            1000000.0,
+		LocalRopeTheta:       10000.0,
+		SlidingWindowPattern: 6,
+		SlidingWindow:        4096,
+		LogitSoftcap:         30.0,
+		GlobalNumKVHeads:     2,
+		GlobalHeadDim:        4,
+		SlidingNumKVHeads:    2,
+		SlidingHeadDim:       4,
+		AttentionKEqV:        true,
+		NumExperts:           4,
+		NumExpertsPerToken:   2,
+	}
+	tensors := makeGemma4_26BTestTensors(cfg)
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	g, emb, err := buildGemma4MoEGraph(tensors, cfg, engine)
+	if err != nil {
+		t.Fatalf("buildGemma4MoEGraph: %v", err)
+	}
+	if g == nil {
+		t.Fatal("graph is nil")
+	}
+	if emb == nil {
+		t.Fatal("embedding is nil")
+	}
+}
+
+func TestBuildGemma4MoEGraph_ForwardNonNaN(t *testing.T) {
+	cfg := &gguf.ModelConfig{
+		Architecture:         "gemma4moe",
+		VocabSize:            32,
+		HiddenSize:           16,
+		NumLayers:            4,
+		NumHeads:             4,
+		NumKVHeads:           2,
+		IntermediateSize:     32,
+		MaxSeqLen:            64,
+		RopeTheta:            1000000.0,
+		LocalRopeTheta:       10000.0,
+		SlidingWindowPattern: 6,
+		SlidingWindow:        4096,
+		LogitSoftcap:         30.0,
+		GlobalNumKVHeads:     2,
+		GlobalHeadDim:        4,
+		SlidingNumKVHeads:    2,
+		SlidingHeadDim:       4,
+		AttentionKEqV:        true,
+		NumExperts:           4,
+		NumExpertsPerToken:   2,
+	}
+	tensors := makeGemma4_26BTestTensors(cfg)
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	g, _, err := buildGemma4MoEGraph(tensors, cfg, engine)
+	if err != nil {
+		t.Fatalf("buildGemma4MoEGraph: %v", err)
+	}
+
+	assertGraphForwardNonNaN(t, g, cfg.VocabSize)
+}
+
+func TestBuildGemma4MoEGraph_MoELayerDetection(t *testing.T) {
+	// Verify that layers with router weights are MoE and others are dense.
+	// We build with 4 layers: even (0,2) = MoE, odd (1,3) = dense.
+	cfg := &gguf.ModelConfig{
+		Architecture:         "gemma4moe",
+		VocabSize:            32,
+		HiddenSize:           16,
+		NumLayers:            4,
+		NumHeads:             4,
+		NumKVHeads:           2,
+		IntermediateSize:     32,
+		MaxSeqLen:            64,
+		RopeTheta:            1000000.0,
+		LocalRopeTheta:       10000.0,
+		SlidingWindowPattern: 6,
+		SlidingWindow:        4096,
+		LogitSoftcap:         30.0,
+		GlobalNumKVHeads:     2,
+		GlobalHeadDim:        4,
+		SlidingNumKVHeads:    2,
+		SlidingHeadDim:       4,
+		NumExperts:           4,
+		NumExpertsPerToken:   2,
+	}
+	tensors := makeGemma4_26BTestTensors(cfg)
+
+	// Verify MoE layers have router weights.
+	for i := 0; i < cfg.NumLayers; i++ {
+		prefix := "model.layers." + itoa(i) + "."
+		_, hasRouter := tensors[prefix+"mlp.gate.weight"]
+		if i%2 == 0 && !hasRouter {
+			t.Errorf("layer %d should be MoE (has router), but router weight not found", i)
+		}
+		if i%2 != 0 && hasRouter {
+			t.Errorf("layer %d should be dense (no router), but router weight found", i)
+		}
+	}
+
+	// Build succeeds with mixed MoE/dense layers.
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	g, _, err := buildGemma4MoEGraph(tensors, cfg, engine)
+	if err != nil {
+		t.Fatalf("buildGemma4MoEGraph mixed layers: %v", err)
+	}
+
+	assertGraphForwardNonNaN(t, g, cfg.VocabSize)
+}
+
 func TestBuildGemma4Graph_KEqV(t *testing.T) {
 	// Verify K=V on global layers by setting AttentionKEqV=true.
 	// With SlidingWindowPattern=2 and NumLayers=2, layer 1 is global.

--- a/inference/arch_gemma4_test.go
+++ b/inference/arch_gemma4_test.go
@@ -438,3 +438,274 @@ func TestBuildGemma4Graph_KEqV(t *testing.T) {
 
 	assertGraphForwardNonNaN(t, g, cfg.VocabSize)
 }
+
+// --- Gemma 4 Edge variant tests (E4B, E2B) ---
+
+// makeGemma4_E4BTestTensors creates tensors for the Gemma 4 E4B edge variant
+// with PLE (Per-Layer Embeddings) and KV-shared layers.
+func makeGemma4_E4BTestTensors(cfg *gguf.ModelConfig) map[string]*tensor.TensorNumeric[float32] {
+	tensors := makeGemma4_31BTestTensors(cfg)
+
+	hidden := cfg.HiddenSize
+	pleHidden := cfg.PLEHiddenSize
+
+	fill := func(shape []int) *tensor.TensorNumeric[float32] {
+		size := 1
+		for _, d := range shape {
+			size *= d
+		}
+		data := make([]float32, size)
+		for i := range data {
+			data[i] = 0.02 * float32(i%7+1) * 0.1
+		}
+		t, _ := tensor.New(shape, data)
+		return t
+	}
+
+	for i := 0; i < cfg.NumLayers; i++ {
+		prefix := "model.layers." + itoa(i) + "."
+		// PLE embedding weight: [vocab, ple_hidden_size].
+		tensors[prefix+"ple.weight"] = fill([]int{cfg.VocabSize, pleHidden})
+		// PLE projection weight: [hidden_size, ple_hidden_size] (GGUF convention: out, in).
+		tensors[prefix+"ple_proj.weight"] = fill([]int{hidden, pleHidden})
+	}
+
+	return tensors
+}
+
+// makeGemma4_E2BTestTensors creates tensors for the Gemma 4 E2B edge variant
+// with PLE, KV-shared layers, and double-wide MLP.
+func makeGemma4_E2BTestTensors(cfg *gguf.ModelConfig) map[string]*tensor.TensorNumeric[float32] {
+	hidden := cfg.HiddenSize
+	headDim := cfg.HiddenSize / cfg.NumHeads
+	if cfg.HeadDim > 0 {
+		headDim = cfg.HeadDim
+	}
+	pleHidden := cfg.PLEHiddenSize
+	inter := cfg.IntermediateSize
+	if cfg.DoubleWideMLP {
+		inter = cfg.IntermediateSize * 2
+	}
+
+	fill := func(shape []int) *tensor.TensorNumeric[float32] {
+		size := 1
+		for _, d := range shape {
+			size *= d
+		}
+		data := make([]float32, size)
+		for i := range data {
+			data[i] = 0.02 * float32(i%7+1) * 0.1
+		}
+		t, _ := tensor.New(shape, data)
+		return t
+	}
+	ones := func(shape []int) *tensor.TensorNumeric[float32] {
+		size := 1
+		for _, d := range shape {
+			size *= d
+		}
+		data := make([]float32, size)
+		for i := range data {
+			data[i] = 1.0
+		}
+		t, _ := tensor.New(shape, data)
+		return t
+	}
+
+	tensors := make(map[string]*tensor.TensorNumeric[float32])
+	tensors["model.embed_tokens.weight"] = fill([]int{cfg.VocabSize, hidden})
+	tensors["model.norm.weight"] = ones([]int{hidden})
+
+	kvDim := headDim * cfg.NumKVHeads
+	for i := 0; i < cfg.NumLayers; i++ {
+		prefix := "model.layers." + itoa(i) + "."
+
+		// Standard Gemma 4 layer tensors.
+		tensors[prefix+"input_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"self_attn.q_proj.weight"] = fill([]int{hidden, hidden})
+		tensors[prefix+"self_attn.k_proj.weight"] = fill([]int{kvDim, hidden})
+		tensors[prefix+"self_attn.v_proj.weight"] = fill([]int{kvDim, hidden})
+		tensors[prefix+"self_attn.o_proj.weight"] = fill([]int{hidden, hidden})
+		tensors[prefix+"post_attention_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"pre_feedforward_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"post_feedforward_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"self_attn.q_norm.weight"] = ones([]int{headDim})
+		tensors[prefix+"self_attn.k_norm.weight"] = ones([]int{headDim})
+
+		// Double-wide MLP.
+		tensors[prefix+"mlp.gate_proj.weight"] = fill([]int{inter, hidden})
+		tensors[prefix+"mlp.up_proj.weight"] = fill([]int{inter, hidden})
+		tensors[prefix+"mlp.down_proj.weight"] = fill([]int{hidden, inter})
+
+		// PLE tensors.
+		tensors[prefix+"ple.weight"] = fill([]int{cfg.VocabSize, pleHidden})
+		tensors[prefix+"ple_proj.weight"] = fill([]int{hidden, pleHidden})
+	}
+
+	return tensors
+}
+
+func TestBuildGemma4EdgeGraph_E4B_Builds(t *testing.T) {
+	cfg := &gguf.ModelConfig{
+		Architecture:         "gemma4e",
+		VocabSize:            32,
+		HiddenSize:           16,
+		NumLayers:            4,
+		NumHeads:             4,
+		NumKVHeads:           2,
+		IntermediateSize:     32,
+		MaxSeqLen:            64,
+		RopeTheta:            1000000.0,
+		LocalRopeTheta:       10000.0,
+		SlidingWindowPattern: 6,
+		SlidingWindow:        4096,
+		LogitSoftcap:         30.0,
+		GlobalNumKVHeads:     2,
+		GlobalHeadDim:        4,
+		SlidingNumKVHeads:    2,
+		SlidingHeadDim:       4,
+		AttentionKEqV:        true,
+		PLEHiddenSize:        4,
+		KVSharedLayers:       2,
+	}
+	tensors := makeGemma4_E4BTestTensors(cfg)
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	g, emb, err := buildGemma4EdgeGraph(tensors, cfg, engine)
+	if err != nil {
+		t.Fatalf("buildGemma4EdgeGraph E4B: %v", err)
+	}
+	if g == nil {
+		t.Fatal("graph is nil")
+	}
+	if emb == nil {
+		t.Fatal("embedding is nil")
+	}
+}
+
+func TestBuildGemma4EdgeGraph_E4B_ForwardNonNaN(t *testing.T) {
+	cfg := &gguf.ModelConfig{
+		Architecture:         "gemma4e",
+		VocabSize:            32,
+		HiddenSize:           16,
+		NumLayers:            4,
+		NumHeads:             4,
+		NumKVHeads:           2,
+		IntermediateSize:     32,
+		MaxSeqLen:            64,
+		RopeTheta:            1000000.0,
+		LocalRopeTheta:       10000.0,
+		SlidingWindowPattern: 6,
+		SlidingWindow:        4096,
+		LogitSoftcap:         30.0,
+		GlobalNumKVHeads:     2,
+		GlobalHeadDim:        4,
+		SlidingNumKVHeads:    2,
+		SlidingHeadDim:       4,
+		AttentionKEqV:        true,
+		PLEHiddenSize:        4,
+		KVSharedLayers:       2,
+	}
+	tensors := makeGemma4_E4BTestTensors(cfg)
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	g, _, err := buildGemma4EdgeGraph(tensors, cfg, engine)
+	if err != nil {
+		t.Fatalf("buildGemma4EdgeGraph E4B: %v", err)
+	}
+
+	assertGraphForwardNonNaN(t, g, cfg.VocabSize)
+}
+
+func TestBuildGemma4EdgeGraph_E2B_DoubleWideMLP(t *testing.T) {
+	cfg := &gguf.ModelConfig{
+		Architecture:         "gemma4e",
+		VocabSize:            32,
+		HiddenSize:           16,
+		NumLayers:            2,
+		NumHeads:             4,
+		NumKVHeads:           2,
+		IntermediateSize:     32,
+		MaxSeqLen:            64,
+		RopeTheta:            1000000.0,
+		LocalRopeTheta:       10000.0,
+		SlidingWindowPattern: 6,
+		SlidingWindow:        4096,
+		LogitSoftcap:         30.0,
+		GlobalNumKVHeads:     2,
+		GlobalHeadDim:        4,
+		SlidingNumKVHeads:    2,
+		SlidingHeadDim:       4,
+		PLEHiddenSize:        4,
+		KVSharedLayers:       2,
+		DoubleWideMLP:        true,
+	}
+	tensors := makeGemma4_E2BTestTensors(cfg)
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	g, _, err := buildGemma4EdgeGraph(tensors, cfg, engine)
+	if err != nil {
+		t.Fatalf("buildGemma4EdgeGraph E2B double-wide: %v", err)
+	}
+
+	assertGraphForwardNonNaN(t, g, cfg.VocabSize)
+}
+
+func TestBuildGemma4EdgeGraph_KVSharing(t *testing.T) {
+	// 4 layers with KVSharedLayers=2: layers 0-1 share KV, layers 2-3 share KV.
+	// Verify that the shared layers reference the same underlying weight tensors.
+	cfg := &gguf.ModelConfig{
+		Architecture:         "gemma4e",
+		VocabSize:            32,
+		HiddenSize:           16,
+		NumLayers:            4,
+		NumHeads:             4,
+		NumKVHeads:           2,
+		IntermediateSize:     32,
+		MaxSeqLen:            64,
+		RopeTheta:            1000000.0,
+		LocalRopeTheta:       10000.0,
+		SlidingWindowPattern: 6,
+		SlidingWindow:        4096,
+		LogitSoftcap:         30.0,
+		GlobalNumKVHeads:     2,
+		GlobalHeadDim:        4,
+		SlidingNumKVHeads:    2,
+		SlidingHeadDim:       4,
+		PLEHiddenSize:        4,
+		KVSharedLayers:       2,
+	}
+	tensors := makeGemma4_E4BTestTensors(cfg)
+
+	// Verify that layers 0 and 1 share the same K/V tensors (from layer 0).
+	kLayer0 := tensors["model.layers.0.self_attn.k_proj.weight"]
+	vLayer0 := tensors["model.layers.0.self_attn.v_proj.weight"]
+	kLayer1 := tensors["model.layers.1.self_attn.k_proj.weight"]
+	vLayer1 := tensors["model.layers.1.self_attn.v_proj.weight"]
+
+	// In the tensor map, each layer has its own weights. But the builder should
+	// load K/V from the source layer. Verify the builder resolves KV correctly
+	// by checking that the source tensors exist and the build succeeds.
+	if kLayer0 == nil || vLayer0 == nil {
+		t.Fatal("source layer 0 K/V tensors missing")
+	}
+	if kLayer1 == nil || vLayer1 == nil {
+		t.Fatal("layer 1 K/V tensors missing (expected for tensor map, builder uses layer 0's)")
+	}
+
+	// Layers 2-3 share KV from layer 2.
+	kLayer2 := tensors["model.layers.2.self_attn.k_proj.weight"]
+	vLayer2 := tensors["model.layers.2.self_attn.v_proj.weight"]
+	if kLayer2 == nil || vLayer2 == nil {
+		t.Fatal("source layer 2 K/V tensors missing")
+	}
+
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	g, _, err := buildGemma4EdgeGraph(tensors, cfg, engine)
+	if err != nil {
+		t.Fatalf("buildGemma4EdgeGraph KV sharing: %v", err)
+	}
+
+	assertGraphForwardNonNaN(t, g, cfg.VocabSize)
+}

--- a/inference/registry_init.go
+++ b/inference/registry_init.go
@@ -7,6 +7,7 @@ func init() {
 	RegisterArchitecture("gemma", buildGemmaGraph)
 	RegisterArchitecture("gemma3", buildGemmaGraph)
 	RegisterArchitecture("gemma4", buildGemma4Graph)
+	RegisterArchitecture("gemma4moe", buildGemma4MoEGraph)
 	RegisterArchitecture("qwen2", buildQwenGraph)
 	RegisterArchitecture("mistral", buildMistralGraph)
 	RegisterArchitecture("phi", buildPhiGraph)

--- a/inference/registry_init.go
+++ b/inference/registry_init.go
@@ -8,6 +8,7 @@ func init() {
 	RegisterArchitecture("gemma3", buildGemmaGraph)
 	RegisterArchitecture("gemma4", buildGemma4Graph)
 	RegisterArchitecture("gemma4moe", buildGemma4MoEGraph)
+	RegisterArchitecture("gemma4e", buildGemma4EdgeGraph)
 	RegisterArchitecture("qwen2", buildQwenGraph)
 	RegisterArchitecture("mistral", buildMistralGraph)
 	RegisterArchitecture("phi", buildPhiGraph)


### PR DESCRIPTION
## Summary

Wave E92-3 of Gemma 4 architecture support (E92). Adds MoE and edge variant builders:

- **T92.3.1-4**: `arch_gemma4_moe.go` -- MoE variant (26B-A4B) with per-layer
  MoE/dense FFN detection, 128-expert routing, GELU expert FFNs. Registered as
  "gemma4moe". 3 new tests.

- **T92.4.1-6**: `arch_gemma4_edge.go` -- Edge variants (E4B/E2B) with Per-Layer
  Embeddings (PLE), KV-shared layers, and double-wide MLP option. Registered as
  "gemma4e". 4 new tests.

Decision rationale: docs/adr/085-gemma4-architecture-support.md

## Linked Issues
- fixes #413 (T92.3.1)
- fixes #414 (T92.3.2)
- fixes #415 (T92.3.3)
- fixes #416 (T92.3.4)
- fixes #417 (T92.4.1)
- fixes #418 (T92.4.2)
- fixes #419 (T92.4.3)
- fixes #420 (T92.4.4)
- fixes #421 (T92.4.5)
- fixes #422 (T92.4.6)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./inference/... -run TestBuildGemma4 -race` -- 12 tests pass
- [ ] CI checks pass