### PR TITLE
E95-1: External K/V plumbing for GroupedQueryAttention (Gemma 4 pre-req)

### DIFF
--- a/inference/kv_donor.go
+++ b/inference/kv_donor.go
@@ -1,0 +1,41 @@
+package inference
+
+import "fmt"
+
+// LayerType classifies a transformer layer's attention mode.
+type LayerType int
+
+const (
+	// LayerTypeSliding denotes a sliding-window attention layer.
+	LayerTypeSliding LayerType = iota
+	// LayerTypeGlobal denotes a full (global) attention layer.
+	LayerTypeGlobal
+)
+
+// ResolveKVDonor returns the donor layer index for a shared-KV layer.
+//
+// Per HuggingFace transformers modeling_gemma4.py lines 1148-1160, a
+// shared-KV layer reuses K/V from the last non-shared layer of the same
+// attention type (sliding vs global).
+//
+// Preconditions: layerIdx >= firstSharedIdx, 0 <= firstSharedIdx <= len(layerTypes),
+// len(layerTypes) > layerIdx.
+// Panics if any precondition is violated (caller bug).
+func ResolveKVDonor(layerIdx, firstSharedIdx int, layerTypes []LayerType) int {
+	if firstSharedIdx < 0 || firstSharedIdx > len(layerTypes) {
+		panic(fmt.Sprintf("ResolveKVDonor: firstSharedIdx %d out of range [0,%d]", firstSharedIdx, len(layerTypes)))
+	}
+	if layerIdx < firstSharedIdx {
+		panic(fmt.Sprintf("ResolveKVDonor: layerIdx %d < firstSharedIdx %d", layerIdx, firstSharedIdx))
+	}
+	if layerIdx >= len(layerTypes) {
+		panic(fmt.Sprintf("ResolveKVDonor: layerIdx %d >= len(layerTypes) %d", layerIdx, len(layerTypes)))
+	}
+	want := layerTypes[layerIdx]
+	for j := layerIdx - 1; j >= 0; j-- {
+		if j < firstSharedIdx && layerTypes[j] == want {
+			return j
+		}
+	}
+	panic(fmt.Sprintf("ResolveKVDonor: no donor found for layerIdx %d (firstSharedIdx=%d)", layerIdx, firstSharedIdx))
+}

--- a/inference/kv_donor_test.go
+++ b/inference/kv_donor_test.go
@@ -1,0 +1,159 @@
+package inference
+
+import "testing"
+
+// gemma4E2BLayerTypes returns the Gemma 4 E2B attention pattern:
+// 35 layers, every 5th is global (full) attention at indices 4,9,14,19,24,29,34.
+// All other layers are sliding-window.
+func gemma4E2BLayerTypes() []LayerType {
+	types := make([]LayerType, 35)
+	for i := range types {
+		if (i+1)%5 == 0 {
+			types[i] = LayerTypeGlobal
+		} else {
+			types[i] = LayerTypeSliding
+		}
+	}
+	return types
+}
+
+func TestResolveKVDonor(t *testing.T) {
+	t.Parallel()
+	gemma := gemma4E2BLayerTypes()
+	const firstShared = 15
+
+	tests := []struct {
+		name           string
+		layerIdx       int
+		firstSharedIdx int
+		layerTypes     []LayerType
+		want           int
+	}{
+		{
+			// Shared sliding layer 20: walk back past 19(G), 18..15(shared),
+			// 14(G), to 13(sliding, <15) -> donor=13.
+			name:           "gemma4_e2b_layer20_sliding_donor13",
+			layerIdx:       20,
+			firstSharedIdx: firstShared,
+			layerTypes:     gemma,
+			want:           13,
+		},
+		{
+			// Shared global layer 24: walk back past 23..15(shared), to
+			// 14(global, <15) -> donor=14.
+			name:           "gemma4_e2b_layer24_global_donor14",
+			layerIdx:       24,
+			firstSharedIdx: firstShared,
+			layerTypes:     gemma,
+			want:           14,
+		},
+		{
+			// Shared sliding layer 25: walk back past 24(G), 23..15(shared),
+			// 14(G), to 13(sliding, <15) -> donor=13.
+			name:           "gemma4_e2b_layer25_sliding_donor13",
+			layerIdx:       25,
+			firstSharedIdx: firstShared,
+			layerTypes:     gemma,
+			want:           13,
+		},
+		{
+			// Shared global layer 34: walk back past 33..15 (all shared,
+			// rejected by j<firstSharedIdx), to 14(global, <15) -> donor=14.
+			// Note: 29 is global but 29>=firstSharedIdx=15 so it is a shared
+			// layer itself and cannot be a donor.
+			name:           "gemma4_e2b_layer34_global_donor14",
+			layerIdx:       34,
+			firstSharedIdx: firstShared,
+			layerTypes:     gemma,
+			want:           14,
+		},
+		{
+			// Boundary: firstSharedIdx == layerIdx, pick immediately
+			// preceding same-type layer.
+			name:           "gemma4_e2b_layer15_sliding_donor13",
+			layerIdx:       15,
+			firstSharedIdx: firstShared,
+			layerTypes:     gemma,
+			want:           13,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveKVDonor(tc.layerIdx, tc.firstSharedIdx, tc.layerTypes)
+			if got != tc.want {
+				t.Fatalf("ResolveKVDonor(%d,%d,...) = %d, want %d",
+					tc.layerIdx, tc.firstSharedIdx, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveKVDonor_PanicLayerIdxLessThanFirstShared(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when layerIdx < firstSharedIdx")
+		}
+	}()
+	types := []LayerType{LayerTypeSliding, LayerTypeSliding, LayerTypeGlobal}
+	_ = ResolveKVDonor(1, 2, types)
+}
+
+func TestResolveKVDonor_PanicEmptyLayerTypes(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on empty layerTypes")
+		}
+	}()
+	_ = ResolveKVDonor(0, 0, []LayerType{})
+}
+
+func TestResolveKVDonor_PanicNoDonorFound(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when no donor exists")
+		}
+	}()
+	// All layers before firstSharedIdx=2 are sliding; shared layer at
+	// index 2 is global => no global donor exists.
+	types := []LayerType{LayerTypeSliding, LayerTypeSliding, LayerTypeGlobal}
+	_ = ResolveKVDonor(2, 2, types)
+}
+
+func TestResolveKVDonor_PanicFirstSharedIdxNegative(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on negative firstSharedIdx")
+		}
+	}()
+	types := []LayerType{LayerTypeSliding}
+	_ = ResolveKVDonor(0, -1, types)
+}
+
+func TestResolveKVDonor_PanicFirstSharedIdxTooLarge(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when firstSharedIdx exceeds len(layerTypes)")
+		}
+	}()
+	types := []LayerType{LayerTypeSliding, LayerTypeGlobal}
+	_ = ResolveKVDonor(1, 3, types)
+}
+
+func TestResolveKVDonor_PanicLayerIdxOutOfRange(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when layerIdx >= len(layerTypes)")
+		}
+	}()
+	types := []LayerType{LayerTypeSliding, LayerTypeGlobal}
+	_ = ResolveKVDonor(2, 2, types)
+}

--- a/layers/attention/grouped_query_attention.go
+++ b/layers/attention/grouped_query_attention.go
@@ -83,6 +83,25 @@ type GroupedQueryAttention[T tensor.Numeric] struct {
 	qHeadsRoPE      *tensor.TensorNumeric[T] // Q after RoPE
 	kHeadsRoPE      *tensor.TensorNumeric[T] // K after RoPE
 	outputShape     []int
+
+	// K/V output ports (task-T95.1.2). Captured during Forward after the
+	// layer-local K/V projection + optional per-head norms + post-projection
+	// RoPE have been applied, and before KV-cache expansion or group
+	// replication. Shapes: [batch, numKVHeads, seqLen, headDim].
+	//
+	// Downstream shared-KV layers consume these via KPort()/VPort() when
+	// wired through the external-K/V input path (see ADR-087 and
+	// task-T95.1.1 / T95.2.1). Nil until the first successful Forward.
+	kOut *tensor.TensorNumeric[T]
+	vOut *tensor.TensorNumeric[T]
+
+	// External K/V override. When set (by task-T95.1.1's WithExternalKV()
+	// API), Forward skips local K/V projection and KPort()/VPort() return
+	// these donor ports directly so further chained sharing is transparent.
+	// Unused by the current layer body; wired by T95.1.1.
+	externalKV    bool
+	extKPortNode  graph.Node[T]
+	extVPortNode  graph.Node[T]
 }
 
 // OpType returns the operation type.
@@ -431,6 +450,10 @@ func (gqa *GroupedQueryAttention[T]) Forward(ctx context.Context, inputs ...*ten
 		return nil, err
 	}
 
+	// T95.1.2: capture V output port (post reshape+transpose, pre cache
+	// expansion / group replication). Shape: [batch, numKVHeads, seqLen, headDim].
+	gqa.vOut = vHeads
+
 	// Fused QK norm+RoPE decode path: replaces 4 kernel launches with 1.
 	// Conditions: decode (seqLen=1), RoPE enabled, Q/K norm weights available, engine supports it.
 	fusedQKNormRoPE := false
@@ -697,6 +720,10 @@ func (gqa *GroupedQueryAttention[T]) Forward(ctx context.Context, inputs ...*ten
 	if err != nil {
 		return nil, err
 	}
+
+	// T95.1.2: capture K output port (post norm + post RoPE, pre cache
+	// expansion / group replication). Shape: [batch, numKVHeads, seqLen, headDim].
+	gqa.kOut = kHeadsRoPE
 
 	// KV Cache: store K/V per KV-head in shape [batch*numKVHeads, seq_len, headDim],
 	// then retrieve full cached K/V for attention computation.
@@ -1248,3 +1275,115 @@ func BuildCausalSlidingWindowMask[T tensor.Numeric](seqLen, windowSize int) *ten
 
 // Statically assert that the type implements the graph.Node interface.
 var _ graph.Node[float32] = (*GroupedQueryAttention[float32])(nil)
+
+// gqaKVPort is a lightweight graph.Node[T] adapter that exposes a cached
+// tensor produced during the owning layer's Forward pass as a readable port.
+// It is used by GroupedQueryAttention.KPort() / VPort() to hand the donor
+// layer's K and V to downstream shared-KV attention layers (ADR-087).
+//
+// The adapter's Forward ignores its inputs and returns whatever tensor the
+// owner most recently stored in the underlying field (kOut or vOut). Reading
+// before the owner's first Forward returns nil, matching the ADR's stated
+// nil-safety contract: downstream consumers must call donor.Forward(...)
+// first, then pass donor.KPort()/VPort() into the shared layer.
+//
+// The adapter carries no parameters of its own and has no gradient path;
+// backward semantics live on the owning GQA layer.
+type gqaKVPort[T tensor.Numeric] struct {
+	owner  *GroupedQueryAttention[T]
+	selKey bool // true = K port, false = V port
+}
+
+// OpType identifies the port kind for debugging and graph dumps.
+func (p *gqaKVPort[T]) OpType() string {
+	if p.selKey {
+		return "GroupedQueryAttention.KPort"
+	}
+	return "GroupedQueryAttention.VPort"
+}
+
+// Attributes returns the port's attributes.
+func (p *gqaKVPort[T]) Attributes() map[string]interface{} {
+	kind := "v"
+	if p.selKey {
+		kind = "k"
+	}
+	return map[string]interface{}{"port": kind}
+}
+
+// Forward returns the cached K or V tensor captured during the owner GQA's
+// most recent Forward pass. Inputs are ignored -- the tensor is produced
+// inside the owner and merely re-exported here. Returns an error if the
+// owner has not yet run (nil cached value).
+func (p *gqaKVPort[T]) Forward(_ context.Context, _ ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	t := p.owner.kOut
+	name := "K"
+	if !p.selKey {
+		t = p.owner.vOut
+		name = "V"
+	}
+	if t == nil {
+		return nil, fmt.Errorf("GroupedQueryAttention.%sPort: owner layer has not produced %s yet; call owner.Forward first", name, name)
+	}
+	return t, nil
+}
+
+// Backward for a port node is a pass-through: the gradient flows back through
+// the owner GQA's Backward path via the shared KV donor relationship, not
+// through this adapter. The adapter therefore returns an empty slice.
+func (p *gqaKVPort[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	return nil, nil
+}
+
+// Parameters returns nil -- the port carries no trainable state of its own.
+func (p *gqaKVPort[T]) Parameters() []*graph.Parameter[T] { return nil }
+
+// OutputShape returns the shape of the cached tensor, or nil if the owner
+// has not yet run.
+func (p *gqaKVPort[T]) OutputShape() []int {
+	t := p.owner.kOut
+	if !p.selKey {
+		t = p.owner.vOut
+	}
+	if t == nil {
+		return nil
+	}
+	return t.Shape()
+}
+
+// Statically assert the port adapter implements graph.Node.
+var _ graph.Node[float32] = (*gqaKVPort[float32])(nil)
+
+// KPort returns a graph.Node[T] that, when executed, yields the layer's
+// computed K after projection + optional per-head K norm + post-projection
+// RoPE, in shape [batch, numKVHeads, seqLen, headDim]. When the layer is
+// running in external-K/V mode (task-T95.1.1's WithExternalKV()), KPort
+// returns the external donor's K port directly so chained K/V sharing is
+// transparent.
+//
+// The returned node's Forward must be called AFTER the owner GQA's Forward
+// pass -- the port simply re-exports the cached tensor produced there.
+// Calling Forward on the port before the owner has produced K yields a
+// descriptive error (see gqaKVPort.Forward).
+//
+// Downstream consumers (e.g. task-T95.2.1's shared-KV wiring node) should
+// treat the returned node as a read-only K source. The node carries no
+// parameters and has no independent gradient.
+func (gqa *GroupedQueryAttention[T]) KPort() graph.Node[T] {
+	if gqa.externalKV && gqa.extKPortNode != nil {
+		return gqa.extKPortNode
+	}
+	return &gqaKVPort[T]{owner: gqa, selKey: true}
+}
+
+// VPort returns a graph.Node[T] that, when executed, yields the layer's
+// computed V after projection + reshape + transpose, in shape
+// [batch, numKVHeads, seqLen, headDim]. When the layer is running in
+// external-K/V mode, VPort returns the external donor's V port directly.
+// See KPort for semantics and nil-safety contract.
+func (gqa *GroupedQueryAttention[T]) VPort() graph.Node[T] {
+	if gqa.externalKV && gqa.extVPortNode != nil {
+		return gqa.extVPortNode
+	}
+	return &gqaKVPort[T]{owner: gqa, selKey: false}
+}

--- a/layers/attention/grouped_query_attention.go
+++ b/layers/attention/grouped_query_attention.go
@@ -102,13 +102,6 @@ type GroupedQueryAttention[T tensor.Numeric] struct {
 	kOut *tensor.TensorNumeric[T]
 	vOut *tensor.TensorNumeric[T]
 
-	// External K/V override. When set (by task-T95.1.1's WithExternalKV()
-	// API), Forward skips local K/V projection and KPort()/VPort() return
-	// these donor ports directly so further chained sharing is transparent.
-	// Unused by the current layer body; wired by T95.1.1.
-	externalKV    bool
-	extKPortNode  graph.Node[T]
-	extVPortNode  graph.Node[T]
 }
 
 // OpType returns the operation type.
@@ -1436,35 +1429,28 @@ func (p *gqaKVPort[T]) OutputShape() []int {
 var _ graph.Node[float32] = (*gqaKVPort[float32])(nil)
 
 // KPort returns a graph.Node[T] that, when executed, yields the layer's
-// computed K after projection + optional per-head K norm + post-projection
-// RoPE, in shape [batch, numKVHeads, seqLen, headDim]. When the layer is
-// running in external-K/V mode (task-T95.1.1's WithExternalKV()), KPort
-// returns the external donor's K port directly so chained K/V sharing is
-// transparent.
+// most-recently-computed K in shape [batch, numKVHeads, seqLen, headDim].
+// In external-K/V mode, the captured K is whatever tensor was supplied
+// via Forward's inputs[1]; otherwise it is the layer's own projection
+// output after optional per-head K norm and post-projection RoPE.
 //
-// The returned node's Forward must be called AFTER the owner GQA's Forward
-// pass -- the port simply re-exports the cached tensor produced there.
+// Donor -> shared wiring is performed by the caller: at graph-build time
+// the builder wires donor.KPort() as an input producing K, then passes
+// the resulting tensor into the shared layer's Forward via inputs[1].
+// See ADR-087.
+//
+// The returned node's Forward must be called AFTER the owner GQA's
+// Forward pass -- the port re-exports the cached tensor produced there.
 // Calling Forward on the port before the owner has produced K yields a
-// descriptive error (see gqaKVPort.Forward).
-//
-// Downstream consumers (e.g. task-T95.2.1's shared-KV wiring node) should
-// treat the returned node as a read-only K source. The node carries no
+// descriptive error (see gqaKVPort.Forward). The node carries no
 // parameters and has no independent gradient.
 func (gqa *GroupedQueryAttention[T]) KPort() graph.Node[T] {
-	if gqa.externalKV && gqa.extKPortNode != nil {
-		return gqa.extKPortNode
-	}
 	return &gqaKVPort[T]{owner: gqa, selKey: true}
 }
 
-// VPort returns a graph.Node[T] that, when executed, yields the layer's
-// computed V after projection + reshape + transpose, in shape
-// [batch, numKVHeads, seqLen, headDim]. When the layer is running in
-// external-K/V mode, VPort returns the external donor's V port directly.
-// See KPort for semantics and nil-safety contract.
+// VPort returns a graph.Node[T] that yields the layer's most-recently-
+// computed V in shape [batch, numKVHeads, seqLen, headDim]. See KPort
+// for semantics, donor-wiring conventions, and nil-safety contract.
 func (gqa *GroupedQueryAttention[T]) VPort() graph.Node[T] {
-	if gqa.externalKV && gqa.extVPortNode != nil {
-		return gqa.extVPortNode
-	}
 	return &gqaKVPort[T]{owner: gqa, selKey: false}
 }

--- a/layers/attention/grouped_query_attention.go
+++ b/layers/attention/grouped_query_attention.go
@@ -74,6 +74,13 @@ type GroupedQueryAttention[T tensor.Numeric] struct {
 	// Gemma 4 global attention layers use this optimization.
 	kEqV bool
 
+	// externalKV, when true, expects K and V to be supplied as forward
+	// inputs (inputs[1] and inputs[2]) instead of being computed from the
+	// layer's own wk/wv weights. In this mode the layer carries no wk, wv,
+	// or k_norm parameters. Used by architectures with cross-layer K/V
+	// sharing (e.g. Gemma 4 edge). Mutually exclusive with kEqV.
+	externalKV bool
+
 	// Cached tensors for backward pass
 	qProj           *tensor.TensorNumeric[T] // Projected Q
 	kProj           *tensor.TensorNumeric[T] // Projected K
@@ -106,6 +113,7 @@ type GQAOptions[T tensor.Numeric] struct {
 	MaxSeqLen     int
 	Bidirectional bool // when true, disables causal masking for encoder-style models
 	NoRoPE        bool // when true, skip RoPE creation (for models like GPT-2 that use learned position embeddings)
+	ExternalKV    bool // when true, K/V are supplied as Forward inputs; wk/wv/k_norm are not instantiated
 }
 
 // GQAOption is a function that applies an option to GQAOptions.
@@ -131,6 +139,21 @@ func WithMaxSeqLen[T tensor.Numeric](maxSeqLen int) GQAOption[T] {
 func WithBidirectionalGQA[T tensor.Numeric]() GQAOption[T] {
 	return func(o *GQAOptions[T]) {
 		o.Bidirectional = true
+	}
+}
+
+// WithExternalKV returns an option that configures the GroupedQueryAttention
+// layer to read K and V from additional Forward inputs instead of computing
+// them from internal wk/wv projections. When set, the constructor does not
+// instantiate wk, wv, or k_norm; Forward expects inputs[1] to be K and
+// inputs[2] to be V, each with shape [batch, seq, numKeyValueHeads * headDim]
+// (matching what the internal projection would produce). RoPE for K still
+// applies (if configured). Q, q_norm, w_out, attention math, and output
+// projection remain unchanged. This option is mutually exclusive with the
+// kEqV mode configured via SetKEqV. See ADR-087 for rationale.
+func WithExternalKV[T tensor.Numeric]() GQAOption[T] {
+	return func(o *GQAOptions[T]) {
+		o.ExternalKV = true
 	}
 }
 
@@ -182,14 +205,17 @@ func NewGroupedQueryAttention[T tensor.Numeric](
 		return nil, fmt.Errorf("failed to create WQ dense layer: %w", err)
 	}
 
-	wk, err := core.NewDense[T]("wk", engine, ops, modelDim, headDim*numKeyValueHeads) // K projection
-	if err != nil {
-		return nil, fmt.Errorf("failed to create WK dense layer: %w", err)
-	}
+	var wk, wv *core.Dense[T]
+	if !options.ExternalKV {
+		wk, err = core.NewDense[T]("wk", engine, ops, modelDim, headDim*numKeyValueHeads) // K projection
+		if err != nil {
+			return nil, fmt.Errorf("failed to create WK dense layer: %w", err)
+		}
 
-	wv, err := core.NewDense[T]("wv", engine, ops, modelDim, headDim*numKeyValueHeads) // V projection
-	if err != nil {
-		return nil, fmt.Errorf("failed to create WV dense layer: %w", err)
+		wv, err = core.NewDense[T]("wv", engine, ops, modelDim, headDim*numKeyValueHeads) // V projection
+		if err != nil {
+			return nil, fmt.Errorf("failed to create WV dense layer: %w", err)
+		}
 	}
 
 	// Initialize ScaledDotProductAttention. dk is headDim.
@@ -223,6 +249,7 @@ func NewGroupedQueryAttention[T tensor.Numeric](
 		wo:                        wo,
 		rope:                      rope,
 		bidirectional:             options.Bidirectional,
+		externalKV:                options.ExternalKV,
 	}, nil
 }
 
@@ -279,8 +306,17 @@ func (gqa *GroupedQueryAttention[T]) SetBidirectional(bidirectional bool) {
 // SetKEqV configures GQA to use the K projection output for both K and V.
 // When enabled, the V projection (wv) is skipped and K output is used as V.
 // This implements Gemma 4's unified K=V projection for global attention layers.
+// Mutually exclusive with WithExternalKV: panics if both are requested.
 func (gqa *GroupedQueryAttention[T]) SetKEqV(v bool) {
+	if v && gqa.externalKV {
+		panic("GroupedQueryAttention: SetKEqV is mutually exclusive with WithExternalKV")
+	}
 	gqa.kEqV = v
+}
+
+// ExternalKV reports whether this layer was configured with WithExternalKV.
+func (gqa *GroupedQueryAttention[T]) ExternalKV() bool {
+	return gqa.externalKV
 }
 
 // OutputShape returns the output shape of the GroupedQueryAttention.
@@ -298,8 +334,16 @@ func (gqa *GroupedQueryAttention[T]) ScaleRope(ctx context.Context, factor float
 
 // SetQKNorms sets optional per-head RMSNorm layers for Q and K projections.
 // Used by architectures like Gemma 3 that normalize Q/K after projection.
+// When externalKV is set, the kNorm argument is ignored (K is supplied
+// pre-computed and any normalization must have been applied by the donor).
 func (gqa *GroupedQueryAttention[T]) SetQKNorms(qNorm, kNorm graph.Node[T]) {
 	gqa.qNorm = qNorm
+	if gqa.externalKV {
+		// In external-KV mode the layer carries no k_norm: the donor layer
+		// is responsible for any K normalization before publishing.
+		gqa.kNorm = nil
+		return
+	}
 	gqa.kNorm = kNorm
 }
 
@@ -349,8 +393,12 @@ func (gqa *GroupedQueryAttention[T]) Parameters() []*graph.Parameter[T] {
 	var params []*graph.Parameter[T]
 
 	params = append(params, gqa.wq.Parameters()...)
-	params = append(params, gqa.wk.Parameters()...)
-	params = append(params, gqa.wv.Parameters()...)
+	if gqa.wk != nil {
+		params = append(params, gqa.wk.Parameters()...)
+	}
+	if gqa.wv != nil {
+		params = append(params, gqa.wv.Parameters()...)
+	}
 	params = append(params, gqa.wo.Parameters()...)
 
 	if p := gqa.MergedQKVParameter(); p != nil {
@@ -369,8 +417,21 @@ func (gqa *GroupedQueryAttention[T]) Forward(ctx context.Context, inputs ...*ten
 	input := inputs[0] // (batch_size, seq_len, model_dim)
 	gqa.outputShape = input.Shape()
 
-	var mask *tensor.TensorNumeric[T]
-	if len(inputs) > 1 {
+	var (
+		externalK *tensor.TensorNumeric[T]
+		externalV *tensor.TensorNumeric[T]
+		mask      *tensor.TensorNumeric[T]
+	)
+	if gqa.externalKV {
+		if len(inputs) < 3 {
+			return nil, fmt.Errorf("GroupedQueryAttention: externalKV mode expects at least 3 inputs (hidden, K, V), got %d", len(inputs))
+		}
+		externalK = inputs[1]
+		externalV = inputs[2]
+		if len(inputs) > 3 {
+			mask = inputs[3]
+		}
+	} else if len(inputs) > 1 {
 		mask = inputs[1]
 	}
 
@@ -383,7 +444,24 @@ func (gqa *GroupedQueryAttention[T]) Forward(ctx context.Context, inputs ...*ten
 	// 1. Linear projections for Q, K, V
 	var err error
 	var qProj, kProj, vProj *tensor.TensorNumeric[T]
-	if gqa.mergedQKV != nil && seqLen == 1 {
+	switch {
+	case gqa.externalKV:
+		// External K/V path: Q projected normally, K/V taken from inputs.
+		qProj, err = gqa.wq.Forward(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		expectedKVDim := gqa.numKeyValueHeads * gqa.headDim
+		for name, t := range map[string]*tensor.TensorNumeric[T]{"K": externalK, "V": externalV} {
+			shape := t.Shape()
+			if len(shape) != 3 || shape[0] != batchSize || shape[1] != seqLen || shape[2] != expectedKVDim {
+				return nil, fmt.Errorf("GroupedQueryAttention: external %s has shape %v, expected [%d, %d, %d]",
+					name, shape, batchSize, seqLen, expectedKVDim)
+			}
+		}
+		kProj = externalK
+		vProj = externalV
+	case gqa.mergedQKV != nil && seqLen == 1:
 		// Merged QKV: single GEMV + zero-copy split for decode.
 		merged, mergeErr := gqa.engine.MatMul(ctx, input, gqa.mergedQKV)
 		if mergeErr != nil {
@@ -393,7 +471,7 @@ func (gqa *GroupedQueryAttention[T]) Forward(ctx context.Context, inputs ...*ten
 		if err != nil {
 			return nil, fmt.Errorf("split merged QKV: %w", err)
 		}
-	} else {
+	default:
 		qProj, err = gqa.wq.Forward(ctx, input)
 		if err != nil {
 			return nil, err
@@ -990,6 +1068,9 @@ func (gqa *GroupedQueryAttention[T]) reverseHeadReplication(ctx context.Context,
 //  6. Reverse head split (reshape/transpose back to projection shape)
 //  7. wq/wk/wv backward
 func (gqa *GroupedQueryAttention[T]) Backward(ctx context.Context, mode types.BackwardMode, dOut *tensor.TensorNumeric[T], inputs ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	if gqa.externalKV {
+		return nil, fmt.Errorf("GroupedQueryAttention: Backward is not supported in externalKV mode")
+	}
 	if len(inputs) != 1 {
 		return nil, fmt.Errorf("GroupedQueryAttention: %w, expected %d, got %d", graph.ErrInvalidInputCount, 1, len(inputs))
 	}

--- a/layers/attention/grouped_query_attention_kvport_test.go
+++ b/layers/attention/grouped_query_attention_kvport_test.go
@@ -1,0 +1,203 @@
+package attention
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/testing/testutils"
+)
+
+// TestGroupedQueryAttention_KVPort_BasicShape verifies that KPort() and
+// VPort() return non-nil graph nodes and that, after the owner's Forward
+// runs, the ports yield tensors of the expected
+// [batch, numKVHeads, seqLen, headDim] shape.
+func TestGroupedQueryAttention_KVPort_BasicShape(t *testing.T) {
+	engine := compute.NewCPUEngine(numeric.Float32Ops{})
+
+	batchSize := 2
+	seqLen := 5
+	modelDim := 16
+	numQueryHeads := 4
+	numKeyValueHeads := 2
+	headDim := modelDim / numQueryHeads
+
+	gqa, err := NewGroupedQueryAttention[float32](
+		engine,
+		numeric.Float32Ops{},
+		modelDim,
+		numQueryHeads,
+		numKeyValueHeads,
+		WithRopeBase[float32](10000.0),
+		WithMaxSeqLen[float32](seqLen),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct GQA: %v", err)
+	}
+
+	kPort := gqa.KPort()
+	vPort := gqa.VPort()
+	if kPort == nil || vPort == nil {
+		t.Fatalf("KPort/VPort must never return nil (got K=%v V=%v)", kPort, vPort)
+	}
+
+	// Before Forward runs, ports' Forward should error (nil-safety).
+	if _, err := kPort.Forward(context.Background()); err == nil {
+		t.Fatalf("KPort.Forward before owner.Forward should error")
+	}
+
+	inp, err := tensor.New[float32]([]int{batchSize, seqLen, modelDim}, nil)
+	if err != nil {
+		t.Fatalf("failed creating input: %v", err)
+	}
+	for i := range inp.Data() {
+		inp.Data()[i] = float32(i%7) * 0.1
+	}
+
+	if _, err := gqa.Forward(context.Background(), inp); err != nil {
+		t.Fatalf("owner Forward failed: %v", err)
+	}
+
+	kTensor, err := kPort.Forward(context.Background())
+	if err != nil {
+		t.Fatalf("KPort.Forward failed after owner.Forward: %v", err)
+	}
+	vTensor, err := vPort.Forward(context.Background())
+	if err != nil {
+		t.Fatalf("VPort.Forward failed after owner.Forward: %v", err)
+	}
+
+	expected := []int{batchSize, numKeyValueHeads, seqLen, headDim}
+	if !testutils.IntSliceEqual(expected, kTensor.Shape()) {
+		t.Fatalf("KPort shape: got %v want %v", kTensor.Shape(), expected)
+	}
+	if !testutils.IntSliceEqual(expected, vTensor.Shape()) {
+		t.Fatalf("VPort shape: got %v want %v", vTensor.Shape(), expected)
+	}
+
+	if kPort.OpType() != "GroupedQueryAttention.KPort" {
+		t.Fatalf("KPort OpType got %q", kPort.OpType())
+	}
+	if vPort.OpType() != "GroupedQueryAttention.VPort" {
+		t.Fatalf("VPort OpType got %q", vPort.OpType())
+	}
+	if !testutils.IntSliceEqual(expected, kPort.OutputShape()) {
+		t.Fatalf("KPort.OutputShape: got %v want %v", kPort.OutputShape(), expected)
+	}
+	if !testutils.IntSliceEqual(expected, vPort.OutputShape()) {
+		t.Fatalf("VPort.OutputShape: got %v want %v", vPort.OutputShape(), expected)
+	}
+}
+
+// TestGroupedQueryAttention_KVPort_SharedIdentity simulates the donor/shared
+// layer pattern from ADR-087 at the K/V port level: layer A runs Forward,
+// layer B is configured to treat A.KPort() / A.VPort() as its external K/V
+// donor. We confirm that B's effective K/V source (as exposed via
+// B.KPort() / B.VPort() when running in external-KV mode) produces tensors
+// identical (same pointer, same shape, same data) to A's K/V output.
+//
+// Until task-T95.1.1's WithExternalKV() option lands, we drive the
+// external-KV override directly through the additive fields.
+func TestGroupedQueryAttention_KVPort_SharedIdentity(t *testing.T) {
+	engine := compute.NewCPUEngine(numeric.Float32Ops{})
+
+	batchSize := 1
+	seqLen := 4
+	modelDim := 8
+	numQueryHeads := 2
+	numKeyValueHeads := 1
+
+	mk := func(name string) *GroupedQueryAttention[float32] {
+		gqa, err := NewGroupedQueryAttention[float32](
+			engine,
+			numeric.Float32Ops{},
+			modelDim,
+			numQueryHeads,
+			numKeyValueHeads,
+			WithRopeBase[float32](10000.0),
+			WithMaxSeqLen[float32](seqLen),
+		)
+		if err != nil {
+			t.Fatalf("construct %s: %v", name, err)
+		}
+		return gqa
+	}
+
+	a := mk("A")
+	b := mk("B")
+
+	inp, err := tensor.New[float32]([]int{batchSize, seqLen, modelDim}, nil)
+	if err != nil {
+		t.Fatalf("failed creating input: %v", err)
+	}
+	for i := range inp.Data() {
+		inp.Data()[i] = float32(i) * 0.01
+	}
+
+	// Run donor layer A.
+	if _, err := a.Forward(context.Background(), inp); err != nil {
+		t.Fatalf("A.Forward: %v", err)
+	}
+
+	// Wire B to consume A's K/V ports as external donor. This emulates
+	// what task-T95.1.1's WithExternalKV() option will produce.
+	b.externalKV = true
+	b.extKPortNode = a.KPort()
+	b.extVPortNode = a.VPort()
+
+	// Also run B on its own input to ensure the layer body still works.
+	if _, err := b.Forward(context.Background(), inp); err != nil {
+		t.Fatalf("B.Forward: %v", err)
+	}
+
+	// In external-KV mode, B.KPort()/VPort() must return the donor ports
+	// *themselves* (not a fresh adapter), so downstream consumers reach
+	// A's K/V without any intermediate hop.
+	if b.KPort() != a.KPort() {
+		// Note: KPort() constructs a fresh adapter each call for the local
+		// case; in external mode we expect the stored donor node reference
+		// to be returned verbatim. Since adapters are fresh, we compare
+		// A's port through the same external-mode access pattern instead:
+		// b.KPort() should === b.extKPortNode.
+	}
+	if b.KPort() != b.extKPortNode {
+		t.Fatalf("B.KPort() in external-KV mode must return the donor port node")
+	}
+	if b.VPort() != b.extVPortNode {
+		t.Fatalf("B.VPort() in external-KV mode must return the donor port node")
+	}
+
+	// The tensors reached through B's external ports must be identical
+	// (same underlying *TensorNumeric) to A's K/V.
+	aK, err := a.KPort().Forward(context.Background())
+	if err != nil {
+		t.Fatalf("A.KPort.Forward: %v", err)
+	}
+	aV, err := a.VPort().Forward(context.Background())
+	if err != nil {
+		t.Fatalf("A.VPort.Forward: %v", err)
+	}
+	bK, err := b.KPort().Forward(context.Background())
+	if err != nil {
+		t.Fatalf("B.KPort.Forward: %v", err)
+	}
+	bV, err := b.VPort().Forward(context.Background())
+	if err != nil {
+		t.Fatalf("B.VPort.Forward: %v", err)
+	}
+
+	if aK != bK {
+		t.Fatalf("B's K in external-KV mode must be the same *TensorNumeric as A's K (got different pointers)")
+	}
+	if aV != bV {
+		t.Fatalf("B's V in external-KV mode must be the same *TensorNumeric as A's V (got different pointers)")
+	}
+	if !testutils.IntSliceEqual(aK.Shape(), bK.Shape()) {
+		t.Fatalf("shape mismatch K: %v vs %v", aK.Shape(), bK.Shape())
+	}
+	if !testutils.IntSliceEqual(aV.Shape(), bV.Shape()) {
+		t.Fatalf("shape mismatch V: %v vs %v", aV.Shape(), bV.Shape())
+	}
+}

--- a/layers/attention/grouped_query_attention_kvport_test.go
+++ b/layers/attention/grouped_query_attention_kvport_test.go
@@ -136,41 +136,10 @@ func TestGroupedQueryAttention_KVPort_SharedIdentity(t *testing.T) {
 		inp.Data()[i] = float32(i) * 0.01
 	}
 
-	// Run donor layer A.
+	// Run donor layer A and pull its K/V tensors via ports.
 	if _, err := a.Forward(context.Background(), inp); err != nil {
 		t.Fatalf("A.Forward: %v", err)
 	}
-
-	// Wire B to consume A's K/V ports as external donor. This emulates
-	// what task-T95.1.1's WithExternalKV() option will produce.
-	b.externalKV = true
-	b.extKPortNode = a.KPort()
-	b.extVPortNode = a.VPort()
-
-	// Also run B on its own input to ensure the layer body still works.
-	if _, err := b.Forward(context.Background(), inp); err != nil {
-		t.Fatalf("B.Forward: %v", err)
-	}
-
-	// In external-KV mode, B.KPort()/VPort() must return the donor ports
-	// *themselves* (not a fresh adapter), so downstream consumers reach
-	// A's K/V without any intermediate hop.
-	if b.KPort() != a.KPort() {
-		// Note: KPort() constructs a fresh adapter each call for the local
-		// case; in external mode we expect the stored donor node reference
-		// to be returned verbatim. Since adapters are fresh, we compare
-		// A's port through the same external-mode access pattern instead:
-		// b.KPort() should === b.extKPortNode.
-	}
-	if b.KPort() != b.extKPortNode {
-		t.Fatalf("B.KPort() in external-KV mode must return the donor port node")
-	}
-	if b.VPort() != b.extVPortNode {
-		t.Fatalf("B.VPort() in external-KV mode must return the donor port node")
-	}
-
-	// The tensors reached through B's external ports must be identical
-	// (same underlying *TensorNumeric) to A's K/V.
 	aK, err := a.KPort().Forward(context.Background())
 	if err != nil {
 		t.Fatalf("A.KPort.Forward: %v", err)
@@ -179,6 +148,48 @@ func TestGroupedQueryAttention_KVPort_SharedIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("A.VPort.Forward: %v", err)
 	}
+
+	// K/V port shape is [B, numKVHeads, S, headDim]. WithExternalKV's
+	// Forward expects inputs[1]/[2] in the layer-input shape
+	// [B, S, numKVHeads*headDim]. Builders bridge the two via a
+	// transpose+reshape node (future T95.2.1). For this unit test we
+	// reshape by hand so B can consume A's K/V as forward inputs.
+	headDim := modelDim / numQueryHeads
+	reshape := func(src *tensor.TensorNumeric[float32]) *tensor.TensorNumeric[float32] {
+		// [B, numKV, S, headDim] -> [B, S, numKV*headDim]
+		out, err := tensor.New[float32]([]int{batchSize, seqLen, numKeyValueHeads * headDim}, nil)
+		if err != nil {
+			t.Fatalf("tensor.New: %v", err)
+		}
+		srcData := src.Data()
+		dstData := out.Data()
+		for bi := 0; bi < batchSize; bi++ {
+			for kh := 0; kh < numKeyValueHeads; kh++ {
+				for s := 0; s < seqLen; s++ {
+					for d := 0; d < headDim; d++ {
+						srcIdx := ((bi*numKeyValueHeads+kh)*seqLen+s)*headDim + d
+						dstIdx := (bi*seqLen+s)*numKeyValueHeads*headDim + kh*headDim + d
+						dstData[dstIdx] = srcData[srcIdx]
+					}
+				}
+			}
+		}
+		return out
+	}
+
+	// Configure B as external-KV via the field set by WithExternalKV().
+	b.externalKV = true
+
+	// Run B with hidden + external K/V (from A).
+	kIn := reshape(aK)
+	vIn := reshape(aV)
+	if _, err := b.Forward(context.Background(), inp, kIn, vIn); err != nil {
+		t.Fatalf("B.Forward (external-KV): %v", err)
+	}
+
+	// B's KPort/VPort should yield tensors that round-trip back to A's
+	// shapes (the external K/V was captured into B's kOut/vOut after
+	// RoPE and any bookkeeping).
 	bK, err := b.KPort().Forward(context.Background())
 	if err != nil {
 		t.Fatalf("B.KPort.Forward: %v", err)
@@ -187,17 +198,10 @@ func TestGroupedQueryAttention_KVPort_SharedIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("B.VPort.Forward: %v", err)
 	}
-
-	if aK != bK {
-		t.Fatalf("B's K in external-KV mode must be the same *TensorNumeric as A's K (got different pointers)")
-	}
-	if aV != bV {
-		t.Fatalf("B's V in external-KV mode must be the same *TensorNumeric as A's V (got different pointers)")
-	}
 	if !testutils.IntSliceEqual(aK.Shape(), bK.Shape()) {
-		t.Fatalf("shape mismatch K: %v vs %v", aK.Shape(), bK.Shape())
+		t.Fatalf("shape mismatch K: donor %v vs shared %v", aK.Shape(), bK.Shape())
 	}
 	if !testutils.IntSliceEqual(aV.Shape(), bV.Shape()) {
-		t.Fatalf("shape mismatch V: %v vs %v", aV.Shape(), bV.Shape())
+		t.Fatalf("shape mismatch V: donor %v vs shared %v", aV.Shape(), bV.Shape())
 	}
 }

--- a/layers/attention/grouped_query_attention_test.go
+++ b/layers/attention/grouped_query_attention_test.go
@@ -2,6 +2,7 @@ package attention
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/zerfoo/zerfoo/layers/core"
@@ -289,6 +290,158 @@ func TestGroupedQueryAttention_NoRoPE_SetDocumentBoundaries(t *testing.T) {
 	// Should not panic when rope is nil.
 	gqa.SetDocumentBoundaries([]int{0, 3})
 	gqa.SetDocumentBoundaries(nil)
+}
+
+// TestGroupedQueryAttention_ExternalKV_MatchesInternal verifies that a GQA
+// configured with WithExternalKV() produces outputs numerically identical to
+// an internal-KV GQA when fed the same pre-computed K/V tensors. See ADR-087.
+func TestGroupedQueryAttention_ExternalKV_MatchesInternal(t *testing.T) {
+	engine := compute.NewCPUEngine(numeric.Float32Ops{})
+
+	batchSize := 2
+	seqLen := 5
+	modelDim := 16
+	numQueryHeads := 4
+	numKeyValueHeads := 2
+
+	// Reference: standard GQA with internal K/V projection.
+	gqaInternal, err := NewGroupedQueryAttention[float32](
+		engine,
+		numeric.Float32Ops{},
+		modelDim,
+		numQueryHeads,
+		numKeyValueHeads,
+		WithRopeBase[float32](10000.0),
+		WithMaxSeqLen[float32](seqLen),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct internal GQA: %v", err)
+	}
+
+	// Under-test: GQA with externalKV mode. Must not instantiate wk/wv.
+	gqaExternal, err := NewGroupedQueryAttention[float32](
+		engine,
+		numeric.Float32Ops{},
+		modelDim,
+		numQueryHeads,
+		numKeyValueHeads,
+		WithRopeBase[float32](10000.0),
+		WithMaxSeqLen[float32](seqLen),
+		WithExternalKV[float32](),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct external GQA: %v", err)
+	}
+	if !gqaExternal.ExternalKV() {
+		t.Fatalf("ExternalKV() = false, expected true")
+	}
+	if gqaExternal.wk != nil {
+		t.Fatalf("externalKV GQA must not instantiate wk")
+	}
+	if gqaExternal.wv != nil {
+		t.Fatalf("externalKV GQA must not instantiate wv")
+	}
+
+	// Share Q and output weights so only the K/V source differs.
+	copyDenseWeights(t, gqaExternal.wq, gqaInternal.wq)
+	copyDenseWeights(t, gqaExternal.wo, gqaInternal.wo)
+
+	// Deterministic input.
+	inp, err := tensor.New[float32]([]int{batchSize, seqLen, modelDim}, nil)
+	if err != nil {
+		t.Fatalf("failed creating input: %v", err)
+	}
+	for i := range inp.Data() {
+		inp.Data()[i] = float32(i%13) / 10.0
+	}
+
+	ctx := context.Background()
+
+	// Run internal GQA and capture the K/V projections it computed.
+	outInternal, err := gqaInternal.Forward(ctx, inp)
+	if err != nil {
+		t.Fatalf("internal GQA Forward failed: %v", err)
+	}
+	kProj := gqaInternal.kProj
+	vProj := gqaInternal.vProj
+	if kProj == nil || vProj == nil {
+		t.Fatalf("internal GQA did not cache kProj/vProj")
+	}
+
+	// Validate K/V shape matches the documented contract.
+	expectedKVShape := []int{batchSize, seqLen, numKeyValueHeads * (modelDim / numQueryHeads)}
+	if !testutils.IntSliceEqual(kProj.Shape(), expectedKVShape) {
+		t.Fatalf("unexpected K shape: got %v want %v", kProj.Shape(), expectedKVShape)
+	}
+
+	// Run external GQA with the same K/V fed as inputs[1]/[2].
+	outExternal, err := gqaExternal.Forward(ctx, inp, kProj, vProj)
+	if err != nil {
+		t.Fatalf("external GQA Forward failed: %v", err)
+	}
+
+	if !testutils.IntSliceEqual(outInternal.Shape(), outExternal.Shape()) {
+		t.Fatalf("shape mismatch: internal %v vs external %v",
+			outInternal.Shape(), outExternal.Shape())
+	}
+
+	const tol = 1e-5
+	for i := range outInternal.Data() {
+		diff := outInternal.Data()[i] - outExternal.Data()[i]
+		if math.Abs(float64(diff)) > tol {
+			t.Fatalf("output mismatch at idx %d: internal=%f external=%f diff=%f",
+				i, outInternal.Data()[i], outExternal.Data()[i], diff)
+		}
+	}
+}
+
+// TestGroupedQueryAttention_ExternalKV_RejectsKEqV verifies the mutual
+// exclusivity of WithExternalKV and SetKEqV.
+func TestGroupedQueryAttention_ExternalKV_RejectsKEqV(t *testing.T) {
+	engine := compute.NewCPUEngine(numeric.Float32Ops{})
+
+	gqa, err := NewGroupedQueryAttention[float32](
+		engine,
+		numeric.Float32Ops{},
+		16, 4, 2,
+		WithNoRoPE[float32](),
+		WithExternalKV[float32](),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct external GQA: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic when SetKEqV is called on externalKV GQA")
+		}
+	}()
+	gqa.SetKEqV(true)
+}
+
+// TestGroupedQueryAttention_ExternalKV_RejectsShortInputs verifies Forward
+// requires hidden+K+V inputs in external mode.
+func TestGroupedQueryAttention_ExternalKV_RejectsShortInputs(t *testing.T) {
+	engine := compute.NewCPUEngine(numeric.Float32Ops{})
+
+	gqa, err := NewGroupedQueryAttention[float32](
+		engine,
+		numeric.Float32Ops{},
+		16, 4, 2,
+		WithNoRoPE[float32](),
+		WithExternalKV[float32](),
+	)
+	if err != nil {
+		t.Fatalf("failed to construct external GQA: %v", err)
+	}
+
+	inp, err := tensor.New[float32]([]int{1, 3, 16}, nil)
+	if err != nil {
+		t.Fatalf("failed creating input: %v", err)
+	}
+	if _, err := gqa.Forward(context.Background(), inp); err == nil {
+		t.Fatalf("expected error when externalKV Forward is called without K/V inputs")
+	}
 }
 
 func TestGroupedQueryAttention_NoRoPE_ScaleRope(t *testing.T) {


### PR DESCRIPTION
## Summary
Wave E95-1 of E95 "External K/V Input Path for GroupedQueryAttention" (ADR-087).
Three independent foundations for shared-KV attention, unblocking the Gemma 4
edge builder rewrite (E93-3).

## Tasks completed

- **T95.1.1** `WithExternalKV()` option: GQA gains an external-KV mode where
  K and V arrive via `Forward` inputs[1]/[2] instead of internal `wk`/`wv`
  projection. Mutually exclusive with `kEqV`. Backward returns an error in
  external mode (inference-only). Parity test vs internal-KV within 1e-5.
- **T95.1.2** `KPort()` / `VPort()` accessors: every GQA layer exposes its
  computed K and V as port nodes (`graph.Node[T]`). Port re-exports the cached
  tensor; donor->shared wiring is done at the caller level via Forward inputs.
- **T95.2.2** `ResolveKVDonor` pure function in `inference/`: for a shared-KV
  layer, returns the donor layer index (last non-shared layer of same attention
  type). Table-driven tests verify the Gemma 4 E2B pattern. 100% coverage.

## Merge notes

Both T95.1.1 and T95.1.2 independently added an `externalKV bool` field and
wired the port accessors slightly differently. Integration commit reconciles
them: single `externalKV` field, port accessors always return a port adapter
over captured `kOut`/`vOut`, SharedIdentity test rewired to pass K/V via
Forward inputs.

## Validation

- `go build ./...`: clean
- `go vet ./...`: clean
- `go test ./layers/attention/... -race`: PASS
- `go test ./inference/... -race`: PASS (pre-existing TSPulse flake unrelated;
  flakes on base main too)

## Linked Issues
- fixes #455 (T95.1.1)
- fixes #456 (T95.1.2)
- fixes #458 (T95.2.2)

## References
- docs/adr/087-external-kv-for-shared-kv-attention.md
- docs/plan.md E95 section

## Next waves
- Wave E95-2 (T95.2.1 kv wiring node, T95.3.1/T95.3.2 non-regression smoke tests)
- Wave E95-3 (T95.4.1 lint)
- Then Wave E93-3 (Gemma 4 edge builder rewrite, now unblocked)