### PR TITLE
fix(inference): resolve gemma4e layer_scalar at construct time, not in Forward

### DIFF
--- a/inference/gemma4_edge_ple_nodes.go
+++ b/inference/gemma4_edge_ple_nodes.go
@@ -446,9 +446,17 @@ func (n *pleSliceNode[T]) Backward(_ context.Context, _ types.BackwardMode, _ *t
 // 1-element tensor (`model.layers.N.layer_output_scale.weight`). Corresponds
 // to `self.layer_scalar` in HF modeling_gemma4.py (line 1337, applied at line
 // 1410: hidden_states *= self.layer_scalar).
+//
+// CUDA graph capture note (ADR-088 follow-up): the scalar value is resolved
+// at construction time (while the tensor is still CPU-resident from GGUF
+// load) and stored in `scalarValue`. Forward never calls `scale.Data()`,
+// because once the graph compiler uploads frozen weights to GPU, `Data()`
+// on the GPU-backed scale tensor triggers a synchronous D2H cudaMemcpy
+// that CUDA rejects inside a capturing stream.
 type layerOutputScaleNode[T tensor.Numeric] struct {
-	engine compute.Engine[T]
-	scale  *tensor.TensorNumeric[T] // shape [1]
+	engine      compute.Engine[T]
+	scale       *tensor.TensorNumeric[T] // shape [1]; retained for EmbeddedFrozen registration
+	scalarValue T
 }
 
 func newLayerOutputScaleNode[T tensor.Numeric](engine compute.Engine[T], scale *tensor.TensorNumeric[T]) (*layerOutputScaleNode[T], error) {
@@ -459,7 +467,11 @@ func newLayerOutputScaleNode[T tensor.Numeric](engine compute.Engine[T], scale *
 	if len(shape) != 1 || shape[0] != 1 {
 		return nil, fmt.Errorf("layerOutputScaleNode: scale shape %v, want [1]", shape)
 	}
-	return &layerOutputScaleNode[T]{engine: engine, scale: scale}, nil
+	sData := scale.Data()
+	if len(sData) == 0 {
+		return nil, fmt.Errorf("layerOutputScaleNode: scale data empty (construct with CPU-backed tensor before GPU upload)")
+	}
+	return &layerOutputScaleNode[T]{engine: engine, scale: scale, scalarValue: sData[0]}, nil
 }
 
 func (n *layerOutputScaleNode[T]) OpType() string                   { return "Gemma4LayerOutputScale" }
@@ -475,11 +487,7 @@ func (n *layerOutputScaleNode[T]) Forward(ctx context.Context, inputs ...*tensor
 	if len(inputs) != 1 {
 		return nil, fmt.Errorf("Gemma4LayerOutputScale: expected 1 input, got %d", len(inputs))
 	}
-	sData := n.scale.Data()
-	if len(sData) == 0 {
-		return nil, fmt.Errorf("Gemma4LayerOutputScale: scale data empty")
-	}
-	return n.engine.MulScalar(ctx, inputs[0], sData[0])
+	return n.engine.MulScalar(ctx, inputs[0], n.scalarValue)
 }
 
 func (n *layerOutputScaleNode[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {


### PR DESCRIPTION
## Summary

Follow-up to #486 (T99.1.2 PLE capture fix). DGX verification pod
`gemma4-e2e-20260416-030107` showed the capture region did form
correctly (`instructions [2, 569) of 569`) but capture still failed
at **instruction 16** (`Gemma4LayerOutputScale`): the node's `Forward`
called `n.scale.Data()` on a GPU-backed frozen scalar, triggering a
synchronous D2H `cudaMemcpy` that CUDA rejects inside a capturing
stream. `TrySlice` returned a zero-length slice, then `MulScalar`
failed with `cuda error 901` (`cudaErrorStreamCaptureImplicit`) on
the already-poisoned stream.

## Fix

The scale value is a trained, frozen weight — it never changes. Read
it once at construction time (while the tensor is still CPU-backed
from GGUF load) and stash it as a Go value. `Forward` now calls
`MulScalar` with the cached value and never touches `scale.Data()`.

The `scale` tensor itself is retained on the struct so `EmbeddedFrozen`
still registers it with the graph compiler for GPU upload (so the
tensor stays alive and its device storage is valid for anything that
might need the GPU-backed form downstream).

## Test plan

- [x] `go test ./inference/` — all gemma4 edge tests pass (12 incl.
  the two ADR-088 regression tests).
- [ ] DGX verify on Spark after merge: submit `gemma4_e2e -mode=generate
  -device=cuda` with `ZERFOO_DISABLE_CUDA_GRAPH` unset, confirm the log
  shows `cuda graph: captured and instantiated successfully` and
  generation completes at >= the uncaptured baseline (3.85 tok/s).

## Observed run (pre-fix)

```
cuda graph: capture region is instructions [2, 569) of 569 total
CUDA GRAPH: about to begin capture, instructions [2, 569)
CUDA GRAPH: capture started, running instructions [2, 569)
WARNING: GPUStorage.TrySlice: cudaMemcpy failed: operation would
  make the legacy stream depend on a capturing blocking stream;
  returning zero slice of length 1
cuda graph: end capture failed: cudaStreamEndCapture failed:
  operation failed due to a previous error during capture
CUDA GRAPH: capture failed: instruction 16 (Gemma4LayerOutputScale):
  mul_scalar kernel failed (cuda error 901)
gemma4_e2e: generated (121 bytes) in 21.00s (0.95 tok/s over 20 steps)
gemma4_e2e: PASS
```

## Linked Issues

- refs E99 T99.1.3 (DGX verify)
- follow-up to #486 (E99 T99.1.2)