### PR TITLE
E93-3: Gemma 4 edge builder canonical layout + shared-KV

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1179,7 +1179,7 @@ edge builder to match the canonical architecture.
 
 #### E93.3: Builder rewrite
 
-- [ ] T93.3.1 Rewrite arch_gemma4_edge.go for canonical layout  Owner: TBD  Est: 3h  verifies: [UC-001]  (Previously blocked on AltUp/Laurel (retracted) and on GQA external-KV (now addressed by E95). HF transformers `modeling_gemma4.py` is the canonical reference; ADR-086 carries line-numbered wiring decisions; ADR-087 covers external-KV plumbing; wave E95 lands it before this task starts.)
+- [x] T93.3.1 Rewrite arch_gemma4_edge.go for canonical layout  Owner: TBD  Est: 3h  verifies: [UC-001]  2026 04 14  (Previously blocked on AltUp/Laurel (retracted) and on GQA external-KV (now addressed by E95). HF transformers `modeling_gemma4.py` is the canonical reference; ADR-086 carries line-numbered wiring decisions; ADR-087 covers external-KV plumbing; wave E95 lands it before this task starts.)
   Deps: T93.2.1, T93.1.2, E95 (all tasks)
   File: `inference/arch_gemma4_edge.go`
   In one focused pass, replace the per-layer-PLE-embedding path with the
@@ -1192,7 +1192,7 @@ edge builder to match the canonical architecture.
   "missing tensor" error on a real GGUF. No changes to exported symbols.
   All tensor lookups use the names defined in T93.2.1.
 
-- [ ] T93.3.2 Update synthetic fixtures in arch_gemma4_test.go  Owner: TBD  Est: 1h  verifies: [UC-001]
+- [x] T93.3.2 Update synthetic fixtures in arch_gemma4_test.go  Owner: TBD  Est: 1h  verifies: [UC-001]  2026 04 14
   Deps: T93.3.1
   File: `inference/arch_gemma4_test.go`
   Update `makeGemma4EdgeTestTensors` (and any sibling helpers) to produce the
@@ -1200,12 +1200,12 @@ edge builder to match the canonical architecture.
   propagate, no panics).
   AC: All existing edge-builder unit tests pass against the rewritten builder.
 
-- [ ] T93.3.3 Run full inference test suite  Owner: TBD  Est: 15m  verifies: [infrastructure]
+- [x] T93.3.3 Run full inference test suite  Owner: TBD  Est: 15m  verifies: [infrastructure]  2026 04 14
   Deps: T93.3.1, T93.3.2
   AC: `go test ./inference/...` clean. Dense and MoE Gemma 4 builders
   unchanged and still pass.
 
-- [ ] T93.3.4 Lint and vet after builder rewrite  Owner: TBD  Est: 15m  verifies: [infrastructure]
+- [x] T93.3.4 Lint and vet after builder rewrite  Owner: TBD  Est: 15m  verifies: [infrastructure]  2026 04 14
   Deps: T93.3.1
   AC: `go vet ./...` clean. `golangci-lint run` clean.
 
@@ -1281,7 +1281,7 @@ set already cataloged in `docs/gemma4-edge-architecture.md`. The three
 open wiring questions in ADR-086 remain, to be resolved by reading the
 correct Gemma 4 builder in llama.cpp (not `gemma3n-iswa.cpp`).
 
-- [ ] Agent 1: T93.3.1 -> T93.3.2 -> T93.3.3 -> T93.3.4
+- [x] Agent 1: T93.3.1 -> T93.3.2 -> T93.3.3 -> T93.3.4  2026 04 14
 
 #### Wave E93-4: Integration (1 agent)
 Deps: Wave E93-3. Steps gate each other (generation depends on graph, parity

--- a/inference/arch_gemma4_edge.go
+++ b/inference/arch_gemma4_edge.go
@@ -451,7 +451,7 @@ func buildGemma4EdgeGraph(
 		gateActivated := builder.AddNode(gelu, gateOut)
 
 		// Per-layer PLE slice: [B, S, pleDim], combined per HF line 1693-1696.
-		sliceNode, err := newPLESliceNode[float32](proxy, pleProducer, pleProjNormGain, rmsEps, i)
+		sliceNode, err := newPLESliceNode[float32](proxy, ops, pleProducer, pleProjNormGain, rmsEps, i)
 		if err != nil {
 			return nil, nil, fmt.Errorf("layer %d: pleSlice: %w", i, err)
 		}

--- a/inference/arch_gemma4_edge.go
+++ b/inference/arch_gemma4_edge.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/zerfoo/layers/activations"
 	"github.com/zerfoo/zerfoo/layers/attention"
 	"github.com/zerfoo/zerfoo/layers/core"
 	"github.com/zerfoo/zerfoo/layers/embeddings"
@@ -17,18 +18,38 @@ import (
 )
 
 // buildGemma4EdgeGraph constructs a computation graph for the Gemma 4 edge
-// variants (E4B and E2B) from pre-loaded GGUF tensors. It extends the dense
-// Gemma 4 builder with three features:
+// variants (E2B and E4B) from pre-loaded GGUF tensors. Per ADR-086 and ADR-087
+// it implements the canonical HuggingFace transformers modeling_gemma4.py
+// layout:
 //
-//  1. Per-Layer Embeddings (PLE): Each layer adds a per-layer token embedding
-//     projected to hidden_size before the input layernorm.
-//  2. KV-Shared Layers: Groups of consecutive layers share K/V weight
-//     projections to reduce parameter count.
-//  3. Double-Wide MLP: The E2B variant uses IntermediateSize*2 for the FFN.
+//   1. Per-Layer Embeddings (PLE). Shared `model.ple_embed_tokens.weight`
+//      [vocab, numLayers*pleDim] and `model.ple_model_proj.weight`
+//      [hidden, numLayers*pleDim] are computed once per forward, sliced per
+//      layer, combined via the shared `model.ple_proj_norm.weight` [pleDim]
+//      RMSNorm, and scaled by 1/sqrt(2). Per-block `input_gate`
+//      (hidden->pleDim), `ple_layer_proj` (pleDim->hidden), `post_layernorm`
+//      (hidden), and `layer_output_scale` [1] weights complete the sub-block.
 //
-// The architecture is:
+//   2. Shared-KV attention. The last `KVSharedLayers` layers skip their own
+//      wk/wv/k_norm and reuse the K/V activations from the nearest non-shared
+//      layer of the same attention type (sliding vs global), wired through
+//      `KVReuseNode` into a consumer GQA configured with
+//      `SetExternalKV(true)`.
 //
-//	Embed*sqrt(d) -> [PLE+Add -> RMSNorm -> GQA(KV-shared) -> PostNorm -> FusedAdd+RMSNorm -> FFN(GELU,double?) -> FusedNorm+Add] x N -> RMSNorm -> LMHead(tied)
+//   3. Dual-RoPE hybrid attention: global layers (every
+//      `SlidingWindowPattern`-th) use `RopeTheta`; sliding layers use
+//      `LocalRopeTheta` and a per-layer sliding window.
+//
+// Per-layer flow (canonical post-mapping names):
+//
+//	input_layernorm -> GQA (donor or shared-via-KVReuseNode)
+//	  -> post_attention_layernorm
+//	  -> fusedAddRMSNorm(pre_feedforward_layernorm, +pre-attn residual)
+//	  -> FFN (GELU, intermediate = gate_proj.Shape()[0])
+//	  -> fusedNormAdd(post_feedforward_layernorm, +pre-FFN residual)
+//	  -> PLE block: input_gate -> GELU -> * per_layer_inputs[i]
+//	       -> ple_layer_proj -> post_layernorm -> + residual
+//	  -> layer_output_scale (scalar broadcast)
 func buildGemma4EdgeGraph(
 	tensors map[string]*tensor.TensorNumeric[float32],
 	cfg *gguf.ModelConfig,
@@ -53,8 +74,29 @@ func buildGemma4EdgeGraph(
 	if err != nil {
 		return nil, nil, err
 	}
-
 	finalNormWeight, err := tl.Lookup("model.norm.weight")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pleDim := cfg.PLEHiddenSize
+	if pleDim <= 0 {
+		return nil, nil, fmt.Errorf("gemma4-edge: PLEHiddenSize must be positive (got %d)", pleDim)
+	}
+
+	pleEmbed, err := tl.Lookup("model.ple_embed_tokens.weight")
+	if err != nil {
+		return nil, nil, fmt.Errorf("gemma4-edge: %w", err)
+	}
+	pleModelProjRaw, err := tl.Lookup("model.ple_model_proj.weight")
+	if err != nil {
+		return nil, nil, fmt.Errorf("gemma4-edge: %w", err)
+	}
+	pleProjNormGain, err := tl.Lookup("model.ple_proj_norm.weight")
+	if err != nil {
+		return nil, nil, fmt.Errorf("gemma4-edge: %w", err)
+	}
+	pleModelProj, err := tw("model.ple_model_proj.weight", pleModelProjRaw)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -63,71 +105,51 @@ func buildGemma4EdgeGraph(
 	builder := graph.NewBuilder[float32](proxy)
 	input := builder.Input([]int{1, 1})
 
-	// Embedding lookup with sqrt(hidden_size) scaling (Gemma family convention).
-	scale := float32(math.Sqrt(float64(cfg.HiddenSize)))
-	embNode := newEmbeddingNode(proxy, embedWeight, scale)
+	// Main embedding: lookup and scale by sqrt(hidden_size) (Gemma convention).
+	hiddenScale := float32(math.Sqrt(float64(cfg.HiddenSize)))
+	embNode := newEmbeddingNode(proxy, embedWeight, hiddenScale)
 	hidden := builder.AddNode(embNode, input)
+
+	// PLE combined producer: caches token-PLE and model-projection tensors
+	// for consumption by per-layer pleSliceNode. Forward returns the hidden
+	// input unchanged so downstream nodes keep a well-formed data edge.
+	pleProducer, err := newPLECombinedProducer[float32](proxy, pleEmbed, pleModelProj,
+		cfg.NumLayers, pleDim, cfg.HiddenSize)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gemma4-edge: %w", err)
+	}
+	hidden = builder.AddNode(pleProducer, input, hidden)
 
 	defaultHeadDim := cfg.HiddenSize / cfg.NumHeads
 	if cfg.HeadDim > 0 {
 		defaultHeadDim = cfg.HeadDim
 	}
 
-	// Determine FFN intermediate size (double-wide for E2B variant).
-	intermediateSize := cfg.IntermediateSize
-	if cfg.DoubleWideMLP {
-		intermediateSize = cfg.IntermediateSize * 2
+	// Classify layers upfront for ResolveKVDonor.
+	layerTypes := make([]LayerType, cfg.NumLayers)
+	for i := 0; i < cfg.NumLayers; i++ {
+		if cfg.SlidingWindowPattern > 0 && (i+1)%cfg.SlidingWindowPattern == 0 {
+			layerTypes[i] = LayerTypeGlobal
+		} else {
+			layerTypes[i] = LayerTypeSliding
+		}
 	}
+	firstSharedIdx := cfg.NumLayers - cfg.KVSharedLayers
+	if firstSharedIdx < 0 {
+		firstSharedIdx = 0
+	}
+	donorGQA := make(map[int]*attention.GroupedQueryAttention[float32], cfg.NumLayers)
+	donorKVGeom := make(map[int][2]int, cfg.NumLayers) // donorIdx -> [numKVHeads, headDim]
 
 	for i := 0; i < cfg.NumLayers; i++ {
 		prefix := fmt.Sprintf("model.layers.%d.", i)
+		isGlobal := layerTypes[i] == LayerTypeGlobal
+		isShared := cfg.KVSharedLayers > 0 && i >= firstSharedIdx
 
-		// --- Per-Layer Embeddings (PLE) ---
-		// PLE adds a per-layer token embedding projected to hidden_size
-		// before the input layernorm.
-		if cfg.PLEHiddenSize > 0 {
-			// Look up PLE embedding weight for this layer.
-			var pleWeight *tensor.TensorNumeric[float32]
-			pleWeight, err = tl.Lookup(prefix + "ple.weight")
-			if err != nil {
-				// Try alternate naming convention.
-				pleWeight, err = tl.Lookup(prefix + "ple_embedding.weight")
-				if err != nil {
-					return nil, nil, fmt.Errorf("layer %d: missing PLE weight: %w", i, err)
-				}
-			}
-
-			// PLE embedding lookup (no scaling, unlike the main embedding).
-			pleEmbNode := newEmbeddingNode(proxy, pleWeight, 0)
-			pleEmb := builder.AddNode(pleEmbNode, input)
-
-			// Project PLE embedding to hidden_size.
-			pleProjW, err := tl.Lookup(prefix + "ple_proj.weight")
-			if err != nil {
-				return nil, nil, fmt.Errorf("layer %d: missing PLE projection weight: %w", i, err)
-			}
-			pleProjWT, err := tw(prefix+"ple_proj.weight", pleProjW)
-			if err != nil {
-				return nil, nil, err
-			}
-			pleProj := core.NewDenseFromParams(
-				core.NewLinearFromParam(proxy, pw.Wrap(prefix+"ple_proj.weight", pleProjWT)), nil,
-			)
-			pleProjOut := builder.AddNode(pleProj, pleEmb)
-
-			// Add PLE projection to hidden state.
-			pleAdd := &elementwiseAddNode[float32]{engine: proxy}
-			hidden = builder.AddNode(pleAdd, hidden, pleProjOut)
-		}
-
-		// Determine if this is a global or sliding layer.
-		isGlobal := cfg.SlidingWindowPattern > 0 && (i+1)%cfg.SlidingWindowPattern == 0
-
-		// Select per-layer attention configuration.
+		// Per-layer attention configuration.
 		var numKVHeads, headDim int
 		var ropeTheta float64
 		var partialRotaryFactor float32
-
 		if isGlobal {
 			numKVHeads = cfg.GlobalNumKVHeads
 			if numKVHeads == 0 {
@@ -153,7 +175,6 @@ func buildGemma4EdgeGraph(
 			} else {
 				ropeTheta = cfg.RopeTheta
 			}
-			// Sliding layers use full RoPE.
 		}
 
 		// --- Input LayerNorm ---
@@ -169,23 +190,8 @@ func buildGemma4EdgeGraph(
 		}
 		normed := builder.AddNode(inputNorm, hidden)
 
-		// --- Self-Attention (GQA) with optional KV sharing ---
-		// For KV-shared layers, load K/V weights from the source layer.
-		kvPrefix := prefix
-		if cfg.KVSharedLayers > 0 {
-			kvSourceLayer := (i / cfg.KVSharedLayers) * cfg.KVSharedLayers
-			kvPrefix = fmt.Sprintf("model.layers.%d.", kvSourceLayer)
-		}
-
+		// --- Q / O projections (always present) ---
 		qW, err := tl.Lookup(prefix + "self_attn.q_proj.weight")
-		if err != nil {
-			return nil, nil, err
-		}
-		kW, err := tl.Lookup(kvPrefix + "self_attn.k_proj.weight")
-		if err != nil {
-			return nil, nil, err
-		}
-		vW, err := tl.Lookup(kvPrefix + "self_attn.v_proj.weight")
 		if err != nil {
 			return nil, nil, err
 		}
@@ -193,16 +199,7 @@ func buildGemma4EdgeGraph(
 		if err != nil {
 			return nil, nil, err
 		}
-
 		qWT, err := tw(prefix+"self_attn.q_proj.weight", qW)
-		if err != nil {
-			return nil, nil, err
-		}
-		kWT, err := tw(kvPrefix+"self_attn.k_proj.weight", kW)
-		if err != nil {
-			return nil, nil, err
-		}
-		vWT, err := tw(kvPrefix+"self_attn.v_proj.weight", vW)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -210,19 +207,39 @@ func buildGemma4EdgeGraph(
 		if err != nil {
 			return nil, nil, err
 		}
-
 		wq := core.NewDenseFromParams(
 			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.q_proj.weight", qWT)), nil,
-		)
-		wk := core.NewDenseFromParams(
-			core.NewLinearFromParam(proxy, pw.Wrap(kvPrefix+"self_attn.k_proj.weight", kWT)), nil,
-		)
-		wv := core.NewDenseFromParams(
-			core.NewLinearFromParam(proxy, pw.Wrap(kvPrefix+"self_attn.v_proj.weight", vWT)), nil,
 		)
 		wo := core.NewDenseFromParams(
 			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.o_proj.weight", oWT)), nil,
 		)
+
+		// --- K / V projections: only for non-shared (donor) layers ---
+		var wk, wv *core.Dense[float32]
+		if !isShared {
+			kW, err := tl.Lookup(prefix + "self_attn.k_proj.weight")
+			if err != nil {
+				return nil, nil, err
+			}
+			vW, err := tl.Lookup(prefix + "self_attn.v_proj.weight")
+			if err != nil {
+				return nil, nil, err
+			}
+			kWT, err := tw(prefix+"self_attn.k_proj.weight", kW)
+			if err != nil {
+				return nil, nil, err
+			}
+			vWT, err := tw(prefix+"self_attn.v_proj.weight", vW)
+			if err != nil {
+				return nil, nil, err
+			}
+			wk = core.NewDenseFromParams(
+				core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.k_proj.weight", kWT)), nil,
+			)
+			wv = core.NewDenseFromParams(
+				core.NewLinearFromParam(proxy, pw.Wrap(prefix+"self_attn.v_proj.weight", vWT)), nil,
+			)
+		}
 
 		// RoPE with per-layer theta and optional partial rotation.
 		ropeOpts := []embeddings.RotaryPositionalEmbeddingOption{
@@ -246,18 +263,11 @@ func buildGemma4EdgeGraph(
 			return nil, nil, fmt.Errorf("layer %d gqa: %w", i, err)
 		}
 		gqa.LayerIndex = i
-
-		// Sliding window attention for non-global layers.
 		if !isGlobal && cfg.SlidingWindow > 0 {
 			gqa.SlidingWindowSize = cfg.SlidingWindow
 		}
 
-		// K=V optimization for global layers.
-		if isGlobal && cfg.AttentionKEqV {
-			gqa.SetKEqV(true)
-		}
-
-		// Q/K norms (always on for Gemma 4).
+		// Q norm is present on every layer; K norm only on donor layers.
 		qNormW, err := tl.Lookup(prefix + "self_attn.q_norm.weight")
 		if err != nil {
 			return nil, nil, err
@@ -268,22 +278,56 @@ func buildGemma4EdgeGraph(
 		if err != nil {
 			return nil, nil, err
 		}
-		kNormW, err := tl.Lookup(prefix + "self_attn.k_norm.weight")
-		if err != nil {
-			return nil, nil, err
-		}
-		kNorm, err := normalization.NewRMSNormFromParam[float32](
-			proxy, ops, rmsEps, pw.Wrap(prefix+"self_attn.k_norm.weight", kNormW),
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-		gqa.SetQKNorms(qNorm, kNorm)
-		gqa.SetQKNormWeights(qNormW, kNormW, rmsEps)
 
-		attnOut := builder.AddNode(gqa, normed)
+		var attnOut graph.Node[float32]
+		if isShared {
+			gqa.SetExternalKV(true)
+			gqa.SetQKNorms(qNorm, nil)
+			gqa.SetQKNormWeights(qNormW, nil, rmsEps)
 
-		// --- Post-Attention Norm (Gemma 4 always has post-norms) ---
+			donorIdx := ResolveKVDonor(i, firstSharedIdx, layerTypes)
+			donor, ok := donorGQA[donorIdx]
+			if !ok {
+				return nil, nil, fmt.Errorf("layer %d: donor GQA for index %d not registered", i, donorIdx)
+			}
+			geom, ok := donorKVGeom[donorIdx]
+			if !ok {
+				return nil, nil, fmt.Errorf("layer %d: donor geometry for index %d not registered", i, donorIdx)
+			}
+			donorKVHeads, donorHeadDim := geom[0], geom[1]
+			kReuse, err := NewKVReuseNode[float32](proxy, donor.KPort(), donorKVHeads, donorHeadDim, true)
+			if err != nil {
+				return nil, nil, fmt.Errorf("layer %d: K reuse: %w", i, err)
+			}
+			vReuse, err := NewKVReuseNode[float32](proxy, donor.VPort(), donorKVHeads, donorHeadDim, false)
+			if err != nil {
+				return nil, nil, fmt.Errorf("layer %d: V reuse: %w", i, err)
+			}
+			kIn := builder.AddNode(kReuse)
+			vIn := builder.AddNode(vReuse)
+			attnOut = builder.AddNode(gqa, normed, kIn, vIn)
+		} else {
+			if isGlobal && cfg.AttentionKEqV {
+				gqa.SetKEqV(true)
+			}
+			kNormW, err := tl.Lookup(prefix + "self_attn.k_norm.weight")
+			if err != nil {
+				return nil, nil, err
+			}
+			kNorm, err := normalization.NewRMSNormFromParam[float32](
+				proxy, ops, rmsEps, pw.Wrap(prefix+"self_attn.k_norm.weight", kNormW),
+			)
+			if err != nil {
+				return nil, nil, err
+			}
+			gqa.SetQKNorms(qNorm, kNorm)
+			gqa.SetQKNormWeights(qNormW, kNormW, rmsEps)
+			donorGQA[i] = gqa
+			donorKVGeom[i] = [2]int{numKVHeads, headDim}
+			attnOut = builder.AddNode(gqa, normed)
+		}
+
+		// --- Post-Attention Norm ---
 		postAttnNormW, err := tl.Lookup(prefix + "post_attention_layernorm.weight")
 		if err != nil {
 			return nil, nil, err
@@ -296,13 +340,13 @@ func buildGemma4EdgeGraph(
 		}
 		attnOut = builder.AddNode(postAttnNorm, attnOut)
 
-		// --- Fused Residual Add + Pre-FFN LayerNorm ---
+		// --- Fused Residual Add + Pre-FFN LayerNorm (residual = pre-attn hidden) ---
 		preFfnNormW, err := tl.Lookup(prefix + "pre_feedforward_layernorm.weight")
 		if err != nil {
 			return nil, nil, err
 		}
-		fusedNode := &fusedAddRMSNormNode[float32]{engine: proxy, weight: preFfnNormW, eps: rmsEps}
-		normed2 := builder.AddNode(fusedNode, attnOut, hidden)
+		fusedPreFFN := &fusedAddRMSNormNode[float32]{engine: proxy, weight: preFfnNormW, eps: rmsEps}
+		normed2 := builder.AddNode(fusedPreFFN, attnOut, hidden)
 
 		// --- FFN (GELU) ---
 		gateW, err := tl.Lookup(prefix + "mlp.gate_proj.weight")
@@ -317,6 +361,16 @@ func buildGemma4EdgeGraph(
 		if err != nil {
 			return nil, nil, err
 		}
+
+		// Per-layer intermediate size from gate_proj ground truth (the GGUF
+		// loader reverses GGUF's [cols, rows] to zerfoo [rows, cols], so
+		// gate_proj.Shape()[0] is the intermediate dim). This correctly
+		// handles HF/unsloth boundary mismatches in E2B packing.
+		gateShape := gateW.Shape()
+		if len(gateShape) != 2 {
+			return nil, nil, fmt.Errorf("layer %d gate_proj rank %d, want 2", i, len(gateShape))
+		}
+		intermediateSize := gateShape[0]
 
 		ffn, err := core.NewFFN[float32](
 			prefix+"mlp", proxy, ops,
@@ -340,7 +394,6 @@ func buildGemma4EdgeGraph(
 		if err != nil {
 			return nil, nil, err
 		}
-
 		ffnParams := ffn.Parameters()
 		ffnParams[0].Value = gateWT // w1 = gate_proj
 		ffnParams[1].Value = downWT // w2 = down_proj
@@ -348,15 +401,86 @@ func buildGemma4EdgeGraph(
 
 		ffnOut := builder.AddNode(ffn, normed2)
 
-		// --- Fused Post-FFN Norm + Residual Add ---
+		// --- Fused Post-FFN Norm + Residual Add (residual from fusedPreFFN input) ---
 		postFfnNormW, err := tl.Lookup(prefix + "post_feedforward_layernorm.weight")
 		if err != nil {
 			return nil, nil, err
 		}
-		fusedNormAdd := &fusedNormAddNode[float32]{engine: proxy, weight: postFfnNormW, eps: rmsEps}
-		resNode := &residualRefNode[float32]{source: fusedNode}
+		fusedPostFFN := &fusedNormAddNode[float32]{engine: proxy, weight: postFfnNormW, eps: rmsEps}
+		resNode := &residualRefNode[float32]{source: fusedPreFFN}
 		residualRef := builder.AddNode(resNode)
-		hidden = builder.AddNode(fusedNormAdd, ffnOut, residualRef)
+		afterFFN := builder.AddNode(fusedPostFFN, ffnOut, residualRef)
+
+		// --- PLE sub-block (after the standard FFN residual) ---
+		inpGateW, err := tl.Lookup(prefix + "input_gate.weight")
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d: %w", i, err)
+		}
+		pleLayerProjW, err := tl.Lookup(prefix + "ple_layer_proj.weight")
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d: %w", i, err)
+		}
+		postLayerNormW, err := tl.Lookup(prefix + "post_layernorm.weight")
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d: %w", i, err)
+		}
+		layerOutputScaleW, err := tl.Lookup(prefix + "layer_output_scale.weight")
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d: %w", i, err)
+		}
+
+		inpGateWT, err := tw(prefix+"input_gate.weight", inpGateW)
+		if err != nil {
+			return nil, nil, err
+		}
+		pleLayerProjWT, err := tw(prefix+"ple_layer_proj.weight", pleLayerProjW)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		inpGate := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"input_gate.weight", inpGateWT)), nil,
+		)
+		pleLayerProj := core.NewDenseFromParams(
+			core.NewLinearFromParam(proxy, pw.Wrap(prefix+"ple_layer_proj.weight", pleLayerProjWT)), nil,
+		)
+
+		// gelu(input_gate(afterFFN)) -- produces [B, S, pleDim]
+		gateOut := builder.AddNode(inpGate, afterFFN)
+		gelu := activations.NewGelu[float32](proxy, ops)
+		gateActivated := builder.AddNode(gelu, gateOut)
+
+		// Per-layer PLE slice: [B, S, pleDim], combined per HF line 1693-1696.
+		sliceNode, err := newPLESliceNode[float32](proxy, pleProducer, pleProjNormGain, rmsEps, i)
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d: pleSlice: %w", i, err)
+		}
+		pleSlice := builder.AddNode(sliceNode)
+
+		// Elementwise multiply gated hidden by per-layer inputs.
+		mulGatePLE := &elementwiseMulNode[float32]{engine: proxy}
+		gated := builder.AddNode(mulGatePLE, gateActivated, pleSlice)
+
+		// Project back to hidden and apply post_layernorm.
+		projected := builder.AddNode(pleLayerProj, gated)
+		postLayerNorm, err := normalization.NewRMSNormFromParam[float32](
+			proxy, ops, rmsEps, pw.Wrap(prefix+"post_layernorm.weight", postLayerNormW),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		postNormed := builder.AddNode(postLayerNorm, projected)
+
+		// Add PLE sub-block output to the FFN residual.
+		addRes := &elementwiseAddNode[float32]{engine: proxy}
+		combined := builder.AddNode(addRes, afterFFN, postNormed)
+
+		// --- Layer output scale (scalar broadcast) ---
+		scaleNode, err := newLayerOutputScaleNode[float32](proxy, layerOutputScaleW)
+		if err != nil {
+			return nil, nil, fmt.Errorf("layer %d: %w", i, err)
+		}
+		hidden = builder.AddNode(scaleNode, combined)
 	}
 
 	// --- Final RMSNorm ---
@@ -368,7 +492,7 @@ func buildGemma4EdgeGraph(
 	}
 	normedFinal := builder.AddNode(finalNorm, hidden)
 
-	// --- LM Head (tied to embedding) ---
+	// --- LM Head (tied to embedding, optional softcap) ---
 	lmHead := newLMHeadNode(proxy, embedWeight, cfg.LogitSoftcap)
 	output := builder.AddNode(lmHead, normedFinal)
 
@@ -376,8 +500,6 @@ func buildGemma4EdgeGraph(
 	if err != nil {
 		return nil, nil, fmt.Errorf("build graph: %w", err)
 	}
-
 	g.SetEngineProxy(proxy)
 	return g, embedWeight, nil
 }
-

--- a/inference/arch_gemma4_test.go
+++ b/inference/arch_gemma4_test.go
@@ -442,12 +442,15 @@ func TestBuildGemma4Graph_KEqV(t *testing.T) {
 // --- Gemma 4 Edge variant tests (E4B, E2B) ---
 
 // makeGemma4_E4BTestTensors creates tensors for the Gemma 4 E4B edge variant
-// with PLE (Per-Layer Embeddings) and KV-shared layers.
+// using the canonical post-mapping layout (ADR-086):
+//   - Shared PLE table, projection, and norm at model.* level.
+//   - Per-block input_gate, ple_layer_proj, post_layernorm, layer_output_scale.
 func makeGemma4_E4BTestTensors(cfg *gguf.ModelConfig) map[string]*tensor.TensorNumeric[float32] {
 	tensors := makeGemma4_31BTestTensors(cfg)
 
 	hidden := cfg.HiddenSize
 	pleHidden := cfg.PLEHiddenSize
+	totalPLE := cfg.NumLayers * pleHidden
 
 	fill := func(shape []int) *tensor.TensorNumeric[float32] {
 		size := 1
@@ -461,20 +464,61 @@ func makeGemma4_E4BTestTensors(cfg *gguf.ModelConfig) map[string]*tensor.TensorN
 		t, _ := tensor.New(shape, data)
 		return t
 	}
+	ones := func(shape []int) *tensor.TensorNumeric[float32] {
+		size := 1
+		for _, d := range shape {
+			size *= d
+		}
+		data := make([]float32, size)
+		for i := range data {
+			data[i] = 1.0
+		}
+		t, _ := tensor.New(shape, data)
+		return t
+	}
+	zeros := func(shape []int) *tensor.TensorNumeric[float32] {
+		size := 1
+		for _, d := range shape {
+			size *= d
+		}
+		t, _ := tensor.New(shape, make([]float32, size))
+		return t
+	}
 
+	// Shared PLE tensors.
+	tensors["model.ple_embed_tokens.weight"] = fill([]int{cfg.VocabSize, totalPLE})
+	tensors["model.ple_model_proj.weight"] = fill([]int{totalPLE, hidden})
+	tensors["model.ple_proj_norm.weight"] = zeros([]int{pleHidden}) // Gemma uses (1+gain); 0 gain => identity.
+
+	// Remove k_proj/v_proj/k_norm for shared layers (canonical layout skips them).
+	firstSharedIdx := cfg.NumLayers - cfg.KVSharedLayers
+	if firstSharedIdx < 0 {
+		firstSharedIdx = 0
+	}
 	for i := 0; i < cfg.NumLayers; i++ {
 		prefix := "model.layers." + itoa(i) + "."
-		// PLE embedding weight: [vocab, ple_hidden_size].
-		tensors[prefix+"ple.weight"] = fill([]int{cfg.VocabSize, pleHidden})
-		// PLE projection weight: [hidden_size, ple_hidden_size] (GGUF convention: out, in).
-		tensors[prefix+"ple_proj.weight"] = fill([]int{hidden, pleHidden})
+		if i >= firstSharedIdx {
+			delete(tensors, prefix+"self_attn.k_proj.weight")
+			delete(tensors, prefix+"self_attn.v_proj.weight")
+			delete(tensors, prefix+"self_attn.k_norm.weight")
+		}
+		// Per-block PLE sub-block tensors.
+		// GGUF post-mapping convention stores weights as [out, in]; the loader
+		// flips to [in, out] for the framework. Fixtures author [out, in] to
+		// match the real GGUF loader path.
+		tensors[prefix+"input_gate.weight"] = fill([]int{pleHidden, hidden})
+		tensors[prefix+"ple_layer_proj.weight"] = fill([]int{hidden, pleHidden})
+		tensors[prefix+"post_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"layer_output_scale.weight"] = ones([]int{1})
 	}
 
 	return tensors
 }
 
 // makeGemma4_E2BTestTensors creates tensors for the Gemma 4 E2B edge variant
-// with PLE, KV-shared layers, and double-wide MLP.
+// using the canonical post-mapping layout (ADR-086): canonical PLE at
+// model.* level plus per-block input_gate, ple_layer_proj, post_layernorm,
+// layer_output_scale. E2B uses double-wide MLP.
 func makeGemma4_E2BTestTensors(cfg *gguf.ModelConfig) map[string]*tensor.TensorNumeric[float32] {
 	hidden := cfg.HiddenSize
 	headDim := cfg.HiddenSize / cfg.NumHeads
@@ -482,6 +526,7 @@ func makeGemma4_E2BTestTensors(cfg *gguf.ModelConfig) map[string]*tensor.TensorN
 		headDim = cfg.HeadDim
 	}
 	pleHidden := cfg.PLEHiddenSize
+	totalPLE := cfg.NumLayers * pleHidden
 	inter := cfg.IntermediateSize
 	if cfg.DoubleWideMLP {
 		inter = cfg.IntermediateSize * 2
@@ -511,35 +556,58 @@ func makeGemma4_E2BTestTensors(cfg *gguf.ModelConfig) map[string]*tensor.TensorN
 		t, _ := tensor.New(shape, data)
 		return t
 	}
+	zeros := func(shape []int) *tensor.TensorNumeric[float32] {
+		size := 1
+		for _, d := range shape {
+			size *= d
+		}
+		t, _ := tensor.New(shape, make([]float32, size))
+		return t
+	}
 
 	tensors := make(map[string]*tensor.TensorNumeric[float32])
 	tensors["model.embed_tokens.weight"] = fill([]int{cfg.VocabSize, hidden})
 	tensors["model.norm.weight"] = ones([]int{hidden})
 
+	// Shared PLE tensors (ADR-086).
+	tensors["model.ple_embed_tokens.weight"] = fill([]int{cfg.VocabSize, totalPLE})
+	tensors["model.ple_model_proj.weight"] = fill([]int{totalPLE, hidden})
+	tensors["model.ple_proj_norm.weight"] = zeros([]int{pleHidden})
+
+	firstSharedIdx := cfg.NumLayers - cfg.KVSharedLayers
+	if firstSharedIdx < 0 {
+		firstSharedIdx = 0
+	}
+
 	kvDim := headDim * cfg.NumKVHeads
 	for i := 0; i < cfg.NumLayers; i++ {
 		prefix := "model.layers." + itoa(i) + "."
 
-		// Standard Gemma 4 layer tensors.
 		tensors[prefix+"input_layernorm.weight"] = ones([]int{hidden})
 		tensors[prefix+"self_attn.q_proj.weight"] = fill([]int{hidden, hidden})
-		tensors[prefix+"self_attn.k_proj.weight"] = fill([]int{kvDim, hidden})
-		tensors[prefix+"self_attn.v_proj.weight"] = fill([]int{kvDim, hidden})
 		tensors[prefix+"self_attn.o_proj.weight"] = fill([]int{hidden, hidden})
 		tensors[prefix+"post_attention_layernorm.weight"] = ones([]int{hidden})
 		tensors[prefix+"pre_feedforward_layernorm.weight"] = ones([]int{hidden})
 		tensors[prefix+"post_feedforward_layernorm.weight"] = ones([]int{hidden})
 		tensors[prefix+"self_attn.q_norm.weight"] = ones([]int{headDim})
-		tensors[prefix+"self_attn.k_norm.weight"] = ones([]int{headDim})
+
+		// Shared layers skip k_proj/v_proj/k_norm (HF modeling_gemma4.py 1167).
+		if i < firstSharedIdx {
+			tensors[prefix+"self_attn.k_proj.weight"] = fill([]int{kvDim, hidden})
+			tensors[prefix+"self_attn.v_proj.weight"] = fill([]int{kvDim, hidden})
+			tensors[prefix+"self_attn.k_norm.weight"] = ones([]int{headDim})
+		}
 
 		// Double-wide MLP.
 		tensors[prefix+"mlp.gate_proj.weight"] = fill([]int{inter, hidden})
 		tensors[prefix+"mlp.up_proj.weight"] = fill([]int{inter, hidden})
 		tensors[prefix+"mlp.down_proj.weight"] = fill([]int{hidden, inter})
 
-		// PLE tensors.
-		tensors[prefix+"ple.weight"] = fill([]int{cfg.VocabSize, pleHidden})
-		tensors[prefix+"ple_proj.weight"] = fill([]int{hidden, pleHidden})
+		// PLE sub-block (per-layer).
+		tensors[prefix+"input_gate.weight"] = fill([]int{pleHidden, hidden})
+		tensors[prefix+"ple_layer_proj.weight"] = fill([]int{hidden, pleHidden})
+		tensors[prefix+"post_layernorm.weight"] = ones([]int{hidden})
+		tensors[prefix+"layer_output_scale.weight"] = ones([]int{1})
 	}
 
 	return tensors
@@ -622,7 +690,7 @@ func TestBuildGemma4EdgeGraph_E2B_DoubleWideMLP(t *testing.T) {
 		Architecture:         "gemma4e",
 		VocabSize:            32,
 		HiddenSize:           16,
-		NumLayers:            2,
+		NumLayers:            4,
 		NumHeads:             4,
 		NumKVHeads:           2,
 		IntermediateSize:     32,
@@ -677,27 +745,31 @@ func TestBuildGemma4EdgeGraph_KVSharing(t *testing.T) {
 	}
 	tensors := makeGemma4_E4BTestTensors(cfg)
 
-	// Verify that layers 0 and 1 share the same K/V tensors (from layer 0).
-	kLayer0 := tensors["model.layers.0.self_attn.k_proj.weight"]
-	vLayer0 := tensors["model.layers.0.self_attn.v_proj.weight"]
-	kLayer1 := tensors["model.layers.1.self_attn.k_proj.weight"]
-	vLayer1 := tensors["model.layers.1.self_attn.v_proj.weight"]
-
-	// In the tensor map, each layer has its own weights. But the builder should
-	// load K/V from the source layer. Verify the builder resolves KV correctly
-	// by checking that the source tensors exist and the build succeeds.
-	if kLayer0 == nil || vLayer0 == nil {
-		t.Fatal("source layer 0 K/V tensors missing")
+	// In the canonical layout (ADR-086, ADR-087), the last KVSharedLayers
+	// layers do not own k_proj/v_proj/k_norm tensors -- they reuse K/V at
+	// runtime via KVReuseNode from the nearest non-shared layer of the same
+	// attention type. With NumLayers=4 and KVSharedLayers=2, layers 0..1 are
+	// donors and layers 2..3 are shared consumers.
+	for i := 0; i < 2; i++ {
+		prefix := "model.layers." + itoa(i) + "."
+		if tensors[prefix+"self_attn.k_proj.weight"] == nil {
+			t.Fatalf("donor layer %d k_proj.weight missing", i)
+		}
+		if tensors[prefix+"self_attn.v_proj.weight"] == nil {
+			t.Fatalf("donor layer %d v_proj.weight missing", i)
+		}
 	}
-	if kLayer1 == nil || vLayer1 == nil {
-		t.Fatal("layer 1 K/V tensors missing (expected for tensor map, builder uses layer 0's)")
-	}
-
-	// Layers 2-3 share KV from layer 2.
-	kLayer2 := tensors["model.layers.2.self_attn.k_proj.weight"]
-	vLayer2 := tensors["model.layers.2.self_attn.v_proj.weight"]
-	if kLayer2 == nil || vLayer2 == nil {
-		t.Fatal("source layer 2 K/V tensors missing")
+	for i := 2; i < 4; i++ {
+		prefix := "model.layers." + itoa(i) + "."
+		if _, exists := tensors[prefix+"self_attn.k_proj.weight"]; exists {
+			t.Fatalf("shared layer %d unexpectedly has k_proj.weight", i)
+		}
+		if _, exists := tensors[prefix+"self_attn.v_proj.weight"]; exists {
+			t.Fatalf("shared layer %d unexpectedly has v_proj.weight", i)
+		}
+		if _, exists := tensors[prefix+"self_attn.k_norm.weight"]; exists {
+			t.Fatalf("shared layer %d unexpectedly has k_norm.weight", i)
+		}
 	}
 
 	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})

--- a/inference/gemma4_edge_ple_nodes.go
+++ b/inference/gemma4_edge_ple_nodes.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/zerfoo/zerfoo/layers/normalization"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
 	"github.com/zerfoo/ztensor/types"
 )
@@ -180,8 +182,7 @@ func (p *pleCombinedProducer[T]) Backward(_ context.Context, _ types.BackwardMod
 type pleSliceNode[T tensor.Numeric] struct {
 	engine    compute.Engine[T]
 	producer  *pleCombinedProducer[T]
-	normGain  *tensor.TensorNumeric[T] // [pleDim] shared RMSNorm gain
-	eps       float32
+	normLayer *normalization.RMSNorm[T] // shared per-layer projection norm
 	layerIdx  int
 	pleDim    int
 	numLayers int
@@ -189,6 +190,7 @@ type pleSliceNode[T tensor.Numeric] struct {
 
 func newPLESliceNode[T tensor.Numeric](
 	engine compute.Engine[T],
+	ops numeric.Arithmetic[T],
 	producer *pleCombinedProducer[T],
 	normGain *tensor.TensorNumeric[T],
 	eps float32,
@@ -207,11 +209,18 @@ func newPLESliceNode[T tensor.Numeric](
 	if layerIdx < 0 || layerIdx >= producer.numLayers {
 		return nil, fmt.Errorf("pleSliceNode: layerIdx %d out of range [0, %d)", layerIdx, producer.numLayers)
 	}
+	gainParam, err := graph.NewParameter[T](fmt.Sprintf("ple_proj_norm.gain.layer_%d", layerIdx), normGain, tensor.New[T])
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode: wrap normGain: %w", err)
+	}
+	normLayer, err := normalization.NewRMSNormFromParam[T](engine, ops, ops.FromFloat64(float64(eps)), gainParam)
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode: build RMSNorm: %w", err)
+	}
 	return &pleSliceNode[T]{
 		engine:    engine,
 		producer:  producer,
-		normGain:  normGain,
-		eps:       eps,
+		normLayer: normLayer,
 		layerIdx:  layerIdx,
 		pleDim:    producer.pleDim,
 		numLayers: producer.numLayers,
@@ -224,7 +233,12 @@ func (n *pleSliceNode[T]) OutputShape() []int                { return nil }
 func (n *pleSliceNode[T]) Parameters() []*graph.Parameter[T] { return nil }
 
 func (n *pleSliceNode[T]) EmbeddedFrozen() []*tensor.TensorNumeric[T] {
-	return []*tensor.TensorNumeric[T]{n.normGain}
+	params := n.normLayer.Parameters()
+	frozen := make([]*tensor.TensorNumeric[T], 0, len(params))
+	for _, p := range params {
+		frozen = append(frozen, p.Value)
+	}
+	return frozen
 }
 
 // Forward reads the producer's cached tensors, extracts slice [layerIdx],
@@ -242,8 +256,9 @@ func (n *pleSliceNode[T]) Forward(ctx context.Context, _ ...*tensor.TensorNumeri
 	if err != nil {
 		return nil, fmt.Errorf("pleSliceNode(layer=%d): proj slice: %w", n.layerIdx, err)
 	}
-	// RMSNorm over last dim using the shared normGain.
-	projNormed, err := rmsNormLastDim[T](ctx, n.engine, projSlice, n.normGain, n.eps)
+	// Delegate RMSNorm to layers/normalization (architectural guard:
+	// private layer reimpls are disallowed outside layers/).
+	projNormed, err := n.normLayer.Forward(ctx, projSlice)
 	if err != nil {
 		return nil, fmt.Errorf("pleSliceNode(layer=%d): rmsnorm: %w", n.layerIdx, err)
 	}
@@ -289,44 +304,6 @@ func sliceLastDim[T tensor.Numeric](_ context.Context, _ compute.Engine[T], src 
 		}
 	}
 	return tensor.New[T]([]int{batch, seqLen, length}, out)
-}
-
-// rmsNormLastDim computes RMSNorm over the last axis of a rank-3 tensor
-// using the provided per-channel gain. Gemma-family RMSNorm uses (1 + gain)
-// as the effective scale (matches normalization.RMSNorm Gemma default).
-func rmsNormLastDim[T tensor.Numeric](_ context.Context, _ compute.Engine[T], src *tensor.TensorNumeric[T], gain *tensor.TensorNumeric[T], eps float32) (*tensor.TensorNumeric[T], error) {
-	shape := src.Shape()
-	if len(shape) != 3 {
-		return nil, fmt.Errorf("rmsNormLastDim: expected rank 3, got %d", len(shape))
-	}
-	dim := shape[2]
-	gainShape := gain.Shape()
-	if len(gainShape) != 1 || gainShape[0] != dim {
-		return nil, fmt.Errorf("rmsNormLastDim: gain shape %v incompatible with dim=%d", gainShape, dim)
-	}
-	gainData := gain.Data()
-	srcData := src.Data()
-	if srcData == nil || gainData == nil {
-		return nil, fmt.Errorf("rmsNormLastDim: CPU path requires dense data")
-	}
-	out := make([]T, len(srcData))
-	batch, seqLen := shape[0], shape[1]
-	for b := 0; b < batch; b++ {
-		for s := 0; s < seqLen; s++ {
-			off := (b*seqLen + s) * dim
-			var sumSq float64
-			for d := 0; d < dim; d++ {
-				v := float64(srcData[off+d])
-				sumSq += v * v
-			}
-			invRMS := 1.0 / math.Sqrt(sumSq/float64(dim)+float64(eps))
-			for d := 0; d < dim; d++ {
-				g := 1.0 + float64(gainData[d])
-				out[off+d] = T(float64(srcData[off+d]) * invRMS * g)
-			}
-		}
-	}
-	return tensor.New[T](shape, out)
 }
 
 // layerOutputScaleNode multiplies its input by a learned scalar stored as a

--- a/inference/gemma4_edge_ple_nodes.go
+++ b/inference/gemma4_edge_ple_nodes.go
@@ -363,7 +363,7 @@ func (n *layerOutputScaleNode[T]) Forward(ctx context.Context, inputs ...*tensor
 		return nil, fmt.Errorf("Gemma4LayerOutputScale: expected 1 input, got %d", len(inputs))
 	}
 	sData := n.scale.Data()
-	if sData == nil || len(sData) == 0 {
+	if len(sData) == 0 {
 		return nil, fmt.Errorf("Gemma4LayerOutputScale: scale data empty")
 	}
 	return n.engine.MulScalar(ctx, inputs[0], sData[0])

--- a/inference/gemma4_edge_ple_nodes.go
+++ b/inference/gemma4_edge_ple_nodes.go
@@ -1,0 +1,396 @@
+// Package inference: Gemma 4 edge PLE (Per-Layer Embedding) helper nodes.
+//
+// These nodes implement the PLE combiner described in ADR-086 and
+// HuggingFace transformers modeling_gemma4.py Gemma4TextModel.project_per_layer_inputs
+// (lines 1674-1696) and Gemma4TextDecoderLayer.forward (lines 1401-1408).
+//
+// The canonical Gemma 4 edge layout packs 35 per-layer 256-dim embedding
+// slices into a single [vocab, 8960] table (`model.ple_embed_tokens.weight`).
+// A global [hidden, 8960] projection (`model.ple_model_proj.weight`) and a
+// shared [256] RMSNorm (`model.ple_proj_norm.weight`) feed the per-layer
+// combiner. Per-block `input_gate`, `ple_layer_proj`, and `post_layernorm`
+// weights complete the sub-block.
+//
+// The builder wires one `pleCombinedProducer` per graph to compute both
+// full-width per-layer feature tensors once, and one `pleSliceNode` per
+// transformer layer to extract that layer's [B, S, 256] slice and combine
+// them into `per_layer_inputs[i]`.
+package inference
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// pleCombinedProducer computes the two full-width [B, S, numLayers*pleDim]
+// per-layer feature tensors once per forward pass and caches the result for
+// consumption by pleSliceNode.
+//
+// Inputs:
+//
+//	inputs[0] -- token ids [B, S]
+//	inputs[1] -- hidden after main embedding lookup, scaled by sqrt(hidden).
+//	             HF multiplies by hidden_size**-0.5 before the projection; we
+//	             pre-apply the inverse scale inside this node so the caller
+//	             passes the standard `embeds * sqrt(hidden)` (same tensor the
+//	             main transformer stack consumes).
+//
+// Outputs an opaque placeholder tensor; consumers read results via the
+// producer's cached tokenPLE / modelProj fields through pleSliceNode.
+type pleCombinedProducer[T tensor.Numeric] struct {
+	engine compute.Engine[T]
+
+	pleEmbed     *tensor.TensorNumeric[T] // [vocab, numLayers*pleDim]
+	pleModelProj *tensor.TensorNumeric[T] // [hidden, numLayers*pleDim] (already transposed for MatMul)
+
+	numLayers  int
+	pleDim     int
+	hiddenSize int
+	vocabSize  int
+
+	tokenPLE  *tensor.TensorNumeric[T] // cached: [B, S, numLayers*pleDim]
+	modelProj *tensor.TensorNumeric[T] // cached: [B, S, numLayers*pleDim]
+}
+
+func newPLECombinedProducer[T tensor.Numeric](
+	engine compute.Engine[T],
+	pleEmbed, pleModelProj *tensor.TensorNumeric[T],
+	numLayers, pleDim, hiddenSize int,
+) (*pleCombinedProducer[T], error) {
+	if pleEmbed == nil || pleModelProj == nil {
+		return nil, fmt.Errorf("pleCombinedProducer: pleEmbed and pleModelProj must be non-nil")
+	}
+	embShape := pleEmbed.Shape()
+	if len(embShape) != 2 || embShape[1] != numLayers*pleDim {
+		return nil, fmt.Errorf("pleCombinedProducer: pleEmbed shape %v incompatible with numLayers=%d pleDim=%d",
+			embShape, numLayers, pleDim)
+	}
+	projShape := pleModelProj.Shape()
+	if len(projShape) != 2 || projShape[0] != hiddenSize || projShape[1] != numLayers*pleDim {
+		return nil, fmt.Errorf("pleCombinedProducer: pleModelProj shape %v incompatible with hidden=%d numLayers=%d pleDim=%d",
+			projShape, hiddenSize, numLayers, pleDim)
+	}
+	return &pleCombinedProducer[T]{
+		engine:       engine,
+		pleEmbed:     pleEmbed,
+		pleModelProj: pleModelProj,
+		numLayers:    numLayers,
+		pleDim:       pleDim,
+		hiddenSize:   hiddenSize,
+		vocabSize:    embShape[0],
+	}, nil
+}
+
+func (p *pleCombinedProducer[T]) OpType() string                   { return "Gemma4PLECombinedProducer" }
+func (p *pleCombinedProducer[T]) Attributes() map[string]any        { return nil }
+func (p *pleCombinedProducer[T]) OutputShape() []int                { return nil }
+func (p *pleCombinedProducer[T]) Parameters() []*graph.Parameter[T] { return nil }
+
+// EmbeddedFrozen registers the PLE tables as frozen constants so the graph
+// compiler treats them the same as normal embedding/weight tensors.
+func (p *pleCombinedProducer[T]) EmbeddedFrozen() []*tensor.TensorNumeric[T] {
+	return []*tensor.TensorNumeric[T]{p.pleEmbed, p.pleModelProj}
+}
+
+// Forward computes per-layer features. Returns inputs[1] unchanged as a
+// pass-through; the actual per-layer outputs are read by pleSliceNode
+// consumers via p.tokenPLE and p.modelProj.
+func (p *pleCombinedProducer[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	if len(inputs) != 2 {
+		return nil, fmt.Errorf("Gemma4PLECombinedProducer: expected 2 inputs (ids, hidden), got %d", len(inputs))
+	}
+	ids := inputs[0]
+	hidden := inputs[1]
+
+	idsShape := ids.Shape()
+	if len(idsShape) != 2 {
+		return nil, fmt.Errorf("Gemma4PLECombinedProducer: ids rank %d, want 2 ([B, S])", len(idsShape))
+	}
+	batch, seqLen := idsShape[0], idsShape[1]
+	totalPLE := p.numLayers * p.pleDim
+
+	// --- 1. Token-identity PLE lookup.
+	// Produce [B, S, totalPLE] by gathering rows of p.pleEmbed. Use the
+	// same logic as embeddingLookupNode but specialized to float data here.
+	idData := ids.Data()
+	flatLen := batch * seqLen
+	tokenFlat := make([]T, flatLen*totalPLE)
+	pleData := p.pleEmbed.Data()
+	if pleData == nil {
+		return nil, fmt.Errorf("Gemma4PLECombinedProducer: CPU path requires dense pleEmbed data")
+	}
+	for i := 0; i < flatLen; i++ {
+		id := int(idData[i])
+		if id < 0 || id >= p.vocabSize {
+			return nil, fmt.Errorf("Gemma4PLECombinedProducer: token id %d out of range [0, %d)", id, p.vocabSize)
+		}
+		copy(tokenFlat[i*totalPLE:(i+1)*totalPLE], pleData[id*totalPLE:(id+1)*totalPLE])
+	}
+	tokenPLE, err := tensor.New[T]([]int{batch, seqLen, totalPLE}, tokenFlat)
+	if err != nil {
+		return nil, fmt.Errorf("Gemma4PLECombinedProducer: tokenPLE alloc: %w", err)
+	}
+
+	// Scale by sqrt(pleDim). HF: per-layer embedding is multiplied by
+	// sqrt(hidden_size_per_layer_input) = sqrt(256) = 16 (line 1688-1689).
+	pleScale := T(math.Sqrt(float64(p.pleDim)))
+	tokenPLE, err = p.engine.MulScalar(ctx, tokenPLE, pleScale)
+	if err != nil {
+		return nil, fmt.Errorf("Gemma4PLECombinedProducer: tokenPLE scale: %w", err)
+	}
+	p.tokenPLE = tokenPLE
+
+	// --- 2. Per-layer model projection.
+	// HF (line 1687): per_layer_projection = per_layer_model_proj(embeds * hidden_size**-0.5).
+	// Caller passed in `embeds * sqrt(hidden)` (the standard scaled embedding that
+	// feeds the transformer stack). Multiplying by hidden**-0.5 yields
+	// `embeds * sqrt(hidden) * hidden**-0.5 = embeds * hidden**-0.5`, matching HF.
+	invScale := T(1.0 / math.Sqrt(float64(p.hiddenSize)))
+	scaled, err := p.engine.MulScalar(ctx, hidden, invScale)
+	if err != nil {
+		return nil, fmt.Errorf("Gemma4PLECombinedProducer: invScale hidden: %w", err)
+	}
+	// [B, S, hidden] @ [hidden, totalPLE] -> [B, S, totalPLE].
+	proj, err := p.engine.MatMul(ctx, scaled, p.pleModelProj)
+	if err != nil {
+		return nil, fmt.Errorf("Gemma4PLECombinedProducer: model_proj matmul: %w", err)
+	}
+	p.modelProj = proj
+
+	// Pass-through the hidden input so downstream nodes that declare a
+	// dependency on the producer see a well-formed tensor.
+	return hidden, nil
+}
+
+func (p *pleCombinedProducer[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	return nil, nil
+}
+
+// pleSliceNode extracts the per-layer [B, S, pleDim] slice from the producer's
+// cached full-width tensors, applies the shared per-layer projection RMSNorm
+// to the projection slice, adds the token-identity PLE slice, and scales by
+// 1/sqrt(2) to produce `per_layer_inputs[layerIdx]`. See HF
+// modeling_gemma4.py lines 1682-1696.
+type pleSliceNode[T tensor.Numeric] struct {
+	engine    compute.Engine[T]
+	producer  *pleCombinedProducer[T]
+	normGain  *tensor.TensorNumeric[T] // [pleDim] shared RMSNorm gain
+	eps       float32
+	layerIdx  int
+	pleDim    int
+	numLayers int
+}
+
+func newPLESliceNode[T tensor.Numeric](
+	engine compute.Engine[T],
+	producer *pleCombinedProducer[T],
+	normGain *tensor.TensorNumeric[T],
+	eps float32,
+	layerIdx int,
+) (*pleSliceNode[T], error) {
+	if producer == nil {
+		return nil, fmt.Errorf("pleSliceNode: producer must be non-nil")
+	}
+	if normGain == nil {
+		return nil, fmt.Errorf("pleSliceNode: normGain must be non-nil")
+	}
+	normShape := normGain.Shape()
+	if len(normShape) != 1 || normShape[0] != producer.pleDim {
+		return nil, fmt.Errorf("pleSliceNode: normGain shape %v incompatible with pleDim=%d", normShape, producer.pleDim)
+	}
+	if layerIdx < 0 || layerIdx >= producer.numLayers {
+		return nil, fmt.Errorf("pleSliceNode: layerIdx %d out of range [0, %d)", layerIdx, producer.numLayers)
+	}
+	return &pleSliceNode[T]{
+		engine:    engine,
+		producer:  producer,
+		normGain:  normGain,
+		eps:       eps,
+		layerIdx:  layerIdx,
+		pleDim:    producer.pleDim,
+		numLayers: producer.numLayers,
+	}, nil
+}
+
+func (n *pleSliceNode[T]) OpType() string                   { return "Gemma4PLESlice" }
+func (n *pleSliceNode[T]) Attributes() map[string]any        { return map[string]any{"layer": n.layerIdx} }
+func (n *pleSliceNode[T]) OutputShape() []int                { return nil }
+func (n *pleSliceNode[T]) Parameters() []*graph.Parameter[T] { return nil }
+
+func (n *pleSliceNode[T]) EmbeddedFrozen() []*tensor.TensorNumeric[T] {
+	return []*tensor.TensorNumeric[T]{n.normGain}
+}
+
+// Forward reads the producer's cached tensors, extracts slice [layerIdx],
+// applies RMSNorm to the projection slice (dim=pleDim), adds the
+// token-identity slice, scales by 1/sqrt(2), and returns [B, S, pleDim].
+func (n *pleSliceNode[T]) Forward(ctx context.Context, _ ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	if n.producer.tokenPLE == nil || n.producer.modelProj == nil {
+		return nil, fmt.Errorf("pleSliceNode(layer=%d): producer has not run Forward yet", n.layerIdx)
+	}
+	tokenSlice, err := sliceLastDim[T](ctx, n.engine, n.producer.tokenPLE, n.layerIdx*n.pleDim, n.pleDim)
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode(layer=%d): token slice: %w", n.layerIdx, err)
+	}
+	projSlice, err := sliceLastDim[T](ctx, n.engine, n.producer.modelProj, n.layerIdx*n.pleDim, n.pleDim)
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode(layer=%d): proj slice: %w", n.layerIdx, err)
+	}
+	// RMSNorm over last dim using the shared normGain.
+	projNormed, err := rmsNormLastDim[T](ctx, n.engine, projSlice, n.normGain, n.eps)
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode(layer=%d): rmsnorm: %w", n.layerIdx, err)
+	}
+	combined, err := n.engine.Add(ctx, projNormed, tokenSlice)
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode(layer=%d): add: %w", n.layerIdx, err)
+	}
+	// per_layer_input_scale = 1/sqrt(2) (HF line 1695).
+	inputScale := T(1.0 / math.Sqrt(2.0))
+	scaled, err := n.engine.MulScalar(ctx, combined, inputScale)
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode(layer=%d): scale: %w", n.layerIdx, err)
+	}
+	return scaled, nil
+}
+
+func (n *pleSliceNode[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	return nil, nil
+}
+
+// sliceLastDim extracts elements [start, start+length) along the last axis of
+// a rank-3 tensor shaped [B, S, D]. Implemented via a direct data copy; the
+// compute.Engine interface has no generic slice primitive today.
+func sliceLastDim[T tensor.Numeric](_ context.Context, _ compute.Engine[T], src *tensor.TensorNumeric[T], start, length int) (*tensor.TensorNumeric[T], error) {
+	shape := src.Shape()
+	if len(shape) != 3 {
+		return nil, fmt.Errorf("sliceLastDim: expected rank 3, got %d", len(shape))
+	}
+	batch, seqLen, dim := shape[0], shape[1], shape[2]
+	if start < 0 || start+length > dim {
+		return nil, fmt.Errorf("sliceLastDim: [%d, %d) out of range [0, %d)", start, start+length, dim)
+	}
+	srcData := src.Data()
+	if srcData == nil {
+		return nil, fmt.Errorf("sliceLastDim: CPU path requires dense src data")
+	}
+	out := make([]T, batch*seqLen*length)
+	for b := 0; b < batch; b++ {
+		for s := 0; s < seqLen; s++ {
+			srcOff := (b*seqLen+s)*dim + start
+			dstOff := (b*seqLen + s) * length
+			copy(out[dstOff:dstOff+length], srcData[srcOff:srcOff+length])
+		}
+	}
+	return tensor.New[T]([]int{batch, seqLen, length}, out)
+}
+
+// rmsNormLastDim computes RMSNorm over the last axis of a rank-3 tensor
+// using the provided per-channel gain. Gemma-family RMSNorm uses (1 + gain)
+// as the effective scale (matches normalization.RMSNorm Gemma default).
+func rmsNormLastDim[T tensor.Numeric](_ context.Context, _ compute.Engine[T], src *tensor.TensorNumeric[T], gain *tensor.TensorNumeric[T], eps float32) (*tensor.TensorNumeric[T], error) {
+	shape := src.Shape()
+	if len(shape) != 3 {
+		return nil, fmt.Errorf("rmsNormLastDim: expected rank 3, got %d", len(shape))
+	}
+	dim := shape[2]
+	gainShape := gain.Shape()
+	if len(gainShape) != 1 || gainShape[0] != dim {
+		return nil, fmt.Errorf("rmsNormLastDim: gain shape %v incompatible with dim=%d", gainShape, dim)
+	}
+	gainData := gain.Data()
+	srcData := src.Data()
+	if srcData == nil || gainData == nil {
+		return nil, fmt.Errorf("rmsNormLastDim: CPU path requires dense data")
+	}
+	out := make([]T, len(srcData))
+	batch, seqLen := shape[0], shape[1]
+	for b := 0; b < batch; b++ {
+		for s := 0; s < seqLen; s++ {
+			off := (b*seqLen + s) * dim
+			var sumSq float64
+			for d := 0; d < dim; d++ {
+				v := float64(srcData[off+d])
+				sumSq += v * v
+			}
+			invRMS := 1.0 / math.Sqrt(sumSq/float64(dim)+float64(eps))
+			for d := 0; d < dim; d++ {
+				g := 1.0 + float64(gainData[d])
+				out[off+d] = T(float64(srcData[off+d]) * invRMS * g)
+			}
+		}
+	}
+	return tensor.New[T](shape, out)
+}
+
+// layerOutputScaleNode multiplies its input by a learned scalar stored as a
+// 1-element tensor (`model.layers.N.layer_output_scale.weight`). Corresponds
+// to `self.layer_scalar` in HF modeling_gemma4.py (line 1337, applied at line
+// 1410: hidden_states *= self.layer_scalar).
+type layerOutputScaleNode[T tensor.Numeric] struct {
+	engine compute.Engine[T]
+	scale  *tensor.TensorNumeric[T] // shape [1]
+}
+
+func newLayerOutputScaleNode[T tensor.Numeric](engine compute.Engine[T], scale *tensor.TensorNumeric[T]) (*layerOutputScaleNode[T], error) {
+	if scale == nil {
+		return nil, fmt.Errorf("layerOutputScaleNode: scale must be non-nil")
+	}
+	shape := scale.Shape()
+	if len(shape) != 1 || shape[0] != 1 {
+		return nil, fmt.Errorf("layerOutputScaleNode: scale shape %v, want [1]", shape)
+	}
+	return &layerOutputScaleNode[T]{engine: engine, scale: scale}, nil
+}
+
+func (n *layerOutputScaleNode[T]) OpType() string                   { return "Gemma4LayerOutputScale" }
+func (n *layerOutputScaleNode[T]) Attributes() map[string]any        { return nil }
+func (n *layerOutputScaleNode[T]) OutputShape() []int                { return nil }
+func (n *layerOutputScaleNode[T]) Parameters() []*graph.Parameter[T] { return nil }
+
+func (n *layerOutputScaleNode[T]) EmbeddedFrozen() []*tensor.TensorNumeric[T] {
+	return []*tensor.TensorNumeric[T]{n.scale}
+}
+
+func (n *layerOutputScaleNode[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	if len(inputs) != 1 {
+		return nil, fmt.Errorf("Gemma4LayerOutputScale: expected 1 input, got %d", len(inputs))
+	}
+	sData := n.scale.Data()
+	if sData == nil || len(sData) == 0 {
+		return nil, fmt.Errorf("Gemma4LayerOutputScale: scale data empty")
+	}
+	return n.engine.MulScalar(ctx, inputs[0], sData[0])
+}
+
+func (n *layerOutputScaleNode[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	return nil, nil
+}
+
+// elementwiseMulNode computes element-wise inputs[0] * inputs[1]. Used by the
+// PLE sub-block gate stage: `gelu(inp_gate(h)) * per_layer_inputs[i]`.
+type elementwiseMulNode[T tensor.Numeric] struct {
+	engine compute.Engine[T]
+}
+
+func (n *elementwiseMulNode[T]) OpType() string                   { return "ElementwiseMul" }
+func (n *elementwiseMulNode[T]) Attributes() map[string]any        { return nil }
+func (n *elementwiseMulNode[T]) OutputShape() []int                { return nil }
+func (n *elementwiseMulNode[T]) Parameters() []*graph.Parameter[T] { return nil }
+
+func (n *elementwiseMulNode[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	if len(inputs) != 2 {
+		return nil, fmt.Errorf("ElementwiseMul: expected 2 inputs, got %d", len(inputs))
+	}
+	return n.engine.Mul(ctx, inputs[0], inputs[1])
+}
+
+func (n *elementwiseMulNode[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	return nil, nil
+}

--- a/layers/attention/grouped_query_attention.go
+++ b/layers/attention/grouped_query_attention.go
@@ -326,6 +326,29 @@ func (gqa *GroupedQueryAttention[T]) SetKEqV(v bool) {
 	gqa.kEqV = v
 }
 
+// SetExternalKV configures the layer to read K/V from Forward inputs[1]/[2]
+// instead of projecting from its own wk/wv weights. When enabled, wk, wv, and
+// kNorm are cleared (the shared-KV layer does not use them per ADR-087 and
+// HuggingFace transformers modeling_gemma4.py line 1167 "Layers sharing kv
+// states don't need any weight matrices"). Mutually exclusive with kEqV.
+//
+// This setter is the FromParams-path counterpart to the WithExternalKV
+// constructor option: builders that load weights from GGUF construct GQA via
+// NewGroupedQueryAttentionFromParams with wk=nil, wv=nil (or disposable wk/wv),
+// then invoke SetExternalKV(true) to flip the forward path. Idempotent;
+// passing false re-enables internal projection iff wk/wv are still populated.
+func (gqa *GroupedQueryAttention[T]) SetExternalKV(v bool) {
+	if v && gqa.kEqV {
+		panic("GroupedQueryAttention: SetExternalKV is mutually exclusive with SetKEqV")
+	}
+	gqa.externalKV = v
+	if v {
+		gqa.wk = nil
+		gqa.wv = nil
+		gqa.kNorm = nil
+	}
+}
+
 // ExternalKV reports whether this layer was configured with WithExternalKV.
 func (gqa *GroupedQueryAttention[T]) ExternalKV() bool {
 	return gqa.externalKV

--- a/layers/attention/grouped_query_attention_extended_test.go
+++ b/layers/attention/grouped_query_attention_extended_test.go
@@ -2,6 +2,7 @@ package attention
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/zerfoo/ztensor/compute"
@@ -957,4 +958,169 @@ func TestBuildGroupQueryAttention_MissingParams(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGroupedQueryAttention_SetExternalKV_FromParams verifies that
+// SetExternalKV(true) on a GQA constructed via NewGroupedQueryAttentionFromParams
+// nils wk/wv, enables external-KV Forward semantics, and produces numerically
+// identical outputs to a standard internal-KV GQA when fed the same
+// pre-computed K/V tensors. This closes the API gap left by E95 where
+// WithExternalKV only worked via the NewGroupedQueryAttention constructor.
+func TestGroupedQueryAttention_SetExternalKV_FromParams(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine[float32](ops)
+
+	batchSize := 2
+	seqLen := 5
+	modelDim := 16
+	numQueryHeads := 4
+	numKeyValueHeads := 2
+	headDim := modelDim / numQueryHeads
+	kvDim := numKeyValueHeads * headDim
+
+	// Reference: internal-KV GQA built via FromParams.
+	wqRef, err := core.NewDense[float32]("wq_ref", engine, ops, modelDim, modelDim)
+	if err != nil {
+		t.Fatalf("NewDense wq_ref: %v", err)
+	}
+	wkRef, err := core.NewDense[float32]("wk_ref", engine, ops, modelDim, kvDim)
+	if err != nil {
+		t.Fatalf("NewDense wk_ref: %v", err)
+	}
+	wvRef, err := core.NewDense[float32]("wv_ref", engine, ops, modelDim, kvDim)
+	if err != nil {
+		t.Fatalf("NewDense wv_ref: %v", err)
+	}
+	woRef, err := core.NewDense[float32]("wo_ref", engine, ops, modelDim, modelDim)
+	if err != nil {
+		t.Fatalf("NewDense wo_ref: %v", err)
+	}
+	ropeRef, err := embeddings.NewRotaryPositionalEmbedding[float32](
+		context.Background(), engine, headDim, seqLen, embeddings.WithRotaryBase(10000.0))
+	if err != nil {
+		t.Fatalf("NewRotaryPositionalEmbedding ref: %v", err)
+	}
+	gqaInternal, err := NewGroupedQueryAttentionFromParams[float32](
+		engine, ops, modelDim, numQueryHeads, numKeyValueHeads,
+		wqRef, wkRef, wvRef, woRef, ropeRef)
+	if err != nil {
+		t.Fatalf("NewGroupedQueryAttentionFromParams internal: %v", err)
+	}
+
+	// Under-test: FromParams layer with SetExternalKV(true).
+	wqEx, err := core.NewDense[float32]("wq_ex", engine, ops, modelDim, modelDim)
+	if err != nil {
+		t.Fatalf("NewDense wq_ex: %v", err)
+	}
+	wkEx, err := core.NewDense[float32]("wk_ex", engine, ops, modelDim, kvDim)
+	if err != nil {
+		t.Fatalf("NewDense wk_ex: %v", err)
+	}
+	wvEx, err := core.NewDense[float32]("wv_ex", engine, ops, modelDim, kvDim)
+	if err != nil {
+		t.Fatalf("NewDense wv_ex: %v", err)
+	}
+	woEx, err := core.NewDense[float32]("wo_ex", engine, ops, modelDim, modelDim)
+	if err != nil {
+		t.Fatalf("NewDense wo_ex: %v", err)
+	}
+	ropeEx, err := embeddings.NewRotaryPositionalEmbedding[float32](
+		context.Background(), engine, headDim, seqLen, embeddings.WithRotaryBase(10000.0))
+	if err != nil {
+		t.Fatalf("NewRotaryPositionalEmbedding ex: %v", err)
+	}
+	gqaExternal, err := NewGroupedQueryAttentionFromParams[float32](
+		engine, ops, modelDim, numQueryHeads, numKeyValueHeads,
+		wqEx, wkEx, wvEx, woEx, ropeEx)
+	if err != nil {
+		t.Fatalf("NewGroupedQueryAttentionFromParams external: %v", err)
+	}
+
+	gqaExternal.SetExternalKV(true)
+
+	if !gqaExternal.ExternalKV() {
+		t.Fatalf("ExternalKV() = false, want true after SetExternalKV(true)")
+	}
+	if gqaExternal.wk != nil {
+		t.Fatalf("SetExternalKV(true) must nil wk")
+	}
+	if gqaExternal.wv != nil {
+		t.Fatalf("SetExternalKV(true) must nil wv")
+	}
+	if gqaExternal.kNorm != nil {
+		t.Fatalf("SetExternalKV(true) must nil kNorm")
+	}
+
+	// Share Q and output weights so only the K/V source differs.
+	copyDenseWeights(t, gqaExternal.wq, gqaInternal.wq)
+	copyDenseWeights(t, gqaExternal.wo, gqaInternal.wo)
+
+	inp, err := tensor.New[float32]([]int{batchSize, seqLen, modelDim}, nil)
+	if err != nil {
+		t.Fatalf("input tensor: %v", err)
+	}
+	for i := range inp.Data() {
+		inp.Data()[i] = float32(i%13) / 10.0
+	}
+
+	ctx := context.Background()
+	outInternal, err := gqaInternal.Forward(ctx, inp)
+	if err != nil {
+		t.Fatalf("internal Forward: %v", err)
+	}
+	kProj := gqaInternal.kProj
+	vProj := gqaInternal.vProj
+	if kProj == nil || vProj == nil {
+		t.Fatalf("internal GQA did not cache kProj/vProj")
+	}
+
+	outExternal, err := gqaExternal.Forward(ctx, inp, kProj, vProj)
+	if err != nil {
+		t.Fatalf("external Forward: %v", err)
+	}
+
+	if len(outInternal.Shape()) != len(outExternal.Shape()) {
+		t.Fatalf("shape rank mismatch: %v vs %v", outInternal.Shape(), outExternal.Shape())
+	}
+	for i, d := range outInternal.Shape() {
+		if outExternal.Shape()[i] != d {
+			t.Fatalf("shape mismatch at axis %d: %v vs %v", i, outInternal.Shape(), outExternal.Shape())
+		}
+	}
+
+	const tol = 1e-5
+	for i := range outInternal.Data() {
+		if math.Abs(float64(outInternal.Data()[i]-outExternal.Data()[i])) > tol {
+			t.Fatalf("output mismatch at %d: internal=%f external=%f",
+				i, outInternal.Data()[i], outExternal.Data()[i])
+		}
+	}
+}
+
+// TestGroupedQueryAttention_SetExternalKV_RejectsKEqV verifies SetExternalKV
+// panics if called after SetKEqV, matching the WithExternalKV/SetKEqV mutual
+// exclusivity contract.
+func TestGroupedQueryAttention_SetExternalKV_RejectsKEqV(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine[float32](ops)
+
+	wq, _ := core.NewDense[float32]("wq", engine, ops, 16, 16)
+	wk, _ := core.NewDense[float32]("wk", engine, ops, 16, 8)
+	wv, _ := core.NewDense[float32]("wv", engine, ops, 16, 8)
+	wo, _ := core.NewDense[float32]("wo", engine, ops, 16, 16)
+	rope, _ := embeddings.NewRotaryPositionalEmbedding[float32](
+		context.Background(), engine, 4, 64, embeddings.WithRotaryBase(10000.0))
+
+	gqa, err := NewGroupedQueryAttentionFromParams[float32](engine, ops, 16, 4, 2, wq, wk, wv, wo, rope)
+	if err != nil {
+		t.Fatalf("FromParams: %v", err)
+	}
+	gqa.SetKEqV(true)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic when SetExternalKV is called on kEqV GQA")
+		}
+	}()
+	gqa.SetExternalKV(true)
 }


### PR DESCRIPTION
## Summary
Wave E93-3 of Epic E93 (Gemma 4 edge builder correctness).

- **T93.3.1**: Rewrote `inference/arch_gemma4_edge.go` for canonical Gemma 4 edge PLE + shared-KV layout. Shared PLE embed → global per_layer_model_proj → per-block inp_gate/proj/post_norm/layer_output_scale. Shared-KV layers (layers 20-34) use `WithExternalKV` + donor K/V via `kv_reuse_node`, donor resolved by `ResolveKVDonor`.
- **T93.3.2**: Updated `arch_gemma4_test.go` fixtures to produce canonical tensor set.
- **T93.3.3**: Full `go test ./inference/...` green.
- **T93.3.4**: `go vet ./...` clean; golangci-lint on touched files clean.

Deviation: Added `SetExternalKV(bool)` setter on `*GroupedQueryAttention[T]` to bridge the FromParams construction path with the external-KV mode (consistent with existing `SetKEqV` pattern). Unit test included.

## Linked Issues
- fixes #444 (T93.3.1)
- fixes #445 (T93.3.2)
- fixes #446 (T93.3.3)
- fixes #447 (T93.3.4)

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./layers/attention/... -race -count=1` PASS (incl. new SetExternalKV tests)
- [x] `go test ./inference/... -race -count=1` PASS (pre-existing TSPulse flake documented)