### PR TITLE
E95-2: kv_reuse_node + non-regression smoke tests

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1312,7 +1312,7 @@ E93-3 is now gated on E95. E93-4 remains gated on E93-3.
 
 ### E95.2: Graph node wiring
 
-- [ ] T95.2.1 Add kv_reuse_node to inference  Owner: TBD  Est: 1h  verifies: [UC-001]
+- [x] T95.2.1 Add kv_reuse_node to inference  Owner: TBD  Est: 1h  verifies: [UC-001]  2026 04 13
   Deps: T95.1.2
   File: `inference/kv_reuse_node.go` (new)
   Thin graph node that takes a donor layer's K (or V) port as input and passes it through unchanged. Exists to make the donor→shared edge explicit in the graph (for readability, impact tracing, and CUDA graph capture). If the donor's K/V can be wired directly without a pass-through node, skip this file and document the direct wiring approach in ADR-087 Implementation notes.
@@ -1326,12 +1326,12 @@ E93-3 is now gated on E95. E93-4 remains gated on E93-3.
 
 ### E95.3: Non-regression tests for shared infra
 
-- [ ] T95.3.1 Architecture smoke tests: Llama 3, Gemma 3, Mistral  Owner: TBD  Est: 1h  verifies: [infrastructure]
+- [x] T95.3.1 Architecture smoke tests: Llama 3, Gemma 3, Mistral  Owner: TBD  Est: 1h  verifies: [infrastructure]  2026 04 13
   Deps: T95.1.1
   Run existing tests for `inference/arch_llama.go`, `inference/arch_gemma.go`, and any Mistral architecture that uses GroupedQueryAttention. Confirm no behavior change (external-KV mode is default-off). If any test requires updating because it inspected GQA internals, minimize the change and document it.
   AC: `go test ./inference/... -count=1 -race` clean. `go test ./layers/attention/... -count=1 -race` clean.
 
-- [ ] T95.3.2 Architecture smoke tests: Qwen 2, Phi, DeepSeek  Owner: TBD  Est: 1h  verifies: [infrastructure]
+- [x] T95.3.2 Architecture smoke tests: Qwen 2, Phi, DeepSeek  Owner: TBD  Est: 1h  verifies: [infrastructure]  2026 04 13
   Deps: T95.1.1
   Same as T95.3.1 for `arch_qwen*.go`, `arch_phi*.go`, `arch_deepseek*.go`. DeepSeek uses MLA which may not touch GQA; confirm by reading its builder.
   AC: tests clean. DeepSeek's MLA path confirmed not affected or explicitly updated.
@@ -1366,9 +1366,9 @@ Coordinator note: T95.1.1 and T95.1.2 edit the same file. Run Agent 1 first, the
 #### Wave E95-2: Wiring + non-regression (3 agents)
 Deps: Wave E95-1.
 
-- [ ] Agent 1: T95.2.1 (kv_reuse_node or direct wiring decision)
-- [ ] Agent 2: T95.3.1 (Llama/Gemma3/Mistral smoke)
-- [ ] Agent 3: T95.3.2 (Qwen/Phi/DeepSeek smoke)
+- [x] Agent 1: T95.2.1 (kv_reuse_node: Option A — layout-bridging node)  2026 04 13
+- [x] Agent 2: T95.3.1 (Llama/Gemma3/Mistral smoke — verification only, no diff)  2026 04 13
+- [x] Agent 3: T95.3.2 (Qwen/Phi/DeepSeek smoke — DeepSeek uses MLA, not GQA)  2026 04 13
 
 #### Wave E95-3: Lint (1 agent)
 Deps: Wave E95-2.

--- a/inference/kv_reuse_node.go
+++ b/inference/kv_reuse_node.go
@@ -1,0 +1,140 @@
+// Package inference: KVReuseNode bridges a donor attention layer's K or V
+// port (shape [B, numKVHeads, S, headDim]) to the layout expected by a
+// downstream GroupedQueryAttention layer configured with WithExternalKV
+// (shape [B, S, numKVHeads*headDim]).
+//
+// The node exists to make the donor -> shared-KV edge an explicit graph node
+// for readability, impact tracing, and CUDA graph capture (ADR-087). Builders
+// wire donor.KPort()/VPort() through a KVReuseNode before passing the result
+// as inputs[1]/inputs[2] to the consumer GQA's Forward.
+package inference
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// KVReuseNode is a thin pass-through graph node that reads a donor GQA
+// layer's K or V port (produced in [B, numKVHeads, S, headDim] layout) and
+// emits the K/V in the [B, S, numKVHeads*headDim] layout consumed by the
+// downstream consumer GQA's Forward when WithExternalKV is active.
+//
+// The node owns no parameters, has no gradient of its own, and defers to the
+// donor port for source semantics. Forward must be called AFTER the donor
+// layer's Forward pass; otherwise the donor port will error.
+type KVReuseNode[T tensor.Numeric] struct {
+	engine           compute.Engine[T]
+	donor            graph.Node[T]
+	numKVHeads       int
+	headDim          int
+	isKey            bool
+	lastOutputShape  []int
+}
+
+// NewKVReuseNode constructs a KVReuseNode that wraps the given donor port
+// (typically a result of donorGQA.KPort() or donorGQA.VPort()).
+//
+// numKVHeads and headDim describe the donor layer's K/V geometry; the node
+// flattens the head and headDim axes to produce the consumer layer's
+// external-K/V input layout.
+func NewKVReuseNode[T tensor.Numeric](
+	engine compute.Engine[T],
+	donor graph.Node[T],
+	numKVHeads, headDim int,
+	isKey bool,
+) (*KVReuseNode[T], error) {
+	if engine == nil {
+		return nil, fmt.Errorf("KVReuseNode: engine must not be nil")
+	}
+	if donor == nil {
+		return nil, fmt.Errorf("KVReuseNode: donor must not be nil")
+	}
+	if numKVHeads <= 0 || headDim <= 0 {
+		return nil, fmt.Errorf("KVReuseNode: numKVHeads and headDim must be positive (got %d, %d)", numKVHeads, headDim)
+	}
+	return &KVReuseNode[T]{
+		engine:     engine,
+		donor:      donor,
+		numKVHeads: numKVHeads,
+		headDim:    headDim,
+		isKey:      isKey,
+	}, nil
+}
+
+// OpType identifies the node for graph dumps and debugging.
+func (n *KVReuseNode[T]) OpType() string {
+	if n.isKey {
+		return "KVReuseNode.K"
+	}
+	return "KVReuseNode.V"
+}
+
+// Attributes returns the node's static attributes.
+func (n *KVReuseNode[T]) Attributes() map[string]interface{} {
+	kind := "v"
+	if n.isKey {
+		kind = "k"
+	}
+	return map[string]interface{}{
+		"port":         kind,
+		"num_kv_heads": n.numKVHeads,
+		"head_dim":     n.headDim,
+	}
+}
+
+// Forward pulls the donor's cached K/V tensor (shape [B, numKVHeads, S, headDim]),
+// transposes it to [B, S, numKVHeads, headDim], and reshapes to
+// [B, S, numKVHeads*headDim] -- the layout expected by GroupedQueryAttention
+// Forward when WithExternalKV is active. Inputs to this node are ignored.
+func (n *KVReuseNode[T]) Forward(ctx context.Context, _ ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	src, err := n.donor.Forward(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("KVReuseNode: donor port Forward: %w", err)
+	}
+	shape := src.Shape()
+	if len(shape) != 4 {
+		return nil, fmt.Errorf("KVReuseNode: donor tensor rank = %d, want 4 ([B, numKVHeads, S, headDim])", len(shape))
+	}
+	if shape[1] != n.numKVHeads || shape[3] != n.headDim {
+		return nil, fmt.Errorf("KVReuseNode: donor shape %v incompatible with numKVHeads=%d headDim=%d",
+			shape, n.numKVHeads, n.headDim)
+	}
+	batch, seqLen := shape[0], shape[2]
+
+	// [B, numKV, S, headDim] -> [B, S, numKV, headDim]
+	transposed, err := n.engine.Transpose(ctx, src, []int{0, 2, 1, 3})
+	if err != nil {
+		return nil, fmt.Errorf("KVReuseNode: transpose: %w", err)
+	}
+	// [B, S, numKV, headDim] -> [B, S, numKV*headDim]
+	out, err := n.engine.Reshape(ctx, transposed, []int{batch, seqLen, n.numKVHeads * n.headDim})
+	if err != nil {
+		return nil, fmt.Errorf("KVReuseNode: reshape: %w", err)
+	}
+	n.lastOutputShape = out.Shape()
+	return out, nil
+}
+
+// Backward is a no-op: gradients for shared-KV flow back through the donor
+// GQA layer, not through this adapter. In external-KV mode the consumer GQA's
+// Backward is itself unsupported (see ADR-087 implementation notes).
+func (n *KVReuseNode[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	return nil, nil
+}
+
+// Parameters returns nil -- the node carries no trainable state of its own.
+func (n *KVReuseNode[T]) Parameters() []*graph.Parameter[T] { return nil }
+
+// OutputShape returns the last produced output shape, or nil before the first
+// Forward call (the donor must run first to determine batch/seqLen).
+func (n *KVReuseNode[T]) OutputShape() []int {
+	return n.lastOutputShape
+}
+
+// Statically assert KVReuseNode implements graph.Node.
+var _ graph.Node[float32] = (*KVReuseNode[float32])(nil)

--- a/inference/kv_reuse_node_test.go
+++ b/inference/kv_reuse_node_test.go
@@ -1,0 +1,198 @@
+package inference
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zerfoo/zerfoo/layers/attention"
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/testing/testutils"
+)
+
+// TestKVReuseNode_BridgesDonorToConsumerLayout runs a donor GQA layer and
+// routes its K/V via KVReuseNode, verifying that the emitted tensor has the
+// [B, S, numKVHeads*headDim] layout expected by a consumer GQA's external-KV
+// Forward input and that element ordering matches the explicit
+// transpose+reshape reference.
+func TestKVReuseNode_BridgesDonorToConsumerLayout(t *testing.T) {
+	engine := compute.NewCPUEngine(numeric.Float32Ops{})
+
+	batchSize := 2
+	seqLen := 4
+	modelDim := 8
+	numQueryHeads := 4
+	numKVHeads := 2
+	headDim := modelDim / numQueryHeads
+
+	gqa, err := attention.NewGroupedQueryAttention[float32](
+		engine,
+		numeric.Float32Ops{},
+		modelDim,
+		numQueryHeads,
+		numKVHeads,
+		attention.WithRopeBase[float32](10000.0),
+		attention.WithMaxSeqLen[float32](seqLen),
+	)
+	if err != nil {
+		t.Fatalf("construct donor GQA: %v", err)
+	}
+
+	inp, err := tensor.New[float32]([]int{batchSize, seqLen, modelDim}, nil)
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	for i := range inp.Data() {
+		inp.Data()[i] = float32(i%11) * 0.017
+	}
+
+	ctx := context.Background()
+	if _, err := gqa.Forward(ctx, inp); err != nil {
+		t.Fatalf("donor Forward: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		isKey bool
+		port  func() (donor, _ interface{})
+	}{
+		{name: "K", isKey: true},
+		{name: "V", isKey: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var donor = gqa.KPort()
+			if !tc.isKey {
+				donor = gqa.VPort()
+			}
+
+			node, err := NewKVReuseNode[float32](engine, donor, numKVHeads, headDim, tc.isKey)
+			if err != nil {
+				t.Fatalf("NewKVReuseNode: %v", err)
+			}
+
+			out, err := node.Forward(ctx)
+			if err != nil {
+				t.Fatalf("KVReuseNode.Forward: %v", err)
+			}
+			wantShape := []int{batchSize, seqLen, numKVHeads * headDim}
+			if !testutils.IntSliceEqual(wantShape, out.Shape()) {
+				t.Fatalf("output shape: got %v want %v", out.Shape(), wantShape)
+			}
+			if !testutils.IntSliceEqual(wantShape, node.OutputShape()) {
+				t.Fatalf("OutputShape(): got %v want %v", node.OutputShape(), wantShape)
+			}
+
+			// Reference: read donor port directly and do the same
+			// transpose+reshape by hand.
+			src, err := donor.Forward(ctx)
+			if err != nil {
+				t.Fatalf("donor.Forward: %v", err)
+			}
+			ref := make([]float32, batchSize*seqLen*numKVHeads*headDim)
+			srcData := src.Data()
+			for b := 0; b < batchSize; b++ {
+				for kh := 0; kh < numKVHeads; kh++ {
+					for s := 0; s < seqLen; s++ {
+						for d := 0; d < headDim; d++ {
+							srcIdx := ((b*numKVHeads+kh)*seqLen+s)*headDim + d
+							dstIdx := (b*seqLen+s)*numKVHeads*headDim + kh*headDim + d
+							ref[dstIdx] = srcData[srcIdx]
+						}
+					}
+				}
+			}
+			gotData := out.Data()
+			for i, v := range ref {
+				if gotData[i] != v {
+					t.Fatalf("data mismatch at %d: got %v want %v", i, gotData[i], v)
+				}
+			}
+
+			// Metadata checks.
+			wantOp := "KVReuseNode.K"
+			if !tc.isKey {
+				wantOp = "KVReuseNode.V"
+			}
+			if node.OpType() != wantOp {
+				t.Fatalf("OpType: got %q want %q", node.OpType(), wantOp)
+			}
+			attrs := node.Attributes()
+			if attrs["num_kv_heads"].(int) != numKVHeads || attrs["head_dim"].(int) != headDim {
+				t.Fatalf("Attributes: %v", attrs)
+			}
+			if node.Parameters() != nil {
+				t.Fatalf("Parameters should be nil, got %v", node.Parameters())
+			}
+		})
+	}
+}
+
+// TestKVReuseNode_FeedsConsumerExternalKV confirms that the node's output is
+// directly consumable as inputs[1]/inputs[2] for a consumer GQA configured
+// with WithExternalKV -- the end-to-end contract of ADR-087.
+func TestKVReuseNode_FeedsConsumerExternalKV(t *testing.T) {
+	engine := compute.NewCPUEngine(numeric.Float32Ops{})
+
+	batchSize := 1
+	seqLen := 3
+	modelDim := 8
+	numQueryHeads := 2
+	numKVHeads := 1
+	headDim := modelDim / numQueryHeads
+
+	mk := func(withExt bool) *attention.GroupedQueryAttention[float32] {
+		opts := []attention.GQAOption[float32]{
+			attention.WithRopeBase[float32](10000.0),
+			attention.WithMaxSeqLen[float32](seqLen),
+		}
+		if withExt {
+			opts = append(opts, attention.WithExternalKV[float32]())
+		}
+		gqa, err := attention.NewGroupedQueryAttention[float32](
+			engine, numeric.Float32Ops{}, modelDim, numQueryHeads, numKVHeads, opts...,
+		)
+		if err != nil {
+			t.Fatalf("construct GQA: %v", err)
+		}
+		return gqa
+	}
+
+	donor := mk(false)
+	consumer := mk(true)
+
+	inp, err := tensor.New[float32]([]int{batchSize, seqLen, modelDim}, nil)
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	for i := range inp.Data() {
+		inp.Data()[i] = float32(i) * 0.013
+	}
+
+	ctx := context.Background()
+	if _, err := donor.Forward(ctx, inp); err != nil {
+		t.Fatalf("donor.Forward: %v", err)
+	}
+
+	kNode, err := NewKVReuseNode[float32](engine, donor.KPort(), numKVHeads, headDim, true)
+	if err != nil {
+		t.Fatalf("NewKVReuseNode K: %v", err)
+	}
+	vNode, err := NewKVReuseNode[float32](engine, donor.VPort(), numKVHeads, headDim, false)
+	if err != nil {
+		t.Fatalf("NewKVReuseNode V: %v", err)
+	}
+
+	kIn, err := kNode.Forward(ctx)
+	if err != nil {
+		t.Fatalf("kNode.Forward: %v", err)
+	}
+	vIn, err := vNode.Forward(ctx)
+	if err != nil {
+		t.Fatalf("vNode.Forward: %v", err)
+	}
+
+	if _, err := consumer.Forward(ctx, inp, kIn, vIn); err != nil {
+		t.Fatalf("consumer.Forward (external-KV): %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Wave E95-2 of Epic E95 (External K/V plumbing for Gemma 4 pre-req).

- **T95.2.1**: New `inference/kv_reuse_node.go` — layout-bridging node that reshapes donor GQA K/V port output `[B,numKV,S,headDim]` → consumer external-KV input `[B,S,numKV*headDim]`. Makes donor→shared edge explicit for CUDA graph capture.
- **T95.3.1**: Verified Llama/Gemma3/Mistral paths — `go test ./inference/... -run 'Llama|Gemma|Mistral'` and `./layers/attention/...` green. External-KV default-off preserves behavior.
- **T95.3.2**: Verified Qwen/Phi/DeepSeek — DeepSeek uses MLA (not GQA), unaffected. Qwen/Phi delegate to `buildTransformerGraph` covered by T95.3.1.

## Linked Issues
- fixes #457 (T95.2.1)
- fixes #459 (T95.3.1)
- fixes #460 (T95.3.2)

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./inference/... -race -count=1` PASS
- [x] `go test ./layers/attention/... -race -count=1` PASS