### PR TITLE
T99.2.2 Wave 2+3: H19 split ablations + H17 L2 diagnostic results; H20 proposed

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,100 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-04-21: T99.2.2 -- H19 split + H17 L2 diagnostic -> H20 fix candidate
+
+**Type:** investigation
+**Tags:** gemma4e, decode, q4_k, ple, pleSliceNode, h17, h19, h20
+
+### Wave 2 runs (DGX, main tip `b14c3075`, Q4_K_M GGUF, CPU, -mmap=false)
+
+#### T99.2.2.3 H19 split ablations (`-mode generate -steps 32 -prompt "The quick brown fox"`)
+
+| `ZERFOO_GEMMA4_PLE_ZERO` | Decode   | Output (first line) |
+|---|---|---|
+| (unset, baseline)        | 3.27 t/s | `"lyes\nsn\nsn\nsn\nsn"`                           |
+| `token` (zero tokenSlice, proj stays active) | 2.48 t/s | `"**************\n**\n**\n**\n**\n**\n**\n**"` |
+| `proj`  (zero projNormed, token stays active) | 2.65 t/s | `"ichloro▁kangarooလျှ▁Datashexa▁Fre…"` multilingual |
+| `both`  (zero both, regression guard) | 2.50 t/s | `"▁PM▁Transport🇱▁KenЛSm…"` (matches H16 artifact exactly) |
+
+Interpretation.
+- Neither sub-path alone restores coherence; each produces a *different*
+  degenerate output. The Q4 MatMul on `ple_model_proj.weight` drives a
+  short punctuation loop; the Q4 Gather on `ple_embed_tokens.weight`
+  drives multilingual noise. Both sub-paths carry bad values.
+- `both` reproduces the H16 multilingual-noise artifact byte-exactly —
+  `parsePLEZeroMode` regression guard PASSES.
+
+#### T99.2.2.4 H17 ple_embed_tokens.weight Q4 vs Q8 L2 diff (`-mode ple-embed-diff`)
+
+Tensor: `model.ple_embed_tokens.weight` shape `[262144, 8960]`,
+rows=262144, cols=8960, scoped=false.
+
+| Stat | L2   |
+|------|------|
+| p50  |  9.96 |
+| p95  | 10.57 |
+| p99  | 10.98 |
+| p100 | 14.82 |
+
+Top-20 worst rows (row, L2): `236743 14.82`, `236764 13.73`, `236761 13.34`,
+`236772 13.32`, `506 13.29`, `108 13.26`, `236770 12.91`, `236810 12.88`,
+`107 12.88`, `496 12.74`, `236771 12.69`, `532 12.64`, `529 12.58`,
+`236778 12.56`, `236800 12.54`, `0 12.51`, `236900 12.50`, `236919 12.47`,
+`236951 12.46`, `236825 12.44`.
+
+Interpretation.
+- The L2 distribution is tight: p100/p50 = 1.49x, p99/p50 = 1.10x.
+  There is no anomalously-quantized row carrying a disproportionate share
+  of the quantization error. Per-element RMS = L2 / sqrt(8960) ~ 0.10.
+- The worst-row indices concentrate in a narrow high-vocab band
+  (236743-236951, "extra-token" region) and a small low-index pocket
+  (0, 107-108, 496-532). These are added/special tokens whose rows are
+  likely sparser and therefore harder to quantize cleanly, but the
+  absolute error is still only ~1.5x median.
+- **H17 refuted as "bug-carrying row".** The Q4 Gather on large tables
+  does NOT emit a single catastrophic row; it emits uniformly-noisy rows.
+  Combining with H19, neither Q4 gather nor Q4 matmul alone is "the"
+  bug carrier — both contribute small uniform noise that cumulatively
+  poisons the residual stream.
+
+### H20 (proposed, 2026-04-21 post-H17/H19)
+
+Candidate locus: `pleSliceNode.Forward` in `inference/gemma4_edge_ple_nodes.go`,
+specifically the composition of the Q4-gathered `tokenSlice` with the
+Q4-matmul'd-and-RMSNormed `projNormed` via `Add` + `MulScalar(1/sqrt(2))`.
+
+**Mechanism.** HF `Gemma4TextModel.project_per_layer_inputs` does:
+```
+token_pe = per_layer_embed(ids) * sqrt(hidden_per_layer)   # token slice, unnormed
+proj     = rmsnorm(per_layer_proj(embeds * hidden**-0.5))  # normed
+out      = (proj + token_pe) * 1/sqrt(2)                   # combine
+```
+Only `proj` is RMSNormed. `token_pe` rides in raw. Q4 gather noise on
+`ple_embed_tokens.weight` (~0.10 per-element RMS) therefore propagates
+directly into `out` with only a 1/sqrt(2) attenuation, then gets injected
+into every decoder layer as `per_layer_input[i]` via gate+scale and added
+to the residual. Over 35 layers this small-but-persistent noise accumulates.
+
+**DISC test that would refute H20.** Add per-layer RMSNorm to the
+tokenSlice as well (even though HF does not), then run the same Q4_K_M
+generate. If output remains degenerate, H20 is refuted and we pivot to
+H18 (CompileTraced plan-order) or to the non-PLE residual path. If
+output becomes coherent English, H20 is the fix direction and T99.2.2.6
+becomes "apply upstream bias-correction / pre-dequant cast to F16
+before the Q4 gather, then re-benchmark."
+
+**Alternative H20 variant.** Instead of normalising tokenSlice, upgrade
+`ple_embed_tokens.weight` to Q8 at load (H12 tried this and it was
+refuted, but with `ple_model_proj.weight` still at Q4 — revisit jointly).
+
+### Plan update
+
+T99.2.2.3 and T99.2.2.4 complete. T99.2.2.5 is this devlog entry plus
+the T99.2.2.6 task that it files.
+
+---
+
 ## 2026-04-21: T99.2.2 -- H16 CONFIRMED (PLE branch is on the bug vector)
 
 **Type:** investigation

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1950,7 +1950,7 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
   candidate. Prereqs met: H16 confirmed PLE involvement; DGX binary
   built from `cca5ea3b`; Q4_K_M and Q8_0 GGUFs present on DGX.
 
-  - [ ] T99.2.2.1 Extend ZERFOO_GEMMA4_PLE_ZERO to granular modes
+  - [x] T99.2.2.1 Extend ZERFOO_GEMMA4_PLE_ZERO to granular modes (DONE 2026-04-21, commit 30a34cbb via PR #492)
     Owner: TBD  Est: 45m  verifies: [UC-001]  Deps: none
     Change the env var in `inference/gemma4_edge_ple_nodes.go` to
     accept three values beyond "1" (zero all): "token" (zero only
@@ -1962,7 +1962,7 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
     modes; each must produce a non-zero output that is not the same
     as the other. Tier 0/1 run. Commit and push.
 
-  - [ ] T99.2.2.2 H17 diagnostic: dequantize + diff ple_embed_tokens.weight
+  - [x] T99.2.2.2 H17 diagnostic: dequantize + diff ple_embed_tokens.weight (DONE 2026-04-21, commit b14c3075 via PR #492)
     Owner: TBD  Est: 90m  verifies: [UC-001]  Deps: none (can run
     in parallel with T99.2.2.1)
     Write a diagnostic test or `-mode ple-embed-diff` in
@@ -1977,7 +1977,7 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
     all 262144 rows visually; emit statistics only (p50, p95, p99,
     p100, worst 20 rows by index and L2). Commit and push.
 
-  - [ ] T99.2.2.3 Run H19 split ablations on DGX
+  - [x] T99.2.2.3 Run H19 split ablations on DGX (DONE 2026-04-21, results in devlog 2026-04-21 entry)
     Owner: TBD  Est: 30m  verifies: [UC-001]  Deps: T99.2.2.1
     Pull and rebuild on DGX. For each of mode=`token`, mode=`proj`,
     mode=`both`, run `gemma4_e2e -mode generate` on Q4_K_M (CPU,
@@ -1998,7 +1998,7 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
       is distributed across both paths.
     Append the result to `docs/devlog.md`.
 
-  - [ ] T99.2.2.4 Run H17 ple_embed diagnostic on DGX
+  - [x] T99.2.2.4 Run H17 ple_embed diagnostic on DGX (DONE 2026-04-21, results in devlog 2026-04-21 entry)
     Owner: TBD  Est: 20m  verifies: [UC-001]  Deps: T99.2.2.2
     Pull and rebuild on DGX. Run the diagnostic from T99.2.2.2 on
     the two GGUFs. Record the L2 summary (p50/p95/p99/p100 and
@@ -2009,7 +2009,7 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
     `docs/devlog.md`. If top-error rows align with emitted tokens,
     the Q4 gather on large tables is directly implicated.
 
-  - [ ] T99.2.2.5 Analyze + propose fix candidate
+  - [x] T99.2.2.5 Analyze + propose fix candidate (DONE 2026-04-21, devlog "T99.2.2 H19 split + H17 L2 diagnostic -> H20 fix candidate")
     Owner: TBD  Est: 45m  verifies: [UC-001]  Deps: T99.2.2.3,
     T99.2.2.4
     Combine the H19 split and H17 diagnostic findings. Write a
@@ -2021,6 +2021,27 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
     a T99.2.2.6 as a new task implementing the H20 candidate.
     Refresh `.claude-checkpoint.md`.
 
+  - [ ] T99.2.2.6 H20 fix candidate: RMSNorm the tokenSlice path
+    Owner: TBD  Est: 90m  verifies: [UC-001]  Deps: T99.2.2.5
+    Bug locus (from H19 split + H17 L2): Q4 gather on
+    `ple_embed_tokens.weight` (262144x8960) and Q4 matmul on
+    `ple_model_proj.weight` both contribute small uniform noise
+    (~0.10 per-element RMS) that cumulatively poisons the residual
+    stream over 35 layers. Only `projNormed` is RMSNormed today;
+    `tokenSlice` rides in raw.
+    Fix: in `pleSliceNode.Forward` (`inference/gemma4_edge_ple_nodes.go`),
+    apply a new per-layer `ple_token_norm` RMSNorm (shape `[256]`,
+    gain init 1.0, frozen at graph build) to `tokenSlice` before
+    the `Add(projNormed, tokenSlice)` combine. Behind
+    `ZERFOO_GEMMA4_PLE_TOKEN_NORM=1` so we can A/B it. Tests add a
+    case that verifies the normed path produces a bounded output
+    whose max-abs is strictly smaller than the raw-token baseline.
+    DGX run: compare Q4_K_M generate with flag=on vs baseline; coherent
+    English (or at least non-multilingual non-punctuation-loop output)
+    confirms H20. If still degenerate, refute H20 and file T99.2.2.7
+    to revisit H12 + H20 jointly (upgrade both PLE tensors to Q8
+    together, measure).
+
 ### T99.2.2 Next-Session Waves
 
 Wave 1 runs two independent diagnostics in parallel; Wave 2 runs the
@@ -2028,19 +2049,23 @@ DGX executions (serialised on the single DGX, but each run is short);
 Wave 3 is a single synthesis task. Total wall time estimate 4.0h
 assuming no surprises.
 
-#### Wave 1: Instrument (2 agents)
+#### Wave 1: Instrument (2 agents) -- DONE 2026-04-21 via PR #492
 
-- [ ] T99.2.2.1 Extend ZERFOO_GEMMA4_PLE_ZERO to granular modes
-- [ ] T99.2.2.2 H17 diagnostic: dequantize + diff ple_embed_tokens.weight
+- [x] T99.2.2.1 Extend ZERFOO_GEMMA4_PLE_ZERO to granular modes
+- [x] T99.2.2.2 H17 diagnostic: dequantize + diff ple_embed_tokens.weight
 
-#### Wave 2: DGX execution (2 agents, serialised on DGX)
+#### Wave 2: DGX execution (2 agents, serialised on DGX) -- DONE 2026-04-21
 
-- [ ] T99.2.2.3 Run H19 split ablations on DGX
-- [ ] T99.2.2.4 Run H17 ple_embed diagnostic on DGX
+- [x] T99.2.2.3 Run H19 split ablations on DGX
+- [x] T99.2.2.4 Run H17 ple_embed diagnostic on DGX
 
-#### Wave 3: Synthesise (1 agent)
+#### Wave 3: Synthesise (1 agent) -- DONE 2026-04-21
 
-- [ ] T99.2.2.5 Analyze + propose fix candidate
+- [x] T99.2.2.5 Analyze + propose fix candidate
+
+#### Wave 4 (queued): H20 implementation (1 agent)
+
+- [ ] T99.2.2.6 H20 fix candidate: RMSNorm the tokenSlice path
 
 ### E98 Risk Register
 


### PR DESCRIPTION
## Summary

Wave 2 + 3 of T99.2.2 investigation. Documentation-only; no code change.

### T99.2.2.3 H19 split ablations (DGX, main tip b14c3075)

| `ZERFOO_GEMMA4_PLE_ZERO` | Output (first line) |
|---|---|
| (baseline) | `\"lyes\\nsn\\nsn\\n...\"` |
| `token`    | `\"**************\\n**\\n**\\n...\"` punctuation loop |
| `proj`     | `\"ichloro▁kangaroo...\"` multilingual noise |
| `both`     | `\"▁PM▁Transport🇱▁Ken...\"` (matches H16 exactly, regression guard ✓) |

Neither sub-path alone restores coherence. Both carry bad values.

### T99.2.2.4 H17 Q4 vs Q8 L2 diff on ple_embed_tokens.weight

L2 distribution is tight: p50=9.96, p95=10.57, p99=10.98, p100=14.82
(p100/p50 = 1.49x). No outlier row. Worst-row band concentrates in
extra-token indices 236743-236951. Q4 gather noise is uniform, not
catastrophic on any single row.

### T99.2.2.5 Synthesis — H20 proposed

Bug locus: `pleSliceNode.Forward` in
`inference/gemma4_edge_ple_nodes.go`. Only `projNormed` is RMSNormed
today; `tokenSlice` rides raw. Q4 gather noise (~0.10 per-element
RMS) propagates straight into every decoder layer's `per_layer_input`
and accumulates across 35 layers.

H20 fix direction: apply a per-layer RMSNorm to `tokenSlice` before
the Add-combine, gated behind `ZERFOO_GEMMA4_PLE_TOKEN_NORM=1` for
A/B. T99.2.2.6 files the implementation task.

## Validation

- Docs-only; no build/test changes.
- `code-review-graph detect-changes`: risk 0.40 (pre-existing gaps
  for `main`/`runForward` not introduced here).

## Checklist

- [x] T99.2.2.3 complete (devlog)
- [x] T99.2.2.4 complete (devlog)
- [x] T99.2.2.5 complete (devlog + T99.2.2.6 queued in plan.md)
- [ ] T99.2.2.6 H20 implementation (next session)