### PR TITLE
feat(gemma4): parameterize Spark manifest + record T97.1.3 blocker

### DIFF
--- a/docs/bench/manifests/gemma4-e2e.yaml
+++ b/docs/bench/manifests/gemma4-e2e.yaml
@@ -33,8 +33,16 @@ spec:
       args:
         - "-gguf"
         - "${GGUF_PATH}"
+        - "-mode"
+        - "${MODE}"
         - "-seq"
-        - "4"
+        - "${SEQ}"
+        - "-prompt"
+        - "${PROMPT}"
+        - "-steps"
+        - "${STEPS}"
+        - "-device"
+        - "${DEVICE}"
       env:
         - name: LD_LIBRARY_PATH
           value: /usr/local/cuda/lib64

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,38 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-04-14: T97.1.3 Gemma 4 edge generate on CUDA -- illegal memory access in qNorm
+
+**Type:** investigation
+**Tags:** gemma4, gemma4e, cuda, grouped-query-attention, rmsnorm, blocker
+
+**Problem:** Submitted pod `gemma4-e2e-20260414-164140` with
+`-mode generate -device cuda -prompt "The quick brown fox" -steps 20`.
+Pod loaded the model correctly (arch=gemma4e, 35 layers, PLE + shared-KV
+detected), but the first forward step of greedy decoding failed with:
+`GroupedQueryAttention: qNorm: cudaMemcpy failed: an illegal memory access
+was encountered (input shapes: [[1 5 1536]], dep ops: [RMSNorm])` preceded
+by three `GPUStorage.TrySlice: cudaMemcpy failed ... returning zero slice
+of length 7680` warnings.
+
+**Root cause:** Unknown. Forward mode (E96) used `compute.NewCPUEngine` and
+succeeded; generate mode uses `inference.LoadFile` with `-device cuda` which
+exercises the real CUDA engine + Generator. The illegal access originates in
+the Q-projection RMSNorm (per-head qNorm) of GroupedQueryAttention. Likely
+suspects: (a) qNorm gain tensor not uploaded to the GPU arena for the
+gemma4e path, (b) a slice/view over an external-KV or PLE-derived tensor
+that is CPU-backed instead of GPU-backed, (c) an alignment issue on the
+shared-KV donor/proxy tensors on the CUDA side.
+
+**Fix:** N/A yet. Filed as T97.1.3 BLOCKED. Next step: reproduce under a
+smaller model (gemma3:1b on CUDA) to confirm this is gemma4e-specific, then
+trace the qNorm gain tensor registration path in `inference/arch_gemma4_edge.go`
+vs the CPU-tested path from E96.
+
+**Impact:** Blocks T97.1.3 (GPU greedy decode verification) and the E97
+close-out. T97.1.1 (CLI surface) and T97.1.2 (Spark manifest params) landed
+successfully and are not affected.
+
 ## 2026-04-14: T97.2.1 Ollama Gemma 4 availability -- DEFER E97.2
 
 **Type:** investigation

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1472,19 +1472,22 @@ run against Spark on DGX.
   and asserts non-empty, non-degenerate output. Forward path (E96) unchanged.
   AC met: `-mode=generate -prompt "..." -steps 50` wired; local build+vet+tests green.
 
-- [ ] T97.1.2 Add generate mode to Spark manifest  Owner: TBD  Est: 20m  verifies: [infrastructure]
+- [x] T97.1.2 Add generate mode to Spark manifest  Owner: dndungu  Est: 20m  verifies: [infrastructure]  Completed: 2026-04-14
   Deps: T97.1.1
-  File: `docs/bench/manifests/gemma4-e2e.yaml`
-  Parameterize args so the submit script picks mode=forward (E96) or
-  mode=generate (E97). Add a second manifest `gemma4-generate.yaml` if
-  substitution gets messy.
-  AC: `scripts/gemma4-spark.sh -mode generate -prompt "..."` submits a
-  pod that runs the generation path.
+  File: `docs/bench/manifests/gemma4-e2e.yaml`, `scripts/gemma4-spark.sh`
+  Parameterized both: manifest accepts ${MODE}, ${PROMPT}, ${STEPS}, ${SEQ},
+  ${DEVICE}; script exposes flags with safe defaults (forward/cpu).
+  AC met: `scripts/gemma4-spark.sh -mode generate -device cuda -prompt "..."`
+  submits and runs the generation path on DGX.
 
-- [ ] T97.1.3 Run generation on DGX and record result  Owner: TBD  Est: 30m  verifies: [UC-001]
+- [ ] T97.1.3 Run generation on DGX and record result  Owner: TBD  Est: 30m  verifies: [UC-001]  BLOCKED 2026-04-14 by qNorm CUDA bug
   Deps: T97.1.2, T96.2.1
-  AC: pod completes; decoded text non-degenerate (not all same token); no
-  NaN/Inf across all 50 steps; devlog entry with output.
+  Blocker: pod gemma4-e2e-20260414-164140 failed with
+  `GroupedQueryAttention: qNorm: cudaMemcpy failed: an illegal memory access`
+  during prefill. Infrastructure (binary, manifest, script) verified end-to-end;
+  blocker is in the gemma4e CUDA Q-projection RMSNorm path.
+  Follow-up: file a bug epic; reproduce with gemma3:1b on CUDA to isolate; trace
+  qNorm gain tensor registration in inference/arch_gemma4_edge.go.
 
 ### E97.2: Ollama parity
 

--- a/scripts/gemma4-spark.sh
+++ b/scripts/gemma4-spark.sh
@@ -27,17 +27,29 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 MANIFEST_TEMPLATE="${REPO_ROOT}/docs/bench/manifests/gemma4-e2e.yaml"
 
 GGUF_PATH="/var/lib/zerfoo/models/gemma-4-E2B-it-Q4_K_M.gguf"
+MODE="forward"
+PROMPT="The quick brown fox"
+STEPS="50"
+SEQ="4"
+DEVICE="cpu"
 CLEANUP=0
 
 usage() {
   cat >&2 <<USAGE
-Usage: $0 [-gguf /path/to/model.gguf] [-cleanup]
+Usage: $0 [-gguf PATH] [-mode forward|generate] [-prompt TEXT]
+          [-steps N] [-seq N] [-device cpu|cuda] [-cleanup]
 
 Submits docs/bench/manifests/gemma4-e2e.yaml to Spark at \${SPARK_HOST}
 (currently ${SPARK_HOST}), polls until the pod terminates, prints logs,
 and exits with the pod's success/failure status.
 
-Default GGUF path: ${GGUF_PATH}
+Defaults:
+  -gguf   ${GGUF_PATH}
+  -mode   ${MODE}
+  -prompt ${PROMPT}
+  -steps  ${STEPS}
+  -seq    ${SEQ}
+  -device ${DEVICE}
 USAGE
   exit 2
 }
@@ -45,6 +57,11 @@ USAGE
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -gguf)     GGUF_PATH="$2"; shift 2 ;;
+    -mode)     MODE="$2"; shift 2 ;;
+    -prompt)   PROMPT="$2"; shift 2 ;;
+    -steps)    STEPS="$2"; shift 2 ;;
+    -seq)      SEQ="$2"; shift 2 ;;
+    -device)   DEVICE="$2"; shift 2 ;;
     -cleanup)  CLEANUP=1; shift ;;
     -h|--help) usage ;;
     *) echo "unknown arg: $1" >&2; usage ;;
@@ -60,6 +77,11 @@ MANIFEST_RENDERED="$(
   sed \
     -e "s|\${RUN_ID}|${RUN_ID}|g" \
     -e "s|\${GGUF_PATH}|${GGUF_PATH}|g" \
+    -e "s|\${MODE}|${MODE}|g" \
+    -e "s|\${PROMPT}|${PROMPT}|g" \
+    -e "s|\${STEPS}|${STEPS}|g" \
+    -e "s|\${SEQ}|${SEQ}|g" \
+    -e "s|\${DEVICE}|${DEVICE}|g" \
     "${MANIFEST_TEMPLATE}"
 )"
 


### PR DESCRIPTION
## Summary
- **T97.1.2**: `docs/bench/manifests/gemma4-e2e.yaml` and `scripts/gemma4-spark.sh` now expose `-mode`, `-prompt`, `-steps`, `-seq`, `-device`. Forward/E96 behavior unchanged at defaults.
- **T97.1.3 BLOCKED**: submitted pod reached prefill, then CUDA illegal memory access in `GroupedQueryAttention.qNorm` on the gemma4e path. Infrastructure verified end-to-end (binary loads model, detects gemma4e, dequantizes Q4→Q8 embed). Blocker needs its own scoped work.
- Plan + devlog updated with full finding and follow-up steps.

## Test plan
- [x] Local diff review; scripts are shell-only
- [ ] CI green (no code paths exercised by tests)