### PR TITLE
T99.2.2 Wave 1: H19 granular PLE ablation + H17 ple_embed diff tool

### DIFF
--- a/cmd/gemma4_e2e/main.go
+++ b/cmd/gemma4_e2e/main.go
@@ -3,18 +3,23 @@
 // forward pass on CPU exceeds reasonable test timeouts, so these assertions
 // cannot live in the CPU `go test` path.
 //
-// Two modes:
+// Three modes:
 //   - forward (default, T93.4.1/E96): load GGUF, build the graph, run one
 //     forward pass, and verify finite non-zero logits.
 //   - generate (T97.1.1): load the model end-to-end via inference.LoadFile
 //     (which builds graph + extracts tokenizer + wires a Generator), then run
 //     greedy decode for N steps on the given prompt and verify finite logits
 //     and non-degenerate output.
+//   - ple-embed-diff (T99.2.2.2/H17): load `model.ple_embed_tokens.weight`
+//     from a Q4_K_M GGUF and a Q8_0 GGUF, dequantize both to F32, and print
+//     per-row L2-difference summary statistics plus the top-20 worst rows.
+//     No graph build, no generation -- purely a weight-level diagnostic.
 //
 // Usage (from Spark pod manifest):
 //
 //	gemma4_e2e -gguf /var/lib/zerfoo/models/gemma-4-E2B-it-Q4_K_M.gguf
 //	gemma4_e2e -gguf <path> -mode generate -prompt "The quick" -steps 50
+//	gemma4_e2e -mode ple-embed-diff -gguf-q4 <q4-path> -gguf-q8 <q8-path>
 //
 // Exit codes: 0 = all checks pass; 1 = any check fails.
 package main
@@ -35,33 +40,48 @@ import (
 )
 
 func main() {
-	ggufPath := flag.String("gguf", "", "path to Gemma 4 E2B GGUF file (required)")
-	mode := flag.String("mode", "forward", "mode: forward | generate")
+	ggufPath := flag.String("gguf", "", "path to Gemma 4 E2B GGUF file ([forward|generate] required)")
+	mode := flag.String("mode", "forward", "mode: forward | generate | ple-embed-diff")
 	seqLen := flag.Int("seq", 4, "[forward] sequence length for the single forward pass")
 	prompt := flag.String("prompt", "The quick brown fox", "[generate] prompt text")
 	steps := flag.Int("steps", 50, "[generate] max new tokens")
 	device := flag.String("device", "cpu", "[generate] compute device: cpu | cuda")
 	mmap := flag.Bool("mmap", true, "[generate] use mmap GGUF loader (false forces heap load + Q4->Q8 embedding upgrade)")
+	ggufQ4 := flag.String("gguf-q4", "", "[ple-embed-diff] absolute path to Q4_K_M GGUF (required for this mode)")
+	ggufQ8 := flag.String("gguf-q8", "", "[ple-embed-diff] absolute path to Q8_0 GGUF (required for this mode)")
+	pleMaxRows := flag.Int("ple-max-rows", 0, "[ple-embed-diff] if > 0, limit comparison to the first N rows (R99.2.2.A scoped run)")
 	flag.Parse()
-
-	if *ggufPath == "" {
-		fmt.Fprintln(os.Stderr, "gemma4_e2e: -gguf is required")
-		os.Exit(2)
-	}
 
 	switch *mode {
 	case "forward":
+		if *ggufPath == "" {
+			fmt.Fprintln(os.Stderr, "gemma4_e2e: -gguf is required for -mode forward")
+			os.Exit(2)
+		}
 		if err := runForward(*ggufPath, *seqLen); err != nil {
 			fmt.Fprintf(os.Stderr, "gemma4_e2e: %v\n", err)
 			os.Exit(1)
 		}
 	case "generate":
+		if *ggufPath == "" {
+			fmt.Fprintln(os.Stderr, "gemma4_e2e: -gguf is required for -mode generate")
+			os.Exit(2)
+		}
 		if err := runGenerate(*ggufPath, *device, *prompt, *steps, *mmap); err != nil {
 			fmt.Fprintf(os.Stderr, "gemma4_e2e: %v\n", err)
 			os.Exit(1)
 		}
+	case "ple-embed-diff":
+		if *ggufQ4 == "" || *ggufQ8 == "" {
+			fmt.Fprintln(os.Stderr, "gemma4_e2e: -gguf-q4 and -gguf-q8 are required for -mode ple-embed-diff")
+			os.Exit(2)
+		}
+		if err := runPLEEmbedDiff(*ggufQ4, *ggufQ8, *pleMaxRows, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "gemma4_e2e: %v\n", err)
+			os.Exit(1)
+		}
 	default:
-		fmt.Fprintf(os.Stderr, "gemma4_e2e: unknown -mode %q (want forward|generate)\n", *mode)
+		fmt.Fprintf(os.Stderr, "gemma4_e2e: unknown -mode %q (want forward|generate|ple-embed-diff)\n", *mode)
 		os.Exit(2)
 	}
 

--- a/cmd/gemma4_e2e/ple_embed_diff.go
+++ b/cmd/gemma4_e2e/ple_embed_diff.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"sort"
+
+	"github.com/zerfoo/zerfoo/inference"
+)
+
+// rowDiffStats holds summary statistics of per-row L2 differences between two
+// equally-shaped [vocab, cols] float32 matrices.
+type rowDiffStats struct {
+	Rows   int       // number of rows compared
+	Cols   int       // columns per row
+	P50    float32   // median L2
+	P95    float32   // 95th percentile L2
+	P99    float32   // 99th percentile L2
+	P100   float32   // max L2 (p100)
+	TopK   []rowDiff // largest-L2 rows, descending
+	Scoped bool      // true when only a prefix of rows was compared (scoped run)
+}
+
+// rowDiff records a single row's L2 distance.
+type rowDiff struct {
+	Row int
+	L2  float32
+}
+
+// perRowL2 computes the L2 norm of (a - b) for every row i in [0, rows),
+// assuming both slices are laid out as row-major [rows, cols] float32 matrices.
+// Returns one L2 value per row.
+func perRowL2(a, b []float32, rows, cols int) ([]float32, error) {
+	if rows <= 0 || cols <= 0 {
+		return nil, fmt.Errorf("perRowL2: rows=%d cols=%d must be positive", rows, cols)
+	}
+	need := rows * cols
+	if len(a) < need || len(b) < need {
+		return nil, fmt.Errorf("perRowL2: need %d elements, got len(a)=%d len(b)=%d", need, len(a), len(b))
+	}
+	out := make([]float32, rows)
+	for r := 0; r < rows; r++ {
+		base := r * cols
+		var sumSq float64
+		for c := 0; c < cols; c++ {
+			d := float64(a[base+c]) - float64(b[base+c])
+			sumSq += d * d
+		}
+		out[r] = float32(math.Sqrt(sumSq))
+	}
+	return out, nil
+}
+
+// summarizeRowL2 converts a slice of per-row L2 values into percentile stats
+// and a top-K largest-error list. topK must be >= 0; if 0 no rows are returned.
+// The caller retains ownership of l2; this function does not modify it.
+func summarizeRowL2(l2 []float32, cols, topK int) rowDiffStats {
+	n := len(l2)
+	stats := rowDiffStats{Rows: n, Cols: cols}
+	if n == 0 || topK < 0 {
+		return stats
+	}
+	sorted := make([]float32, n)
+	copy(sorted, l2)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	stats.P50 = percentile(sorted, 0.50)
+	stats.P95 = percentile(sorted, 0.95)
+	stats.P99 = percentile(sorted, 0.99)
+	stats.P100 = sorted[n-1]
+
+	if topK == 0 {
+		return stats
+	}
+	if topK > n {
+		topK = n
+	}
+	// Build (row, L2) pairs and sort descending by L2, ascending by row on ties.
+	pairs := make([]rowDiff, n)
+	for i, v := range l2 {
+		pairs[i] = rowDiff{Row: i, L2: v}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].L2 != pairs[j].L2 {
+			return pairs[i].L2 > pairs[j].L2
+		}
+		return pairs[i].Row < pairs[j].Row
+	})
+	stats.TopK = pairs[:topK]
+	return stats
+}
+
+// percentile returns the p-th quantile (0..1) of a pre-sorted ascending slice
+// using the nearest-rank method: index = ceil(p * n) - 1, clamped to [0, n-1].
+func percentile(sorted []float32, p float64) float32 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[n-1]
+	}
+	idx := int(math.Ceil(p*float64(n))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= n {
+		idx = n - 1
+	}
+	return sorted[idx]
+}
+
+// writeRowDiffReport prints a human-readable summary of the row-diff statistics
+// to w. The caller controls output destination so tests can capture it.
+func writeRowDiffReport(w io.Writer, label string, stats rowDiffStats) {
+	fmt.Fprintf(w, "ple-embed-diff[%s]: rows=%d cols=%d scoped=%v\n",
+		label, stats.Rows, stats.Cols, stats.Scoped)
+	fmt.Fprintf(w, "ple-embed-diff[%s]: L2 p50=%.6g p95=%.6g p99=%.6g p100=%.6g\n",
+		label, stats.P50, stats.P95, stats.P99, stats.P100)
+	for i, rd := range stats.TopK {
+		fmt.Fprintf(w, "ple-embed-diff[%s]: top[%02d] row=%d L2=%.6g\n",
+			label, i+1, rd.Row, rd.L2)
+	}
+}
+
+// runPLEEmbedDiff loads `model.ple_embed_tokens.weight` from both a Q4 and a
+// Q8 GGUF, dequantizes each to F32 via the standard tensor.Data() path, and
+// emits per-row L2 summary statistics + top-20 worst rows. If maxRows > 0 and
+// the tensor has more rows than maxRows, only the first maxRows are compared
+// (for use with the scoped R99.2.2.A ablation) and the output flags scoped=true.
+func runPLEEmbedDiff(q4Path, q8Path string, maxRows int, w io.Writer) error {
+	const tensorName = "model.ple_embed_tokens.weight"
+	const topK = 20
+
+	fmt.Fprintf(w, "ple-embed-diff: q4=%s\n", q4Path)
+	fmt.Fprintf(w, "ple-embed-diff: q8=%s\n", q8Path)
+
+	mdlQ4, err := inference.LoadGGUF(q4Path)
+	if err != nil {
+		return fmt.Errorf("load q4 GGUF: %w", err)
+	}
+	mdlQ8, err := inference.LoadGGUF(q8Path)
+	if err != nil {
+		return fmt.Errorf("load q8 GGUF: %w", err)
+	}
+
+	tQ4, ok := mdlQ4.Tensors[tensorName]
+	if !ok {
+		return fmt.Errorf("q4 GGUF missing tensor %q", tensorName)
+	}
+	tQ8, ok := mdlQ8.Tensors[tensorName]
+	if !ok {
+		return fmt.Errorf("q8 GGUF missing tensor %q", tensorName)
+	}
+
+	shapeQ4 := tQ4.Shape()
+	shapeQ8 := tQ8.Shape()
+	if len(shapeQ4) != 2 || len(shapeQ8) != 2 {
+		return fmt.Errorf("expected rank-2 tensor, got shapes q4=%v q8=%v", shapeQ4, shapeQ8)
+	}
+	if shapeQ4[0] != shapeQ8[0] || shapeQ4[1] != shapeQ8[1] {
+		return fmt.Errorf("shape mismatch: q4=%v q8=%v", shapeQ4, shapeQ8)
+	}
+	rows, cols := shapeQ4[0], shapeQ4[1]
+	fmt.Fprintf(w, "ple-embed-diff: tensor=%s shape=[%d,%d]\n", tensorName, rows, cols)
+
+	scoped := false
+	if maxRows > 0 && maxRows < rows {
+		fmt.Fprintf(w, "ple-embed-diff: scoped run -- comparing first %d of %d rows (R99.2.2.A)\n", maxRows, rows)
+		rows = maxRows
+		scoped = true
+	}
+
+	dataQ4 := tQ4.Data()
+	dataQ8 := tQ8.Data()
+
+	l2, err := perRowL2(dataQ4, dataQ8, rows, cols)
+	if err != nil {
+		return err
+	}
+	stats := summarizeRowL2(l2, cols, topK)
+	stats.Scoped = scoped
+	writeRowDiffReport(w, "q4_vs_q8", stats)
+	return nil
+}

--- a/cmd/gemma4_e2e/ple_embed_diff_test.go
+++ b/cmd/gemma4_e2e/ple_embed_diff_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestPerRowL2_KnownDeltas(t *testing.T) {
+	// 4 rows x 3 cols. Construct (a - b) so row L2 norms are
+	// row 0: ||(1, 0, 0)|| = 1
+	// row 1: ||(3, 4, 0)|| = 5
+	// row 2: ||(0, 0, 0)|| = 0
+	// row 3: ||(1, 2, 2)|| = 3
+	a := []float32{
+		1, 0, 0,
+		3, 4, 0,
+		7, 7, 7,
+		1, 2, 2,
+	}
+	b := []float32{
+		0, 0, 0,
+		0, 0, 0,
+		7, 7, 7,
+		0, 0, 0,
+	}
+	l2, err := perRowL2(a, b, 4, 3)
+	if err != nil {
+		t.Fatalf("perRowL2: %v", err)
+	}
+	want := []float32{1, 5, 0, 3}
+	if len(l2) != len(want) {
+		t.Fatalf("len(l2)=%d want %d", len(l2), len(want))
+	}
+	for i := range want {
+		if diff := math.Abs(float64(l2[i] - want[i])); diff > 1e-5 {
+			t.Errorf("row %d: got %.6g want %.6g", i, l2[i], want[i])
+		}
+	}
+}
+
+func TestPerRowL2_ShapeErrors(t *testing.T) {
+	if _, err := perRowL2(nil, nil, 0, 3); err == nil {
+		t.Error("expected error for rows=0")
+	}
+	if _, err := perRowL2([]float32{1}, []float32{1}, 1, 0); err == nil {
+		t.Error("expected error for cols=0")
+	}
+	if _, err := perRowL2([]float32{1, 2}, []float32{1, 2, 3}, 1, 3); err == nil {
+		t.Error("expected error for short input")
+	}
+}
+
+func TestSummarizeRowL2_PercentilesAndTopK(t *testing.T) {
+	// 10 values chosen so percentile indices are obvious with nearest-rank:
+	// sorted: [1 2 3 4 5 6 7 8 9 10].
+	// p50: ceil(0.50*10)-1 = 4 -> value 5
+	// p95: ceil(0.95*10)-1 = 9 -> value 10 (same as p100 at n=10; expected)
+	// p99: ceil(0.99*10)-1 = 9 -> value 10
+	// p100: value 10
+	l2 := []float32{10, 1, 7, 3, 9, 5, 2, 8, 4, 6}
+	stats := summarizeRowL2(l2, 8960, 3)
+	if stats.Rows != 10 {
+		t.Errorf("Rows = %d, want 10", stats.Rows)
+	}
+	if stats.Cols != 8960 {
+		t.Errorf("Cols = %d, want 8960", stats.Cols)
+	}
+	if stats.P50 != 5 {
+		t.Errorf("P50 = %v, want 5", stats.P50)
+	}
+	if stats.P95 != 10 {
+		t.Errorf("P95 = %v, want 10", stats.P95)
+	}
+	if stats.P99 != 10 {
+		t.Errorf("P99 = %v, want 10", stats.P99)
+	}
+	if stats.P100 != 10 {
+		t.Errorf("P100 = %v, want 10", stats.P100)
+	}
+	// Top 3 by L2 descending: values 10, 9, 8 at original rows 0, 4, 7.
+	wantTop := []rowDiff{{0, 10}, {4, 9}, {7, 8}}
+	if len(stats.TopK) != len(wantTop) {
+		t.Fatalf("len(TopK) = %d, want %d", len(stats.TopK), len(wantTop))
+	}
+	for i, rd := range stats.TopK {
+		if rd.Row != wantTop[i].Row || rd.L2 != wantTop[i].L2 {
+			t.Errorf("TopK[%d] = {row=%d, L2=%v}, want {row=%d, L2=%v}",
+				i, rd.Row, rd.L2, wantTop[i].Row, wantTop[i].L2)
+		}
+	}
+}
+
+func TestSummarizeRowL2_TopKClampedToLength(t *testing.T) {
+	// Request 50 rows but only 3 are present -- must return exactly 3.
+	stats := summarizeRowL2([]float32{0.5, 2.0, 1.0}, 4, 50)
+	if len(stats.TopK) != 3 {
+		t.Fatalf("len(TopK) = %d, want 3", len(stats.TopK))
+	}
+	wantOrder := []int{1, 2, 0} // L2=2.0, 1.0, 0.5
+	for i, rd := range stats.TopK {
+		if rd.Row != wantOrder[i] {
+			t.Errorf("TopK[%d].Row = %d, want %d", i, rd.Row, wantOrder[i])
+		}
+	}
+}
+
+func TestSummarizeRowL2_ZeroTopK(t *testing.T) {
+	stats := summarizeRowL2([]float32{1, 2, 3, 4, 5}, 2, 0)
+	if stats.TopK != nil && len(stats.TopK) != 0 {
+		t.Errorf("TopK must be empty when topK=0, got %v", stats.TopK)
+	}
+	if stats.P100 != 5 {
+		t.Errorf("P100 = %v, want 5", stats.P100)
+	}
+}
+
+func TestSummarizeRowL2_TiedL2SortsByRow(t *testing.T) {
+	// Two rows share the same max L2 -- the smaller row index must come first.
+	stats := summarizeRowL2([]float32{2, 2, 1}, 1, 2)
+	if len(stats.TopK) != 2 {
+		t.Fatalf("len(TopK) = %d, want 2", len(stats.TopK))
+	}
+	if stats.TopK[0].Row != 0 || stats.TopK[1].Row != 1 {
+		t.Errorf("tie-break wrong: got rows %d, %d; want 0, 1",
+			stats.TopK[0].Row, stats.TopK[1].Row)
+	}
+}
+
+func TestSummarizeRowL2_EmptyInput(t *testing.T) {
+	stats := summarizeRowL2(nil, 4, 10)
+	if stats.Rows != 0 || stats.P100 != 0 || len(stats.TopK) != 0 {
+		t.Errorf("empty summary mishandled: %+v", stats)
+	}
+}
+
+func TestWriteRowDiffReport_ContainsExpectedFields(t *testing.T) {
+	stats := summarizeRowL2([]float32{0.1, 0.3, 0.2}, 8960, 2)
+	stats.Scoped = true
+	var buf bytes.Buffer
+	writeRowDiffReport(&buf, "q4_vs_q8", stats)
+	out := buf.String()
+
+	for _, want := range []string{
+		"q4_vs_q8",
+		"rows=3",
+		"cols=8960",
+		"scoped=true",
+		"p50=",
+		"p95=",
+		"p99=",
+		"p100=",
+		"top[01]",
+		"top[02]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q; full output:\n%s", want, out)
+		}
+	}
+	// Top entries must list row indices of the two largest values: row 1 (0.3) then row 2 (0.2).
+	if !strings.Contains(out, "row=1") || !strings.Contains(out, "row=2") {
+		t.Errorf("top rows missing from output:\n%s", out)
+	}
+}

--- a/inference/arch_gemma4_test.go
+++ b/inference/arch_gemma4_test.go
@@ -1104,10 +1104,10 @@ func TestPLECombinedProducer_DecodeFastPathSharesBackingStorage(t *testing.T) {
 	}
 }
 
-// TestPLESliceNode_ZeroAblation validates the T99.2.2 H16 ablation gate:
-// when ZERFOO_GEMMA4_PLE_ZERO=1 is set at graph build time, pleSliceNode.Forward
-// returns an all-zero tensor of the same shape as the normal path. Without the
-// env var, the output is non-zero for non-zero inputs.
+// TestPLESliceNode_ZeroAblation validates the T99.2.2 H16 / H19 ablation gates:
+// ZERFOO_GEMMA4_PLE_ZERO=1/both zero the entire PLE output; =token zeros only
+// the tokenSlice contribution; =proj zeros only the projNormed contribution.
+// Unset keeps the normal path.
 func TestPLESliceNode_ZeroAblation(t *testing.T) {
 	const (
 		numLayers = 2
@@ -1139,14 +1139,11 @@ func TestPLESliceNode_ZeroAblation(t *testing.T) {
 	pleModelProj := fill([]int{hidden, totalPLE}, 2.0)
 	normGain := fill([]int{pleDim}, 1.0)
 
-	runForward := func(zeroEnv string) []float32 {
+	// runForward rebuilds the pleSliceNode after setting the env var so the
+	// constructor re-reads ZERFOO_GEMMA4_PLE_ZERO under the current subtest.
+	runForward := func(t *testing.T, zeroEnv string) []float32 {
 		t.Helper()
-		if zeroEnv != "" {
-			t.Setenv("ZERFOO_GEMMA4_PLE_ZERO", zeroEnv)
-		} else {
-			// Clear the env var so the "off" branch is exercised.
-			t.Setenv("ZERFOO_GEMMA4_PLE_ZERO", "")
-		}
+		t.Setenv("ZERFOO_GEMMA4_PLE_ZERO", zeroEnv)
 		producer, err := newPLECombinedProducer[float32](engine, pleEmbed, pleModelProj, numLayers, pleDim, hidden)
 		if err != nil {
 			t.Fatalf("newPLECombinedProducer: %v", err)
@@ -1178,24 +1175,82 @@ func TestPLESliceNode_ZeroAblation(t *testing.T) {
 		return append([]float32(nil), out.Data()...)
 	}
 
-	// Off: output must contain at least one non-zero value.
-	off := runForward("")
-	anyNonZero := false
-	for _, v := range off {
-		if v != 0 {
-			anyNonZero = true
-			break
+	maxAbs := func(vs []float32) float32 {
+		var m float32
+		for _, v := range vs {
+			if v < 0 {
+				v = -v
+			}
+			if v > m {
+				m = v
+			}
 		}
+		return m
 	}
-	if !anyNonZero {
-		t.Fatalf("off path produced all-zero output; test fixture cannot discriminate ablation")
+	allZero := func(vs []float32) bool { return maxAbs(vs) == 0 }
+	differs := func(a, b []float32) bool {
+		if len(a) != len(b) {
+			return true
+		}
+		for i := range a {
+			d := a[i] - b[i]
+			if d < 0 {
+				d = -d
+			}
+			if d > 1e-6 {
+				return true
+			}
+		}
+		return false
 	}
 
-	// On: output must be exactly zero element-wise.
-	on := runForward("1")
-	for i, v := range on {
-		if v != 0 {
-			t.Fatalf("ZERFOO_GEMMA4_PLE_ZERO=1 output[%d] = %v, want 0", i, v)
+	// Capture each mode in its own subtest so t.Setenv scoping rebuilds the
+	// node against a fresh env var each time.
+	var baseline, tokenOnly []float32
+
+	t.Run("unset", func(t *testing.T) {
+		baseline = runForward(t, "")
+		if allZero(baseline) {
+			t.Fatalf("baseline all-zero; fixture cannot discriminate ablations")
 		}
-	}
+	})
+
+	t.Run("one", func(t *testing.T) {
+		// Regression guard for the H16 artifact (commit cca5ea3b): "1"
+		// must zero the entire PLE output, byte-for-byte identical to "both".
+		got := runForward(t, "1")
+		if !allZero(got) {
+			t.Fatalf("ZERFOO_GEMMA4_PLE_ZERO=1 max|out| = %v, want 0", maxAbs(got))
+		}
+	})
+
+	t.Run("both", func(t *testing.T) {
+		got := runForward(t, "both")
+		if !allZero(got) {
+			t.Fatalf("ZERFOO_GEMMA4_PLE_ZERO=both max|out| = %v, want 0", maxAbs(got))
+		}
+	})
+
+	t.Run("token", func(t *testing.T) {
+		tokenOnly = runForward(t, "token")
+		if allZero(tokenOnly) {
+			t.Fatalf("token mode produced all-zero output; expected projNormed contribution to remain")
+		}
+		if !differs(tokenOnly, baseline) {
+			t.Fatalf("token mode output equals baseline; tokenSlice suppression not observable")
+		}
+	})
+
+	t.Run("proj", func(t *testing.T) {
+		projOnly := runForward(t, "proj")
+		if allZero(projOnly) {
+			t.Fatalf("proj mode produced all-zero output; expected tokenSlice contribution to remain")
+		}
+		if !differs(projOnly, baseline) {
+			t.Fatalf("proj mode output equals baseline; projNormed suppression not observable")
+		}
+		if !differs(projOnly, tokenOnly) {
+			t.Fatalf("proj output equals token output; modes are not independently discriminating")
+		}
+	})
 }

--- a/inference/gemma4_edge_ple_nodes.go
+++ b/inference/gemma4_edge_ple_nodes.go
@@ -520,6 +520,35 @@ func (p *pleCombinedProducer[T]) Backward(_ context.Context, _ types.BackwardMod
 	return nil, nil
 }
 
+// pleZeroMode selects which portion of the PLE slice path to zero at graph
+// build time. See ZERFOO_GEMMA4_PLE_ZERO parsing in newPLESliceNode for the
+// accepted string values.
+type pleZeroMode int
+
+const (
+	pleZeroNone  pleZeroMode = iota // no ablation
+	pleZeroBoth                     // zero final scaled output (legacy "1" / "both")
+	pleZeroToken                    // zero only the tokenSlice contribution
+	pleZeroProj                     // zero only the projNormed contribution
+)
+
+// parsePLEZeroMode maps the raw ZERFOO_GEMMA4_PLE_ZERO env value to a mode.
+// "1" and "both" map to pleZeroBoth (preserves the H16 artifact). "token" and
+// "proj" select granular ablations for T99.2.2 H19 discrimination. Anything
+// else (including unset / empty) is pleZeroNone.
+func parsePLEZeroMode(raw string) pleZeroMode {
+	switch raw {
+	case "1", "both":
+		return pleZeroBoth
+	case "token":
+		return pleZeroToken
+	case "proj":
+		return pleZeroProj
+	default:
+		return pleZeroNone
+	}
+}
+
 // pleSliceNode extracts the per-layer [B, S, pleDim] slice from the producer's
 // cached full-width tensors, applies the shared per-layer projection RMSNorm
 // to the projection slice, adds the token-identity PLE slice, and scales by
@@ -532,10 +561,10 @@ type pleSliceNode[T tensor.Numeric] struct {
 	layerIdx  int
 	pleDim    int
 	numLayers int
-	// zeroOut is set when ZERFOO_GEMMA4_PLE_ZERO=1 at graph build time.
-	// T99.2.2 H16 ablation: zeroing per_layer_inputs[i] for every layer
-	// isolates whether the PLE branch is on the bug vector path.
-	zeroOut bool
+	// zeroMode is set from ZERFOO_GEMMA4_PLE_ZERO at graph build time.
+	// T99.2.2 H16 / H19 ablation: isolates whether the PLE branch, its
+	// tokenSlice sub-path, or its projNormed sub-path is on the bug vector.
+	zeroMode pleZeroMode
 }
 
 func newPLESliceNode[T tensor.Numeric](
@@ -574,7 +603,7 @@ func newPLESliceNode[T tensor.Numeric](
 		layerIdx:  layerIdx,
 		pleDim:    producer.pleDim,
 		numLayers: producer.numLayers,
-		zeroOut:   os.Getenv("ZERFOO_GEMMA4_PLE_ZERO") == "1",
+		zeroMode:  parsePLEZeroMode(os.Getenv("ZERFOO_GEMMA4_PLE_ZERO")),
 	}, nil
 }
 
@@ -619,6 +648,24 @@ func (n *pleSliceNode[T]) Forward(ctx context.Context, _ ...*tensor.TensorNumeri
 	if err != nil {
 		return nil, fmt.Errorf("pleSliceNode(layer=%d): rmsnorm: %w", n.layerIdx, err)
 	}
+	// T99.2.2 H19 ablation: suppress only the target sub-path BEFORE the
+	// combine, so "token" and "proj" are truly independent. Producer cache
+	// tensors must not be mutated -- allocate zeroed replacements via
+	// MulScalar and substitute them into the local variables.
+	switch n.zeroMode {
+	case pleZeroToken:
+		zeroedToken, err := n.engine.MulScalar(ctx, tokenSlice, T(0))
+		if err != nil {
+			return nil, fmt.Errorf("pleSliceNode(layer=%d): zero token: %w", n.layerIdx, err)
+		}
+		tokenSlice = zeroedToken
+	case pleZeroProj:
+		zeroedProj, err := n.engine.MulScalar(ctx, projNormed, T(0))
+		if err != nil {
+			return nil, fmt.Errorf("pleSliceNode(layer=%d): zero proj: %w", n.layerIdx, err)
+		}
+		projNormed = zeroedProj
+	}
 	combined, err := n.engine.Add(ctx, projNormed, tokenSlice)
 	if err != nil {
 		return nil, fmt.Errorf("pleSliceNode(layer=%d): add: %w", n.layerIdx, err)
@@ -629,11 +676,12 @@ func (n *pleSliceNode[T]) Forward(ctx context.Context, _ ...*tensor.TensorNumeri
 	if err != nil {
 		return nil, fmt.Errorf("pleSliceNode(layer=%d): scale: %w", n.layerIdx, err)
 	}
-	// T99.2.2 H16 ablation: when ZERFOO_GEMMA4_PLE_ZERO=1, zero the
+	// T99.2.2 H16 ablation: when ZERFOO_GEMMA4_PLE_ZERO=1/both, zero the
 	// per-layer PLE contribution. Preserves shape and storage so the
 	// downstream graph runs unmodified; if the decode output stays
-	// degenerate, the PLE branch is not the bug vector.
-	if n.zeroOut {
+	// degenerate, the PLE branch is not the bug vector. Kept as a post-scale
+	// zero so the legacy "1" artifact (commit cca5ea3b) is bit-identical.
+	if n.zeroMode == pleZeroBoth {
 		zeroed, err := n.engine.MulScalar(ctx, scaled, T(0))
 		if err != nil {
 			return nil, fmt.Errorf("pleSliceNode(layer=%d): zero ablation: %w", n.layerIdx, err)


### PR DESCRIPTION
## Summary

Wave 1 of T99.2.2 next-session plan — instruments for discriminating the
gemma4e Q4_K_M decode degeneracy bug. Two independent diagnostic tools
land here; no inference-path behaviour changes unless the env var is set.

### T99.2.2.1 — Granular PLE ablation modes (commit 4201a23a)

`ZERFOO_GEMMA4_PLE_ZERO` now accepts:
- `1` or `both` — zero the combined per-layer PLE output (preserves H16
  artifact verbatim; still produces the `"PM Transport Ken…"` multilingual
  noise on Q4_K_M).
- `token` — zero only the tokenSlice contribution (projNormed stays live).
- `proj` — zero only the projNormed contribution (tokenSlice stays live).
- unset / other — no ablation (default behaviour).

Sub-path zeroing happens BEFORE the combine, with zeroed replacement
tensors allocated via `engine.MulScalar(..., T(0))` so the producer's
stable cache is never mutated. Tests cover all five modes.

### T99.2.2.2 — ple-embed-diff H17 diagnostic (commit d9e2d676)

New `-mode ple-embed-diff` in `cmd/gemma4_e2e/`. Loads
`model.ple_embed_tokens.weight` from a Q4_K_M and a Q8_0 GGUF,
dequantizes via `tensor.Data()`, computes per-row L2 norm of the
difference, and prints p50/p95/p99/p100 plus the top-20 worst rows.
Flag `-ple-max-rows` caps the compared row count for the scoped-run
fallback under R99.2.2.A.

## Validation

- `go build ./...` clean on wave-1-integration.
- `go test -race -timeout 180s ./inference/ ./cmd/gemma4_e2e/` PASS
  (56.77s + 1.63s).
- Merge protocol: both branches merged via --no-ff, `git cherry` empty
  for both (no lost patches).

## Next (queued, not in this PR)

- T99.2.2.3 / T99.2.2.4: DGX executions using both tools (Wave 2).
- T99.2.2.5: synthesise H20 fix candidate (Wave 3).

## Linked tasks

- docs/plan.md T99.2.2.1 (granular modes)
- docs/plan.md T99.2.2.2 (H17 diagnostic)