### PR TITLE
docs(adr): ADR-089 LMHead CUDA-graph-capture decision (T99.1.4 handoff)

### DIFF
--- a/docs/adr/089-lmhead-cuda-graph-capture.md
+++ b/docs/adr/089-lmhead-cuda-graph-capture.md
@@ -1,0 +1,205 @@
+# ADR-089: CUDA Graph Capture Compatibility for LMHead
+
+**Status:** Proposed (awaiting ztensor ship)
+**Date:** 2026-04-16
+**Epic:** E99 (gemma4e CUDA graph capture)
+**Task:** T99.1.4
+
+## Context
+
+After ADR-088 (T99.1.2) made `Gemma4PLECombinedProducer` capture-safe,
+the CUDA graph capture region for gemma4e expanded from a single layer
+to `[2, 569)` — the full transformer body. However, `cudaStreamEndCapture`
+still fails with:
+
+```
+cuda graph: end capture failed: cudaStreamEndCapture failed: operation
+failed due to a previous error during capture
+CUDA GRAPH: capture failed: instruction 568 (LMHead): number of axes 3
+must match tensor dimensions 2
+```
+
+Instruction 568 is the last instruction in the plan (LMHead is the
+terminal op of the transformer graph: `hidden -> logits`). The
+`number of axes 3 must match tensor dimensions 2` error originates
+from `CPUEngine.Transpose` in
+`ztensor/compute/cpu_engine.go:1306`, reached via a fallback inside
+`GPUEngine.MatMulTransposeB`
+(`ztensor/compute/gpu_engine.go:1248,1258,1307,1317,1338`). The
+fallback calls `e.Transpose(ctx, b, []int{0, 2, 1})` — 3 axes — on the
+LMHead weight `b` which is always 2D `[vocabSize, hiddenDim]`.
+
+The fallback fires when any of these is true:
+- BLAS does not implement `BLASTransposeB` (SgemmNT).
+- `T` is not `float32` (e.g. FP16 path on gemma4e could end up here).
+- `getDevicePtr(e, a)` or `getDevicePtr(e, b)` fails (common during
+  graph capture because CUDA rejects synchronous H2D copies on a
+  capturing stream when a tensor is CPU-resident).
+- `e.pool.Alloc` fails (VRAM pressure).
+
+On DGX with gemma4e Q4_K_M, at least one of these triggers during
+capture, and the 3-axis Transpose on a 2D weight explodes.
+
+A previous incarnation of this same bug was observed at an earlier
+commit: 2026-03-26 devlog entry reports
+`instruction 184 (LMHead): number of axes 3 must match tensor
+dimensions 2` on the mmap loading path — same root cause, different
+trigger density.
+
+## Options Considered
+
+### A. Register `LMHead` in ztensor's `nonCapturableOps`
+
+**What it means.** Add `"LMHead": true` to the `nonCapturableOps` map
+in `ztensor/graph/cuda_graph.go`. The capture-region selector
+(`NewCUDAGraphExecutor` in `cuda_graph.go:264`) picks the longest
+contiguous capturable run; with LMHead excluded, the region becomes
+`[2, 568)` and LMHead runs post-capture on the host stream (same path
+used for `EmbeddingLookup` at pre-capture).
+
+**Capture region impact.** We lose exactly one instruction at the
+tail. The 35-layer transformer body (~566 instructions) stays captured.
+No layer-body fragmentation, unlike the pre-T99.1.2 state of the PLE
+slicers. This is the ideal outcome for a last-in-plan op.
+
+**Cost.** One-line change in ztensor. Requires release-please cut and a
+go.mod bump in zerfoo. No behavior change on CPU, no throughput
+regression on GPU uncaptured path, no correctness impact.
+
+### B. Fix the axes/dims path in `GPUEngine.MatMulTransposeB` fallback (ztensor)
+
+**What it means.** Change every `e.Transpose(ctx, b, []int{0, 2, 1})`
+in `gpu_engine.go` `MatMulTransposeB` to branch on `len(b.Shape())`:
+use `[]int{1, 0}` when `b` is 2D and `[]int{0, 2, 1}` when 3D.
+
+**Why more risky.** Touches five fallback sites, each with subtly
+different context (unsupported BLAS, wrong dtype, H2D blocked, OOM).
+Also the failure mode inside capture is a CUDA error that may be
+partially synchronous — even with the correct Transpose axes, the
+resulting `e.MatMul(ctx, a, kT, dst...)` would execute on the host
+stream and could still break capture by issuing a synchronous memcpy.
+We would need to confirm all four preconditions that drive into the
+fallback are capture-safe; option A sidesteps the question entirely.
+
+**Why deferred.** This is a general-purpose bugfix in ztensor worth
+doing independently of T99.1.4. It does not need to block the capture
+fix. File as a separate ztensor issue.
+
+### C. Avoid `MatMulTransposeB` in `lmHeadNode.Forward` (zerfoo-only)
+
+**What it means.** In `inference/arch_llama.go:lmHeadNode.Forward`,
+skip the `TransposeBMatMuler` branch for the non-quantized case and
+always do an explicit `Transpose(weight, [1,0])` + `MatMul`.
+
+**Why rejected.**
+
+1. Regresses the original `MatMulTransposeB` motivation. The code's
+   existing comment (line 98-102) explains that explicit Transpose
+   allocates a 1GB+ temporary on large-vocab models and caused a prior
+   use-after-free. While we could avoid caching, the allocation cost
+   alone is a real per-step hit during decode.
+2. Even if the explicit Transpose runs fine uncaptured, it would still
+   hit the same `getDevicePtr`-during-capture failure mode during
+   graph capture on CPU-resident weights.
+3. Does not fix the analogous problem for any other op that routes
+   through `MatMulTransposeB` with a 2D B (e.g., future attention
+   variants that reuse the helper).
+
+### D. Fail-open: catch the CPU Transpose error in LMHead and recover
+
+Not viable. The error happens mid-capture, at which point the CUDA
+stream is already invalidated. Recovering requires tearing down the
+whole capture and starting over — which is exactly what the current
+fall-through-to-uncaptured-path does.
+
+## Decision
+
+**Adopt Option A.** Register `LMHead` in ztensor's `nonCapturableOps`.
+
+Rationale:
+- Matches the T99.1.1 / ADR-088 playbook for an op that does
+  host-visible work during capture.
+- LMHead is the last instruction; post-capture placement costs zero
+  capture-region coverage.
+- Minimal cross-repo surface (one line in ztensor, one go.mod bump in
+  zerfoo).
+- Option B is a ztensor-internal hardening that should land separately
+  as a robustness improvement, not as a blocker for gemma4e capture.
+
+## Consequences
+
+### Positive
+
+- gemma4e on CUDA can drop `ZERFOO_DISABLE_CUDA_GRAPH=1` once the
+  ztensor change ships and the go.mod bump lands. Capture region is
+  35-layer transformer body, equivalent to other GGUF architectures.
+- Pattern generalizes to any terminal op that triggers host-visible
+  fallbacks during capture (e.g., a future sampled-softmax head).
+
+### Negative / cost
+
+- One extra instruction (LMHead) runs post-capture on the host stream
+  instead of replayed inside the graph. Measurable impact: a single
+  MatMul + Reshape + optional softcap at the very end of the pass.
+  Based on the 184/185 instruction capture ratio seen on Gemma 3, the
+  throughput delta from excluding one terminal op is small enough to
+  be inside bench noise.
+- Cross-repo dependency: zerfoo's gemma4e capture fix requires a
+  ztensor release. Not new (ADR-088 had the same pattern).
+
+### Follow-ups
+
+- **Ship the one-line ztensor change** (T99.1.4a, this ADR's
+  implementation). Coordinator ships `zerfoo/ztensor` first, then a
+  bump PR in `zerfoo/zerfoo`.
+- **T99.1.3** (currently blocked): verify on DGX that
+  `cudaStreamEndCapture` succeeds without the env var.
+- **Optional: fix `MatMulTransposeB` fallback axes** (file as new
+  ztensor task). Low-risk hardening that prevents this class of bug
+  recurring for other 2D-B callers.
+- **T99.2.1** (throughput regression) and **T99.2.2** (decode
+  correctness) remain separate and out of scope here.
+
+## Handoff diff (ztensor)
+
+The exact change required in `github.com/zerfoo/ztensor` at
+`graph/cuda_graph.go:57-66`:
+
+```diff
+ var nonCapturableOps = map[string]bool{
+ 	"EmbeddingLookup":            true,
+ 	"Gather":                     true,
+ 	"AutoAttentionMask":          true,
+ 	"AutoPositionIds":            true,
+ 	"Slice":                      true,
+ 	"ConstantOfShape":            true,
+ 	"Shape":                      true,
+ 	"Gemma4PLECombinedProducer":  true,
++	"LMHead":                     true,
+ }
+```
+
+Accompanying comment block (`graph/cuda_graph.go`, near the
+`Gemma4PLECombinedProducer` justification):
+
+```go
+// LMHead is the terminal op of transformer graphs (hidden -> logits).
+// Its internal MatMulTransposeB fallback calls Transpose(weight,
+// [0,2,1]) on a 2D weight tensor, raising "number of axes 3 must
+// match tensor dimensions 2" from CPUEngine.Transpose when any of
+// BLAS-NT absence, non-float32 T, getDevicePtr failure, or
+// Alloc-during-capture drives into the fallback path. Since LMHead
+// is the last instruction, placing it post-capture costs zero
+// capture-region coverage. See zerfoo/docs/adr/089.
+```
+
+After the ztensor PR merges and release-please cuts a version X:
+
+- Update `zerfoo/go.mod`: bump `github.com/zerfoo/ztensor` to version X.
+- Run `go mod tidy` to update `go.sum`.
+- Drop `ZERFOO_DISABLE_CUDA_GRAPH: "1"` from
+  `docs/bench/manifests/gemma4-e2e.yaml`.
+- Verify on DGX via `scripts/gemma4-spark.sh -mode generate -device cuda
+  -steps 32 -cleanup`. Success = no
+  `cudaStreamEndCapture failed` or `capture failed: instruction ... (LMHead)`
+  lines in the log. Unblocks T99.1.3.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,146 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-04-16: T99.1.4 -- LMHead CUDA-graph-capture root cause + ztensor handoff diff
+
+**Type:** investigation
+**Tags:** gemma4e, cuda, graph-capture, e99, t99.1.4, lmhead, nonCapturableOps, adr-089, cross-repo
+
+**Problem:** T99.1.3 (2026-04-16 earlier entry) observed that after
+T99.1.2's PLE-combiner fix, gemma4e capture still fails with
+`cudaStreamEndCapture failed: operation failed due to a previous
+error during capture` and `instruction 568 (LMHead): number of axes
+3 must match tensor dimensions 2`. T99.1.4 is to fix LMHead so
+capture completes.
+
+**Root cause:** The error string matches exactly one source in
+ztensor: `CPUEngine.Transpose` at `compute/cpu_engine.go:1306`, which
+checks `len(axes) != len(originalShape)`. LMHead's weight is always 2D
+`[vocabSize, hiddenDim]`, so the caller is passing 3 axes.
+
+The caller is `GPUEngine.MatMulTransposeB` in
+`ztensor/compute/gpu_engine.go`. That function has five fallback sites
+(lines 1248, 1258, 1307, 1317, 1338) that all do
+`e.Transpose(ctx, b, []int{0, 2, 1})` — hard-coded 3 axes, assuming `b`
+is always 3D. When `b` is 2D (as in every LMHead call), the fallback
+explodes.
+
+The fallback fires when any of these is true during graph capture:
+
+- BLAS does not implement `BLASTransposeB` (SgemmNT).
+- `T` is not `float32`.
+- `getDevicePtr(e, a)` or `getDevicePtr(e, b)` fails (common under
+  capture if a tensor is CPU-resident — CUDA rejects synchronous H2D
+  on a capturing stream).
+- `e.pool.Alloc` fails.
+
+On DGX gemma4e Q4_K_M, at least one of these triggers during capture.
+
+**Prior art:** the 2026-03-26 mmap devlog entry records the same
+string at `instruction 184 (LMHead)` for the mmap load path. Same root
+cause, different trigger density. Never fixed; masked by
+`ZERFOO_DISABLE_CUDA_GRAPH=1`.
+
+**Decision (ADR-089):** Adopt Option A — register `"LMHead"` in
+ztensor's `nonCapturableOps` map. LMHead is the last instruction in
+the plan (568 of 569), so excluding it loses zero capture coverage:
+the capture region becomes `[2, 568)`, which is the full 35-layer
+transformer body. Post-capture, LMHead runs on the host stream via
+the same mechanism used for `EmbeddingLookup` pre-capture. Mirrors
+T99.1.1 / ADR-088's playbook.
+
+**Options rejected:**
+
+- **Option B** (fix `MatMulTransposeB` fallback axes for 2D B, in
+  ztensor): Correct but touches five fallback sites with subtly
+  different preconditions. Also, even with correct axes, the
+  fallback's `MatMul` would run on the host stream during capture and
+  could still break capture via implicit memcpy. File separately as a
+  ztensor hardening task; do not block T99.1.4 on it.
+- **Option C** (swap `MatMulTransposeB` for explicit Transpose+MatMul
+  in zerfoo's `lmHeadNode.Forward`): Regresses the fix documented in
+  `inference/arch_llama.go:98-102` — explicit Transpose allocates
+  1GB+ on large-vocab LMs each pass. Also hits the same
+  capture-during-fallback failure class.
+- **Option D** (catch-and-recover in LMHead): not viable, stream is
+  already invalidated mid-capture.
+
+**Cross-repo constraint:** Option A's fix lives in
+`github.com/zerfoo/ztensor`. Per CLAUDE.md policy and T99.1.4 brief,
+cross-repo release is a 30min-2h coordination (ztensor PR ->
+release-please version cut -> zerfoo go.mod bump). The T99.1.4 brief
+explicitly instructs:
+
+> if option (a) is clearly correct but the cross-repo cycle blocks
+> you, STOP and write up the exact ztensor change needed as a handoff
+> note — do NOT attempt to force a cross-repo ship.
+
+Option (a) is clearly correct. Handoff follows.
+
+**Exact ztensor diff** (`github.com/zerfoo/ztensor` @
+`graph/cuda_graph.go`):
+
+```diff
+ var nonCapturableOps = map[string]bool{
+ 	"EmbeddingLookup":            true,
+ 	"Gather":                     true,
+ 	"AutoAttentionMask":          true,
+ 	"AutoPositionIds":            true,
+ 	"Slice":                      true,
+ 	"ConstantOfShape":            true,
+ 	"Shape":                      true,
+ 	"Gemma4PLECombinedProducer":  true,
++	"LMHead":                     true,
+ }
+```
+
+Include a justification comment near the existing
+`Gemma4PLECombinedProducer` comment:
+
+```go
+// LMHead is the terminal op of transformer graphs
+// (hidden -> logits). Its internal MatMulTransposeB fallback calls
+// Transpose(weight, [0,2,1]) on a 2D weight tensor, raising
+// "number of axes 3 must match tensor dimensions 2" from
+// CPUEngine.Transpose when any of BLAS-NT absence, non-float32 T,
+// getDevicePtr failure, or Alloc-during-capture drives into the
+// fallback path. Since LMHead is the last instruction, placing it
+// post-capture costs zero capture-region coverage.
+// See zerfoo/docs/adr/089.
+```
+
+**Coordinator checklist to close T99.1.4:**
+
+1. Open PR in `zerfoo/ztensor` with the diff above (conventional
+   commit: `fix(graph): mark LMHead as non-capturable for CUDA graph`).
+2. Merge (rebase+merge). Wait for release-please to cut ztensor
+   vN.N.N.
+3. In `zerfoo/zerfoo`, update `go.mod`: bump
+   `github.com/zerfoo/ztensor` to vN.N.N. Run `go mod tidy`.
+4. Remove the `ZERFOO_DISABLE_CUDA_GRAPH: "1"` env entry from
+   `docs/bench/manifests/gemma4-e2e.yaml`.
+5. Submit `scripts/gemma4-spark.sh -mode generate -device cuda -steps
+   32 -cleanup`. Success = no `cudaStreamEndCapture failed` or
+   `capture failed: instruction ... (LMHead)` lines in the log.
+   Output may still be degenerate (T99.2.2 is pre-existing and out of
+   scope).
+6. Unblocks T99.1.3 (verify throughput vs baseline with capture on).
+
+**Process note:** the investigation in this repo worktree reached the
+root cause in ~20 minutes by cross-referencing the error string
+(exactly one grep hit in ztensor), the LMHead callsite
+(`inference/arch_llama.go:lmHeadNode.Forward`), and the
+`MatMulTransposeB` fallback pattern (five identical `[]int{0, 2, 1}`
+sites). Confirmation that LMHead is the terminal instruction was the
+deciding factor for Option A over Option B — losing a tail
+instruction costs nothing; a mid-graph non-capturable op would have
+fragmented the region and forced Option B.
+
+**Impact:** No functional change in this repo yet. The worktree is
+clean except for ADR-089 and this devlog entry. Full fix requires the
+coordinator to ship the ztensor diff above and then bump the zerfoo
+go.mod.
+
 ## 2026-04-16: T99.1.3 investigation -- three stacked gemma4e issues, none caused by T99.1.2
 
 **Type:** investigation

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1842,6 +1842,17 @@ everything else; this is a performance task, not a correctness blocker.
   AC: gemma4_e2e generate on cuda completes `cudaStreamEndCapture`
   successfully with `ZERFOO_DISABLE_CUDA_GRAPH` unset, on a binary
   built from current main (regardless of T99.2.1/T99.2.2 state).
+  Status (2026-04-16, handoff): investigation complete. Root cause is
+  the `MatMulTransposeB` fallback in ztensor
+  `compute/gpu_engine.go:1248,1258,1307,1317,1338` which calls
+  `Transpose(b, [0,2,1])` (3 axes) on LMHead's always-2D weight.
+  Decision is Option A (see ADR-089) -- register `"LMHead"` in
+  ztensor's `nonCapturableOps` map. Since LMHead is the last
+  instruction (568 of 569), post-capture placement costs zero
+  capture-region coverage. Exact one-line diff for ztensor + the
+  coordinator checklist are in `docs/devlog.md` (2026-04-16 T99.1.4
+  entry) and `docs/adr/089-lmhead-cuda-graph-capture.md`. Awaiting
+  coordinator to ship ztensor PR and bump `go.mod`.
 
 ### E99.2 Pre-existing gemma4e correctness + throughput issues (discovered 2026-04-16)
 


### PR DESCRIPTION
## Summary

Docs-only PR capturing the T99.1.4 investigation. **This PR does NOT complete T99.1.4** -- the actual fix lives in a separate repo (`github.com/zerfoo/ztensor`). This PR documents the root cause, the chosen option, and the exact one-line diff the coordinator must ship in ztensor to unblock T99.1.4.

## Root cause (summarized from ADR-089)

After T99.1.2 expanded the gemma4e CUDA-graph capture region to `[2, 569)`, `cudaStreamEndCapture` fails at instruction 568 (LMHead):
```
CUDA GRAPH: capture failed: instruction 568 (LMHead): number of axes 3 must match tensor dimensions 2
```
The error originates from `CPUEngine.Transpose` called via `GPUEngine.MatMulTransposeB` fallback in ztensor, which hard-codes `Transpose(b, [0,2,1])` (3 axes) on LMHead's always-2D weight `[vocabSize, hiddenDim]`.

## Decision: Option A (ADR-089)

Register `"LMHead"` in ztensor's `nonCapturableOps` map. LMHead is the last instruction in the plan -- moving it post-capture costs zero capture-region coverage and avoids the five-site fallback fix risk of Option B.

## Coordinator follow-up (required to complete T99.1.4)

1. Open PR in `zerfoo/ztensor` with this one-line diff to `graph/cuda_graph.go`:
   ```diff
    var nonCapturableOps = map[string]bool{
        ...
   +    "LMHead":                     true,
    }
   ```
2. Rebase-merge; wait for release-please to cut a ztensor patch release.
3. Bump `github.com/zerfoo/ztensor` in this repo's `go.mod` + run `go mod tidy`.
4. Verify on DGX: `scripts/gemma4-spark.sh -mode generate -device cuda -steps 32 -cleanup` with `ZERFOO_DISABLE_CUDA_GRAPH` unset in the manifest. Success = no `cudaStreamEndCapture failed` line. Only then mark T99.1.4 `[x]` in `docs/plan.md`.

## What this PR contains

- `docs/adr/089-lmhead-cuda-graph-capture.md` (new) -- decision record with options considered, tradeoffs, and the exact ztensor diff.
- `docs/devlog.md` -- 2026-04-16 entry documenting the investigation.
- `docs/plan.md` -- T99.1.4 annotated with "handoff status + ADR-089 reference"; task remains `[ ]`.

## Test plan

- [x] ADR renders (Markdown headings + code blocks).
- [x] devlog entry appends cleanly above prior 2026-04-16 entries.
- [x] plan.md T99.1.4 status note inserts without disturbing T99.2.1/T99.2.2 stanzas.
- [x] `git diff --stat`: 3 files, +356 lines, -0 lines. No code changes; no CI risk.
- [N/A] DGX verification -- cannot verify until the ztensor change ships.