### PR TITLE
docs(plan): T99 investigation -- decode broken, capture blocked on LMHead

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -10,15 +10,38 @@ All benchmarks run on DGX Spark GB10 unless noted. Greedy sampling, 128 output t
 | DeepSeek-R1 1.5B | Q4_K_M | 186 | 168 | **1.11x** | 2026-03-30 |
 | Llama 3.2 3B | Q4_K_M | 92 | 93 | 0.99x | 2026-03-30 |
 | Mistral 7B | Q4_K_M | 44 | 44 | 1.00x | 2026-03-30 |
-| Gemma 4 E2B (edge) | Q4_K_M | 3.85* | N/A | — | 2026-04-15 |
+| Gemma 4 E2B (edge) | Q4_K_M | 3.85* / 2.69** / 1.23*** | N/A | — | 2026-04-15 / 2026-04-16 |
 
-\* Gemma 4 E2B baseline captured on 2026-04-15 (commit `72828131`) with
-CUDA graph capture disabled (E99 blocker: `pleCombinedProducer` H2D
-memcpy incompatibility). This is a correctness baseline, NOT an
-optimized number. Once E99 lands and the graph-capture path is
-enabled, this should rise substantially (Gemma 3 1B with capture is
-241 tok/s). Ollama comparison skipped because Ollama does not
-support the gemma4 architecture yet (E97.2 DEFERRED).
+\* The `3.85 tok/s` figure originally recorded for commit `72828131`
+could not be reproduced on 2026-04-16: the same binary at the same
+commit, on the same DGX host, running `-mode generate -device cuda
+-steps 64 -prompt "The quick brown fox"` with
+`ZERFOO_DISABLE_CUDA_GRAPH=1`, measured 2.69 tok/s. The 3.85 number
+was likely measured with different parameters (possibly `-mode
+forward`, or different `-steps`/`-seq`) and should be treated as
+unverified. See `docs/devlog.md` 2026-04-16 entry.
+
+\*\* 2.69 tok/s = current best reproducible gemma4e generate
+throughput on GPU, measured 2026-04-16 at commit `72828131`,
+capture disabled.
+
+\*\*\* 1.23 tok/s = current main (`6ad8bceb`) gemma4e generate on GPU,
+capture disabled. A ~2.2x regression vs 72828131 tracked as T99.2.1.
+
+**Correctness caveat (2026-04-16):** gemma4e generate produces
+degenerate tokens (`"ly\ns\ns\ns..."` on CPU, multilingual gibberish
+on GPU) on both `72828131` and current main. The E98 note about
+"40 bytes non-degenerate output" referred to `-mode forward`
+integration, not decode. Do not trust any gemma4e generate
+throughput number until T99.2.2 restores decode coherence. The
+throughput figures above are only useful as a regression floor for
+T99.2.1, not as user-facing performance claims.
+
+Once E99 lands (T99.1.3/T99.1.4) and decode is fixed (T99.2.2) and
+throughput is restored (T99.2.1), this row should rise substantially
+(Gemma 3 1B with capture is 241 tok/s). Ollama comparison skipped
+because Ollama does not support the gemma4 architecture yet (E97.2
+DEFERRED).
 
 CUDA graph capture: 184/185 instructions (99.5%). Fused kernels: softmax+V multiply, repeat-interleave for GQA, fused AddRMSNorm, fused SwiGLU, fused QKNormRoPE, merged QKV, merged gate+up.
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,109 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-04-16: T99.1.3 investigation -- three stacked gemma4e issues, none caused by T99.1.2
+
+**Type:** investigation
+**Tags:** gemma4e, cuda, graph-capture, e99, t99.1.3, t99.1.4, t99.2.1, t99.2.2, regression, correctness
+
+**Problem:** attempted T99.1.3 on current main (`6ad8bceb`): unset
+`ZERFOO_DISABLE_CUDA_GRAPH` in `docs/bench/manifests/gemma4-e2e.yaml`,
+rebuild `gemma4_e2e` on DGX, submit via Spark, compare throughput vs
+the 3.85 tok/s baseline recorded in `docs/benchmarks.md`. Expected
+capture to complete (T99.1.2 fixed the `pleCombinedProducer`
+incompatibility) and throughput to meet or beat the uncaptured path.
+Got neither.
+
+**Reproduction matrix** (DGX Spark GB10, prompt `"The quick brown fox"`,
+`-seq 4`):
+
+| Commit | Device | Capture env | Steps | tok/s | First ~40 bytes of output |
+|--------|--------|-------------|-------|-------|---------------------------|
+| `72828131` (Apr 15) | cpu | N/A | 32 | 0.69 | `"ly\ns\ns\ns\ns\ns\ns\ns\ns..."` |
+| `72828131` (Apr 15) | cuda | `ZERFOO_DISABLE_CUDA_GRAPH=1` | 64 | **2.69** | `"overdaythe\ns\nsn\n..."` |
+| `6ad8bceb` (main) | cpu | N/A | 16 | 0.59 | `"ly\ns\ns\ns\ns\ns\ns\ns\n"` |
+| `6ad8bceb` (main) | cuda | `ZERFOO_DISABLE_CUDA_GRAPH=1` | 64 | 1.23 | multilingual gibberish (457 bytes) |
+| `6ad8bceb` (main) | cuda | unset (capture ON) | 64 | 1.17 | capture fails at LMHead, falls back; same gibberish |
+
+**What the capture attempt actually did** (capture-on run on main):
+T99.1.2's fix worked -- the capture region now extends to
+instructions `[2, 569)` (full graph minus pre-capture PLE producer).
+But `cudaStreamEndCapture` failed with `operation failed due to a
+previous error during capture`, reporting instruction 568 (LMHead):
+`number of axes 3 must match tensor dimensions 2`. Execution fell
+back to the uncaptured path, producing the same output as
+capture-off. So the capture path never ran as a graph, and the
+1.17/1.23 tok/s numbers are both really the uncaptured path -- the
+capture-on variant is slightly slower because it pays the overhead of
+starting and aborting capture each step.
+
+**Three orthogonal issues surfaced:**
+
+1. **LMHead is not capture-safe.** T99.1.2 made the PLE combiner
+   capturable but the capture region now reaches a second
+   incompatible op at the tail. Fix is either to register `LMHead`
+   in ztensor's `nonCapturableOps` (mirrors T99.1.1's playbook) or
+   to fix the axes/dims handling upstream. Filed as T99.1.4.
+
+2. **GPU decode throughput regressed 2.2x.** At capture-off, commit
+   `72828131` ran at 2.69 tok/s; main (`6ad8bceb`) runs at 1.23
+   tok/s. Same binary semantics (both capture-off), same host, same
+   prompt/steps/seq, same GGUF file. Prime suspect is T99.1.2's
+   per-step `CopyFromHost` refresh of 35 per-layer PLE slice buffers
+   in `inference/gemma4_edge_ple_nodes.go`, but this is a guess --
+   not bisected. Filed as T99.2.1. Do NOT revert T99.1.2 to
+   "fix" this; fix forward.
+
+3. **gemma4e decode has never been correct.** Output is degenerate
+   on both CPU (`"ly\ns\ns\ns..."`, a stuck-token loop) and GPU
+   (`"overdaythe\ns\nsn\n..."` at 72828131, full multilingual
+   gibberish at 6ad8bceb) on both measured commits. The plan.md
+   note from the E98 run (`gemma4-e2e-20260415-025542`) stating
+   "gemma4_e2e PASS, 40 bytes non-degenerate output" referred to
+   `-mode forward` integration, not `-mode generate`. Decode was
+   never validated. Filed as T99.2.2. This is arguably epic-level
+   work -- could be sampling, LMHead, tied embeddings, or the
+   Q4->Q8 upgrade path for `model.embed_tokens.weight` (which the
+   logs show happens on load for GPU runs).
+
+   A fourth, possibly related, noise signal: every generate run
+   prints `CompileTraced plan validation failed, falling back to
+   Compile: instruction 0 (Gather|MulScalar): input tensors cannot
+   be nil` before decoding. Unclear if this is related to the
+   degenerate output or independent. Worth chasing as part of
+   T99.2.2.
+
+**What we verified and what we did NOT do:**
+- Verified that T99.1.2 did not regress decode correctness (decode
+  was already broken at 72828131).
+- Verified that the 3.85 tok/s figure in `docs/benchmarks.md` is not
+  reproducible at its recorded commit (measured 2.69 tok/s with
+  plausible defaults).
+- Did NOT revert T99.1.2 -- it did what ADR-088 Option C
+  specified (PLE combiner is now capturable), and the correctness
+  break predates it. A revert would trade a smaller capture region
+  for no correctness benefit.
+- Did NOT mark T99.1.3 complete. It remains `[ ]` and BLOCKED on
+  T99.1.4 + T99.2.2.
+
+**Process note:** the initial instinct was to revert T99.1.2 + its
+follow-up `6ad8bceb` and re-implement with a regression test.
+Running a CPU diagnostic at main first, then a GPU diagnostic at the
+prior commit, cheaply invalidated that plan (both commits equally
+broken in different ways). Rule worth generalizing: before blaming a
+recent commit for a regression, reproduce the pre-commit state. The
+3 minutes of bench time saved hours of wrong-path bisecting and a
+PR that would have lost the T99.1.2 work for no gain.
+
+**Fix:** N/A for this investigation. Three follow-up tasks filed in
+`docs/plan.md`: T99.1.4, T99.2.1, T99.2.2. Benchmarks entry annotated.
+
+**Impact:** gemma4e inference on Zerfoo does not produce usable
+output today; capture is blocked beyond the PLE fix; the best
+reproducible throughput number is 2.69 tok/s and it's on gibberish.
+Gemma 4 E2B should not appear in user-facing benchmarks or marketing
+until T99.2.2 lands.
+
 ## 2026-04-15: E99 T99.1.1 + T99.1.2 -- fix gemma4e CUDA graph capture vs pleCombinedProducer
 
 **Type:** finding

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1814,11 +1814,72 @@ everything else; this is a performance task, not a correctness blocker.
   (prefill -> decode reallocation path). Removed now-unused
   `sliceLastDim` helper. Full test suite green locally.
 
-- [ ] T99.1.3 Re-verify gemma4e generate with CUDA graph capture ENABLED  Owner: dndungu  Est: 20m  verifies: [UC-001]
-  Deps: T99.1.2
+- [ ] T99.1.3 Re-verify gemma4e generate with CUDA graph capture ENABLED  Owner: dndungu  Est: 20m  verifies: [UC-001]  BLOCKED by T99.1.4 + T99.2.2
+  Deps: T99.1.2, T99.1.4, T99.2.2
   AC: gemma4_e2e generate on cuda runs with `ZERFOO_DISABLE_CUDA_GRAPH` unset,
   graph capture completes, and throughput meets or beats the
   uncaptured path. Drop the env var from the manifest.
+  Status (2026-04-16): attempted on main `6ad8bceb`, capture fails at
+  instruction 568 (LMHead) with `number of axes 3 must match tensor
+  dimensions 2`; falls back to uncaptured path at 1.17 tok/s vs 1.23
+  tok/s baseline (equivalent -- capture never completes). Also
+  surfaced two deeper issues tracked as T99.2.1 and T99.2.2. See
+  `docs/devlog.md` 2026-04-16 entry.
+
+- [ ] T99.1.4 Make LMHead CUDA-graph-capture compatible  Owner: TBD  Est: 2-4h  verifies: [UC-001]
+  Deps: none (unblocks T99.1.3)
+  Problem: during gemma4e generate on cuda with capture enabled, the
+  capture region extends to the full [2, 569) graph but ends with
+  `cudaStreamEndCapture failed: operation failed due to a previous
+  error during capture` and the error message points at instruction
+  568 (LMHead): "number of axes 3 must match tensor dimensions 2".
+  Options: (a) register `LMHead` in ztensor's `nonCapturableOps` so it
+  runs post-capture on the host stream (mirrors T99.1.1's playbook for
+  `Gemma4PLECombinedProducer`), or (b) fix the axes/dims path in
+  LMHead so it is capture-safe. Pick based on how small the capture
+  region becomes in option (a) -- losing the last instruction is
+  fine; losing a larger tail is not.
+  AC: gemma4_e2e generate on cuda completes `cudaStreamEndCapture`
+  successfully with `ZERFOO_DISABLE_CUDA_GRAPH` unset, on a binary
+  built from current main (regardless of T99.2.1/T99.2.2 state).
+
+### E99.2 Pre-existing gemma4e correctness + throughput issues (discovered 2026-04-16)
+
+These were surfaced while attempting T99.1.3 and are orthogonal to
+the capture-compatibility work in E99.1. Neither is caused by T99.1.2
+-- both reproduce on commit `72828131` (the prior "baseline"). See
+`docs/devlog.md` 2026-04-16 entry for the reproduction matrix.
+
+- [ ] T99.2.1 Bisect and fix gemma4e GPU decode throughput regression  Owner: TBD  Est: 4-8h  verifies: [infrastructure]
+  Deps: none
+  Problem: gemma4e generate on cuda with `ZERFOO_DISABLE_CUDA_GRAPH=1`
+  ran at 2.69 tok/s on commit `72828131` (2026-04-15) and at 1.23
+  tok/s on commit `6ad8bceb` (main, 2026-04-16). Same prompt, steps,
+  seq, device. Prime suspect is T99.1.2's per-step `CopyFromHost`
+  refresh of the 35 per-layer PLE slice buffers, but not yet bisected.
+  AC: restore gemma4e decode throughput to at least the 72828131
+  level (>= 2.69 tok/s at capture-off on the same bench params), with
+  the root cause identified and documented in the fix PR. Do NOT
+  revert T99.1.2 -- fix forward.
+
+- [ ] T99.2.2 Fix gemma4e decode correctness (degenerate output)  Owner: TBD  Est: unknown (epic-level)  verifies: [UC-001]
+  Deps: none
+  Problem: `gemma4_e2e -mode generate -device cpu -steps 32 -prompt
+  "The quick brown fox"` produces `"ly\ns\ns\ns..."` on both
+  `72828131` and `6ad8bceb`. GPU output is differently degenerate
+  (`"overdaythe\ns\nsn\n..."` on 72828131, multilingual gibberish on
+  6ad8bceb) but also incoherent. The existing plan note that the
+  E98 test pod gave "40 bytes non-degenerate output" referred to
+  `-mode forward`, not `-mode generate`; decode has never been
+  validated for coherence on gemma4e in either mode on either device.
+  Also: every generate run logs `CompileTraced plan validation failed,
+  falling back to Compile: instruction 0 (Gather|MulScalar): input
+  tensors cannot be nil`; unclear whether this is related to the
+  decode break or a separate noise.
+  AC: gemma4e generate on a standard prompt produces coherent
+  English tokens on both CPU and GPU, verified by a committed
+  regression test. Likely touches sampling, logits/LMHead, tied
+  embeddings, or the Q4->Q8 upgrade path for `model.embed_tokens.weight`.
 
 ### E98 Risk Register
 


### PR DESCRIPTION
## Summary

Docs-only PR. Attempted T99.1.3 (re-enable CUDA graph capture for gemma4e generate) on current main; capture region extends end-to-end but `cudaStreamEndCapture` fails at LMHead, the \`3.85 tok/s\` baseline does not reproduce, and decode output is degenerate on both CPU and GPU at both the prior commit (\`72828131\`) and current main (\`6ad8bceb\`). Filing three scoped follow-ups; no code revert.

## Reproduction matrix

| Commit | Device | Capture env | Steps | tok/s | Output sample |
|---|---|---|---|---|---|
| 72828131 | cpu | N/A | 32 | 0.69 | \`"ly\ns\ns\ns..."\` |
| 72828131 | cuda | DISABLE=1 | 64 | **2.69** | \`"overdaythe\ns\nsn\n..."\` |
| 6ad8bceb (main) | cpu | N/A | 16 | 0.59 | \`"ly\ns\ns\ns..."\` |
| 6ad8bceb (main) | cuda | DISABLE=1 | 64 | 1.23 | multilingual gibberish |
| 6ad8bceb (main) | cuda | unset | 64 | 1.17 | capture fails at LMHead (inst 568: axes 3 vs dims 2), falls back, same gibberish |

## What this PR does

- `docs/plan.md`: mark T99.1.3 BLOCKED; file T99.1.4 (LMHead capture compat), T99.2.1 (2.69 -> 1.23 throughput regression), T99.2.2 (gemma4e decode correctness, pre-existing).
- `docs/benchmarks.md`: annotate the \`3.85 tok/s\` figure as unverified; add correctness caveat; record 2.69 as current reproducible floor and 1.23 as current main.
- `docs/devlog.md`: full investigation entry (2026-04-16) with matrix, LMHead stack detail, and process notes on why we did NOT revert T99.1.2.

## What this PR deliberately does NOT do

- Revert T99.1.2 or \`6ad8bceb\`. T99.1.2 did what ADR-088 Option C specified; decode breakage predates it; revert would lose the PLE capture fix for no correctness gain.
- Propose fixes for T99.1.4 / T99.2.1 / T99.2.2. Those are separate PRs.

## Test plan

- [x] \`docs/plan.md\` renders cleanly (headings + BLOCKED marker).
- [x] \`docs/benchmarks.md\` renders cleanly (footnote asterisks match).
- [x] \`docs/devlog.md\` 2026-04-16 entry prepends cleanly above prior 2026-04-15 entry.
- [x] \`git diff --stat\`: 3 files, 198 insertions, 11 deletions. No code changes.