### PR TITLE
fix(layers/normalization): float64 backward for LayerNorm on CPU

### DIFF
--- a/layers/normalization/comprehensive_test.go
+++ b/layers/normalization/comprehensive_test.go
@@ -232,6 +232,10 @@ func TestLayerNormalization_BackwardErrors(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			// Force the engine-op path so the err-engine's per-op
+			// failure points are actually reachable. The mixed-CPU
+			// backward bypasses engine ops entirely.
+			ln.useMixedBackward = false
 			data := make([]float32, dim*dim)
 			for i := range data {
 				data[i] = float32(i+1) * 0.1

--- a/layers/normalization/layer_normalization.go
+++ b/layers/normalization/layer_normalization.go
@@ -4,7 +4,10 @@ package normalization
 import (
 	"context"
 	"fmt"
+	"math"
 
+	"github.com/zerfoo/float16"
+	"github.com/zerfoo/float8"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
@@ -12,6 +15,17 @@ import (
 )
 
 // LayerNormalization implements the Layer Normalization operation.
+//
+// When T is float32 or sub-float32 (float16, float8) AND the engine is
+// a CPU engine, Backward runs all per-element arithmetic in float64 and
+// casts the result back to T. Parameter storage and gradient outputs stay
+// at T. This removes the catastrophic-cancellation risk in (input - mean)
+// when activations drift far from zero, and protects the stdDev^3
+// division chain from float32 rounding noise. The GPU engine path
+// preserves the original T-only computation because GPU kernels batch
+// these ops and maintain intermediate precision better than naive
+// per-element float32 math; upgrading GPU kernels to mixed precision
+// is a follow-up once native kernels exist.
 type LayerNormalization[T tensor.Numeric] struct {
 	engine  compute.Engine[T]
 	epsilon T // Small constant to avoid division by zero
@@ -26,6 +40,8 @@ type LayerNormalization[T tensor.Numeric] struct {
 	variance    *tensor.TensorNumeric[T]
 	normedInput *tensor.TensorNumeric[T] // (input - mean) / sqrt(variance + epsilon)
 	outputShape []int
+
+	useMixedBackward bool // Run Backward per-element in float64 on CPU.
 }
 
 // LayerNormalizationOptions holds configuration options for LayerNormalization layers.
@@ -85,10 +101,11 @@ func NewLayerNormalization[T tensor.Numeric](engine compute.Engine[T], featureDi
 	}
 
 	return &LayerNormalization[T]{
-		engine:  engine,
-		epsilon: opts.Epsilon,
-		gamma:   gamma,
-		beta:    beta,
+		engine:           engine,
+		epsilon:          opts.Epsilon,
+		gamma:            gamma,
+		beta:             beta,
+		useMixedBackward: shouldUseMixedPrecisionBackward[T](engine),
 	}, nil
 }
 
@@ -102,10 +119,31 @@ func NewLayerNormalizationFromParams[T tensor.Numeric](
 	beta *graph.Parameter[T],
 ) *LayerNormalization[T] {
 	return &LayerNormalization[T]{
-		engine:  engine,
-		epsilon: epsilon,
-		gamma:   gamma,
-		beta:    beta,
+		engine:           engine,
+		epsilon:          epsilon,
+		gamma:            gamma,
+		beta:             beta,
+		useMixedBackward: shouldUseMixedPrecisionBackward[T](engine),
+	}
+}
+
+// shouldUseMixedPrecisionBackward returns true when LayerNorm.Backward
+// should run per-element arithmetic in float64 instead of T. True only
+// when T is float32 or below AND the engine is a CPU engine. GPU engines
+// keep the current all-T path so their CUDA-native kernels remain in
+// charge of precision.
+func shouldUseMixedPrecisionBackward[T tensor.Numeric](engine compute.Engine[T]) bool {
+	if _, ok := engine.(*compute.CPUEngine[T]); !ok {
+		return false
+	}
+	var zero T
+	switch any(zero).(type) {
+	case float64:
+		return false
+	case float32, float16.Float16, float16.BFloat16, float8.Float8:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -209,6 +247,11 @@ func (ln *LayerNormalization[T]) Backward(ctx context.Context, mode types.Backwa
 	if len(inputs) != 1 {
 		return nil, fmt.Errorf("LayerNormalization: %w, expected %d, got %d", graph.ErrInvalidInputCount, 1, len(inputs))
 	}
+
+	if ln.useMixedBackward {
+		return ln.backwardMixedCPU(dOut, inputs[0])
+	}
+
 	// Gradients for gamma and beta
 	// dL/dgamma = sum(dOut * normedInput) along the normalization axis
 	dOutMulNormedInput, err := ln.engine.Mul(ctx, dOut, ln.normedInput, nil)
@@ -341,6 +384,146 @@ func (ln *LayerNormalization[T]) Backward(ctx context.Context, mode types.Backwa
 	}
 
 	return []*tensor.TensorNumeric[T]{dInput}, nil
+}
+
+// backwardMixedCPU runs LayerNormalization.Backward with all per-element
+// arithmetic performed in float64, while parameter storage and gradient
+// outputs remain at T. Used only when T is float32 or below and the
+// engine is a CPU engine (see shouldUseMixedPrecisionBackward).
+//
+// The critical precision concerns it addresses:
+//   - (input - mean) can lose most significant digits to catastrophic
+//     cancellation when activations drift far from zero during training.
+//     float64 subtraction preserves full precision.
+//   - The stdDev^3 division chain amplifies any rounding error; running
+//     it in float64 keeps intermediate magnitudes meaningful.
+//   - Sum-of-products reductions over the feature axis accumulate error
+//     linearly in float32; float64 caps accumulated error below 1e-12.
+func (ln *LayerNormalization[T]) backwardMixedCPU(dOut *tensor.TensorNumeric[T], input *tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	ops := ln.engine.Ops()
+	nFeat := ln.inputShape[len(ln.inputShape)-1]
+	if nFeat <= 0 {
+		return nil, fmt.Errorf("LayerNormalization: invalid feature dim %d", nFeat)
+	}
+	total := 1
+	for _, d := range ln.inputShape {
+		total *= d
+	}
+	positions := total / nFeat
+	epsilon := lnNumericToFloat64(ln.epsilon)
+
+	inputData := input.Data()
+	dOutData := dOut.Data()
+	meanData := ln.mean.Data()
+	varData := ln.variance.Data()
+	normedData := ln.normedInput.Data()
+	gammaData := ln.gamma.Value.Data()
+
+	dInputTensor, err := tensor.New[T](ln.inputShape, nil)
+	if err != nil {
+		return nil, err
+	}
+	dInputData := dInputTensor.Data()
+
+	dGamma64 := make([]float64, nFeat)
+	dBeta64 := make([]float64, nFeat)
+	nFeatF := float64(nFeat)
+
+	for p := 0; p < positions; p++ {
+		mu := lnNumericToFloat64(meanData[p])
+		sigma := math.Sqrt(lnNumericToFloat64(varData[p]) + epsilon)
+		sigma3 := sigma * sigma * sigma
+		base := p * nFeat
+
+		var sumDNorm, sumDNormXMu float64
+		for i := 0; i < nFeat; i++ {
+			gi := lnNumericToFloat64(gammaData[i])
+			dOutI := lnNumericToFloat64(dOutData[base+i])
+			xMinusMu := lnNumericToFloat64(inputData[base+i]) - mu
+			dNorm := dOutI * gi
+			sumDNorm += dNorm
+			sumDNormXMu += dNorm * xMinusMu
+		}
+
+		for i := 0; i < nFeat; i++ {
+			gi := lnNumericToFloat64(gammaData[i])
+			dOutI := lnNumericToFloat64(dOutData[base+i])
+			xMinusMu := lnNumericToFloat64(inputData[base+i]) - mu
+			normed := lnNumericToFloat64(normedData[base+i])
+
+			dNorm := dOutI * gi
+			term1 := dNorm / sigma
+			term2 := xMinusMu * sumDNormXMu / (nFeatF * sigma3)
+			term3 := sumDNorm / (nFeatF * sigma)
+
+			dInputData[base+i] = ops.FromFloat64(term1 - term2 - term3)
+			dGamma64[i] += dOutI * normed
+			dBeta64[i] += dOutI
+		}
+	}
+
+	dGammaTensor, err := tensor.New[T]([]int{nFeat}, nil)
+	if err != nil {
+		return nil, err
+	}
+	dBetaTensor, err := tensor.New[T]([]int{nFeat}, nil)
+	if err != nil {
+		return nil, err
+	}
+	dGammaData := dGammaTensor.Data()
+	dBetaData := dBetaTensor.Data()
+	for i := 0; i < nFeat; i++ {
+		dGammaData[i] = ops.FromFloat64(dGamma64[i])
+		dBetaData[i] = ops.FromFloat64(dBeta64[i])
+	}
+
+	if err := ln.gamma.AddGradient(dGammaTensor); err != nil {
+		return nil, err
+	}
+	if err := ln.beta.AddGradient(dBetaTensor); err != nil {
+		return nil, err
+	}
+
+	return []*tensor.TensorNumeric[T]{dInputTensor}, nil
+}
+
+// lnNumericToFloat64 converts a tensor.Numeric value to float64. This is
+// duplicated from training/optimizer and training/loss to keep this
+// package self-contained. Consolidate to a shared helper if a fourth
+// duplicate emerges.
+func lnNumericToFloat64[T tensor.Numeric](v T) float64 {
+	switch val := any(v).(type) {
+	case float32:
+		return float64(val)
+	case float64:
+		return val
+	case int:
+		return float64(val)
+	case int8:
+		return float64(val)
+	case int16:
+		return float64(val)
+	case int32:
+		return float64(val)
+	case int64:
+		return float64(val)
+	case uint:
+		return float64(val)
+	case uint8:
+		return float64(val)
+	case uint32:
+		return float64(val)
+	case uint64:
+		return float64(val)
+	case float16.Float16:
+		return float64(val.ToFloat32())
+	case float16.BFloat16:
+		return float64(val.ToFloat32())
+	case float8.Float8:
+		return val.ToFloat64()
+	default:
+		return 0
+	}
 }
 
 // OpType returns the operation type of the LayerNormalization layer.

--- a/layers/normalization/layer_normalization_test.go
+++ b/layers/normalization/layer_normalization_test.go
@@ -244,3 +244,169 @@ func TestLayerNormalization_Backward(t *testing.T) {
 	testutils.AssertEqual(t, len(inputGrads), 1, "Should return one input gradient")
 	testutils.AssertTrue(t, testutils.IntSliceEqual(inputShape, inputGrads[0].Shape()), "Input gradient shape should match input shape")
 }
+
+// TestLayerNormalization_BackwardMixedCPUMatchesEngine proves the
+// float64-internal backward path on CPU produces gradients that agree
+// with the pure engine path to within a tight tolerance, for a workload
+// where both paths are numerically stable. If this test fails, the
+// mixed-precision rewrite introduced a derivation bug.
+func TestLayerNormalization_BackwardMixedCPUMatchesEngine(t *testing.T) {
+	ctx := context.Background()
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine[float32](ops)
+
+	const featureDim = 8
+	const batch = 4
+	shape := []int{batch, featureDim}
+
+	lnMixed, err := NewLayerNormalization[float32](engine, featureDim)
+	if err != nil {
+		t.Fatalf("NewLayerNormalization(mixed) failed: %v", err)
+	}
+	if !lnMixed.useMixedBackward {
+		t.Fatal("expected mixed-precision path to be active for CPU/float32")
+	}
+
+	lnEngine, err := NewLayerNormalization[float32](engine, featureDim)
+	if err != nil {
+		t.Fatalf("NewLayerNormalization(engine) failed: %v", err)
+	}
+	lnEngine.useMixedBackward = false
+
+	inputData := make([]float32, batch*featureDim)
+	for i := range inputData {
+		inputData[i] = float32(i+1) * 0.13
+	}
+	inputMixed, err := tensor.New[float32](shape, append([]float32(nil), inputData...))
+	if err != nil {
+		t.Fatalf("tensor.New input mixed: %v", err)
+	}
+	inputEngine, err := tensor.New[float32](shape, append([]float32(nil), inputData...))
+	if err != nil {
+		t.Fatalf("tensor.New input engine: %v", err)
+	}
+
+	if _, err := lnMixed.Forward(ctx, inputMixed); err != nil {
+		t.Fatalf("Forward mixed: %v", err)
+	}
+	if _, err := lnEngine.Forward(ctx, inputEngine); err != nil {
+		t.Fatalf("Forward engine: %v", err)
+	}
+
+	gradData := make([]float32, batch*featureDim)
+	for i := range gradData {
+		gradData[i] = float32(i%featureDim+1) * 0.017
+	}
+	gradMixed, err := tensor.New[float32](shape, append([]float32(nil), gradData...))
+	if err != nil {
+		t.Fatalf("tensor.New grad mixed: %v", err)
+	}
+	gradEngine, err := tensor.New[float32](shape, append([]float32(nil), gradData...))
+	if err != nil {
+		t.Fatalf("tensor.New grad engine: %v", err)
+	}
+
+	dInputMixed, err := lnMixed.Backward(ctx, types.FullBackprop, gradMixed, inputMixed)
+	if err != nil {
+		t.Fatalf("Backward mixed: %v", err)
+	}
+	dInputEngine, err := lnEngine.Backward(ctx, types.FullBackprop, gradEngine, inputEngine)
+	if err != nil {
+		t.Fatalf("Backward engine: %v", err)
+	}
+
+	const tol = 1e-4
+	for i := range dInputMixed[0].Data() {
+		diff := float64(dInputMixed[0].Data()[i]) - float64(dInputEngine[0].Data()[i])
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > tol {
+			t.Fatalf("dInput[%d] mismatch: mixed=%v engine=%v diff=%v tol=%v",
+				i, dInputMixed[0].Data()[i], dInputEngine[0].Data()[i], diff, tol)
+		}
+	}
+	for i := range lnMixed.gamma.Gradient.Data() {
+		diff := float64(lnMixed.gamma.Gradient.Data()[i]) - float64(lnEngine.gamma.Gradient.Data()[i])
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > tol {
+			t.Fatalf("dGamma[%d] mismatch: mixed=%v engine=%v",
+				i, lnMixed.gamma.Gradient.Data()[i], lnEngine.gamma.Gradient.Data()[i])
+		}
+	}
+	for i := range lnMixed.beta.Gradient.Data() {
+		diff := float64(lnMixed.beta.Gradient.Data()[i]) - float64(lnEngine.beta.Gradient.Data()[i])
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > tol {
+			t.Fatalf("dBeta[%d] mismatch: mixed=%v engine=%v",
+				i, lnMixed.beta.Gradient.Data()[i], lnEngine.beta.Gradient.Data()[i])
+		}
+	}
+}
+
+// TestLayerNormalization_BackwardMixedCPUResistsUnderflow shows the
+// mixed-precision backward produces finite gradients for an input whose
+// activations sit far from zero — the pattern that drove fold-0 to NaN
+// in E9 T9.7 attempts #3-#5. The equivalent float32 engine path on the
+// same input is permitted to diverge; the only claim here is that the
+// mixed path stays finite.
+func TestLayerNormalization_BackwardMixedCPUResistsUnderflow(t *testing.T) {
+	ctx := context.Background()
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine[float32](ops)
+
+	const featureDim = 16
+	shape := []int{1, featureDim}
+	ln, err := NewLayerNormalization[float32](engine, featureDim)
+	if err != nil {
+		t.Fatalf("NewLayerNormalization: %v", err)
+	}
+	if !ln.useMixedBackward {
+		t.Fatal("expected mixed-precision path to be active for CPU/float32")
+	}
+
+	inputData := make([]float32, featureDim)
+	for i := range inputData {
+		inputData[i] = 1e5 + float32(i)*1e-2
+	}
+	input, err := tensor.New[float32](shape, inputData)
+	if err != nil {
+		t.Fatalf("tensor.New input: %v", err)
+	}
+	if _, err := ln.Forward(ctx, input); err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+
+	gradData := make([]float32, featureDim)
+	for i := range gradData {
+		gradData[i] = 0.0005
+	}
+	grad, err := tensor.New[float32](shape, gradData)
+	if err != nil {
+		t.Fatalf("tensor.New grad: %v", err)
+	}
+
+	dInput, err := ln.Backward(ctx, types.FullBackprop, grad, input)
+	if err != nil {
+		t.Fatalf("Backward: %v", err)
+	}
+	for i, v := range dInput[0].Data() {
+		if v != v || v > 1e20 || v < -1e20 {
+			t.Fatalf("dInput[%d] non-finite or huge: %v", i, v)
+		}
+	}
+	for i, v := range ln.gamma.Gradient.Data() {
+		if v != v || v > 1e20 || v < -1e20 {
+			t.Fatalf("dGamma[%d] non-finite: %v", i, v)
+		}
+	}
+	for i, v := range ln.beta.Gradient.Data() {
+		if v != v || v > 1e20 || v < -1e20 {
+			t.Fatalf("dBeta[%d] non-finite: %v", i, v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

When T is float32 or below AND the engine is a CPU engine, `LayerNormalization.Backward` now runs all per-element arithmetic in float64 and casts the result back to T. Parameter storage and gradient outputs stay at T. GPU engines keep the existing all-T path.

## Why

Wolf's CrossAsset walk-forward training (E9 T9.7) kept NaN'ing on CPU. The pattern across four attempts:

| Attempt | Fix | NaN at |
|--------|-----|--------|
| #3 | grad-clip 0.5, original AdamW | epoch 2-5 |
| #4 | grad-clip 0.1 | epoch 11 |
| #5 | AdamW float64 `v` sidecar (#482) | epoch 14 |

Each fix extended stability by ~3 epochs but did not reach the target 50. The remaining source isolated by AdamW's gradient guard is inside LayerNorm's backward chain:

- `(input - mean)` catastrophically cancels once activations drift far from zero (e.g. mean ≈ 1e4, `x - mean` ≈ 1e-3 has only 3 valid float32 digits).
- `stdDev^3` in the term2 denominator amplifies any rounding.
- Float32 feature-axis reductions accumulate error linearly.

Running the per-element arithmetic in float64 removes all three hazards. Float64 storage for activations/gradients is not needed because the noise sources are intermediate, not boundary.

## Changes

- New `useMixedBackward` field on `LayerNormalization[T]`, set via `shouldUseMixedPrecisionBackward[T](engine)` at construction.
- New `backwardMixedCPU` method: float64 internal arithmetic, T-precision I/O.
- `Backward` branches on `useMixedBackward` at entry; existing engine path is untouched.
- Existing `TestLayerNormalization_BackwardErrors` now sets `useMixedBackward = false` so it keeps exercising the engine-op failure points.
- New `TestLayerNormalization_BackwardMixedCPUMatchesEngine`: mixed vs engine agreement within 1e-4 on well-conditioned input.
- New `TestLayerNormalization_BackwardMixedCPUResistsUnderflow`: finite gradients on far-from-zero activations.

## Test plan

- [x] `go test ./layers/normalization/... -timeout 120s`
- [x] `go test ./... -short` — all packages pass
- [ ] Bump Wolf dep, run T9.7 attempt #6 on DGX — expected: all 5 folds through 50 epochs with no NaN, mean WF accuracy >73%.
- [ ] CI green on this PR.