### PR TITLE
feat(inference): T99.2.2.6 H20 -- RMSNorm tokenSlice in pleSliceNode

### DIFF
--- a/inference/arch_gemma4_test.go
+++ b/inference/arch_gemma4_test.go
@@ -1254,3 +1254,164 @@ func TestPLESliceNode_ZeroAblation(t *testing.T) {
 		}
 	})
 }
+
+// TestPLESliceNode_TokenNormAblation validates the T99.2.2 H20 fix candidate:
+// ZERFOO_GEMMA4_PLE_TOKEN_NORM=1 inserts a per-layer RMSNorm on tokenSlice
+// before the Add(projNormed, tokenSlice) combine. The normed path must:
+//  1. Still produce a non-zero output (contract: normalization, not zeroing).
+//  2. Differ from the baseline (observable behavior change).
+//  3. Produce a strictly smaller max-abs output than the raw-token baseline
+//     for a fixture whose token-identity contribution dominates, confirming
+//     the RMSNorm is bounding the tokenSlice magnitude.
+func TestPLESliceNode_TokenNormAblation(t *testing.T) {
+	const (
+		numLayers = 2
+		pleDim    = 4
+		hidden    = 8
+		vocab     = 16
+	)
+	totalPLE := numLayers * pleDim
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	ops := numeric.Float32Ops{}
+
+	fill := func(shape []int, seed float32) *tensor.TensorNumeric[float32] {
+		n := 1
+		for _, d := range shape {
+			n *= d
+		}
+		data := make([]float32, n)
+		for i := range data {
+			data[i] = seed + 0.01*float32(i)
+		}
+		tn, err := tensor.New[float32](shape, data)
+		if err != nil {
+			t.Fatalf("tensor.New %v: %v", shape, err)
+		}
+		return tn
+	}
+
+	// Amplify the tokenSlice contribution (seed=10) so its max-abs dominates
+	// projNormed (whose magnitude is bounded by the existing RMSNorm). This
+	// makes the H20 bound observable: enabling ple_token_norm should cut the
+	// output max-abs significantly.
+	pleEmbed := fill([]int{vocab, totalPLE}, 10.0)
+	pleModelProj := fill([]int{hidden, totalPLE}, 0.1)
+	normGain := fill([]int{pleDim}, 1.0)
+
+	runForward := func(t *testing.T, tokenNormEnv string) []float32 {
+		t.Helper()
+		// Keep the H19 env unset so both runs share the same ablation state.
+		t.Setenv("ZERFOO_GEMMA4_PLE_ZERO", "")
+		t.Setenv("ZERFOO_GEMMA4_PLE_TOKEN_NORM", tokenNormEnv)
+		producer, err := newPLECombinedProducer[float32](engine, pleEmbed, pleModelProj, numLayers, pleDim, hidden)
+		if err != nil {
+			t.Fatalf("newPLECombinedProducer: %v", err)
+		}
+		ids := fill([]int{1, 1}, 0.0)
+		ids.Data()[0] = 3
+		hiddenIn := fill([]int{1, 1, hidden}, 0.5)
+		if _, err := producer.Forward(context.Background(), ids, hiddenIn); err != nil {
+			t.Fatalf("producer Forward: %v", err)
+		}
+		node, err := newPLESliceNode[float32](engine, ops, producer, normGain, 1e-6, 0)
+		if err != nil {
+			t.Fatalf("newPLESliceNode: %v", err)
+		}
+		out, err := node.Forward(context.Background())
+		if err != nil {
+			t.Fatalf("pleSliceNode Forward: %v", err)
+		}
+		return append([]float32(nil), out.Data()...)
+	}
+
+	maxAbs := func(vs []float32) float32 {
+		var m float32
+		for _, v := range vs {
+			if v < 0 {
+				v = -v
+			}
+			if v > m {
+				m = v
+			}
+		}
+		return m
+	}
+
+	var baseline, normed []float32
+
+	t.Run("baseline_unset", func(t *testing.T) {
+		baseline = runForward(t, "")
+		if maxAbs(baseline) == 0 {
+			t.Fatalf("baseline all-zero; fixture cannot discriminate")
+		}
+	})
+
+	t.Run("token_norm_enabled", func(t *testing.T) {
+		normed = runForward(t, "1")
+		if maxAbs(normed) == 0 {
+			t.Fatalf("token-norm output all-zero; expected bounded non-zero value")
+		}
+		if len(normed) != len(baseline) {
+			t.Fatalf("output length %d != baseline %d", len(normed), len(baseline))
+		}
+		differs := false
+		for i := range normed {
+			d := normed[i] - baseline[i]
+			if d < 0 {
+				d = -d
+			}
+			if d > 1e-6 {
+				differs = true
+				break
+			}
+		}
+		if !differs {
+			t.Fatalf("token-norm output equals baseline; ple_token_norm had no effect")
+		}
+		if maxAbs(normed) >= maxAbs(baseline) {
+			t.Fatalf("token-norm max|out|=%v, want strictly < baseline %v (RMSNorm should bound tokenSlice magnitude)",
+				maxAbs(normed), maxAbs(baseline))
+		}
+	})
+
+	t.Run("frozen_registered", func(t *testing.T) {
+		t.Setenv("ZERFOO_GEMMA4_PLE_ZERO", "")
+		t.Setenv("ZERFOO_GEMMA4_PLE_TOKEN_NORM", "1")
+		producer, err := newPLECombinedProducer[float32](engine, pleEmbed, pleModelProj, numLayers, pleDim, hidden)
+		if err != nil {
+			t.Fatalf("newPLECombinedProducer: %v", err)
+		}
+		node, err := newPLESliceNode[float32](engine, ops, producer, normGain, 1e-6, 0)
+		if err != nil {
+			t.Fatalf("newPLESliceNode: %v", err)
+		}
+		frozen := node.EmbeddedFrozen()
+		if len(frozen) < 2 {
+			t.Fatalf("EmbeddedFrozen returned %d tensors, want >= 2 (proj_norm + token_norm gains)", len(frozen))
+		}
+		// At least one frozen tensor must be [pleDim]-shaped and all-ones
+		// (the freshly initialized ple_token_norm gain).
+		foundOnes := false
+		for _, f := range frozen {
+			s := f.Shape()
+			if len(s) != 1 || s[0] != pleDim {
+				continue
+			}
+			d := f.Data()
+			allOne := true
+			for _, v := range d {
+				if v != 1.0 {
+					allOne = false
+					break
+				}
+			}
+			if allOne {
+				foundOnes = true
+				break
+			}
+		}
+		if !foundOnes {
+			t.Fatalf("EmbeddedFrozen did not include an all-ones [%d] gain tensor for ple_token_norm", pleDim)
+		}
+	})
+}

--- a/inference/gemma4_edge_ple_nodes.go
+++ b/inference/gemma4_edge_ple_nodes.go
@@ -558,9 +558,16 @@ type pleSliceNode[T tensor.Numeric] struct {
 	engine    compute.Engine[T]
 	producer  *pleCombinedProducer[T]
 	normLayer *normalization.RMSNorm[T] // shared per-layer projection norm
-	layerIdx  int
-	pleDim    int
-	numLayers int
+	// tokenNormLayer is the T99.2.2 H20 fix candidate: a per-layer RMSNorm
+	// applied to tokenSlice before the Add(projNormed, tokenSlice) combine,
+	// so the Q4-gather noise on `ple_embed_tokens.weight` cannot compound
+	// across 35 layers. Nil when ZERFOO_GEMMA4_PLE_TOKEN_NORM is unset
+	// (baseline). Gain is freshly allocated with init 1.0 and frozen at
+	// graph build.
+	tokenNormLayer *normalization.RMSNorm[T]
+	layerIdx       int
+	pleDim         int
+	numLayers      int
 	// zeroMode is set from ZERFOO_GEMMA4_PLE_ZERO at graph build time.
 	// T99.2.2 H16 / H19 ablation: isolates whether the PLE branch, its
 	// tokenSlice sub-path, or its projNormed sub-path is on the bug vector.
@@ -596,7 +603,7 @@ func newPLESliceNode[T tensor.Numeric](
 	if err != nil {
 		return nil, fmt.Errorf("pleSliceNode: build RMSNorm: %w", err)
 	}
-	return &pleSliceNode[T]{
+	node := &pleSliceNode[T]{
 		engine:    engine,
 		producer:  producer,
 		normLayer: normLayer,
@@ -604,7 +611,45 @@ func newPLESliceNode[T tensor.Numeric](
 		pleDim:    producer.pleDim,
 		numLayers: producer.numLayers,
 		zeroMode:  parsePLEZeroMode(os.Getenv("ZERFOO_GEMMA4_PLE_ZERO")),
-	}, nil
+	}
+	if os.Getenv("ZERFOO_GEMMA4_PLE_TOKEN_NORM") == "1" {
+		tokenNorm, err := buildPLETokenNorm[T](engine, ops, eps, producer.pleDim, layerIdx)
+		if err != nil {
+			return nil, err
+		}
+		node.tokenNormLayer = tokenNorm
+	}
+	return node, nil
+}
+
+// buildPLETokenNorm constructs the T99.2.2 H20 per-layer RMSNorm applied to
+// tokenSlice. Gain is freshly allocated as ones of shape [pleDim] so the norm
+// is initially an identity-scaled (after rms) transform. The gain is frozen at
+// graph build (registered via EmbeddedFrozen on the owning pleSliceNode).
+func buildPLETokenNorm[T tensor.Numeric](
+	engine compute.Engine[T],
+	ops numeric.Arithmetic[T],
+	eps float32,
+	pleDim, layerIdx int,
+) (*normalization.RMSNorm[T], error) {
+	gainData := make([]T, pleDim)
+	one := ops.FromFloat64(1.0)
+	for i := range gainData {
+		gainData[i] = one
+	}
+	gainTensor, err := tensor.New[T]([]int{pleDim}, gainData)
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode: build ple_token_norm gain tensor: %w", err)
+	}
+	gainParam, err := graph.NewParameter[T](fmt.Sprintf("ple_token_norm.gain.layer_%d", layerIdx), gainTensor, tensor.New[T])
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode: wrap ple_token_norm gain: %w", err)
+	}
+	tokenNorm, err := normalization.NewRMSNormFromParam[T](engine, ops, ops.FromFloat64(float64(eps)), gainParam)
+	if err != nil {
+		return nil, fmt.Errorf("pleSliceNode: build ple_token_norm RMSNorm: %w", err)
+	}
+	return tokenNorm, nil
 }
 
 func (n *pleSliceNode[T]) OpType() string                   { return "Gemma4PLESlice" }
@@ -614,6 +659,9 @@ func (n *pleSliceNode[T]) Parameters() []*graph.Parameter[T] { return nil }
 
 func (n *pleSliceNode[T]) EmbeddedFrozen() []*tensor.TensorNumeric[T] {
 	params := n.normLayer.Parameters()
+	if n.tokenNormLayer != nil {
+		params = append(params, n.tokenNormLayer.Parameters()...)
+	}
 	frozen := make([]*tensor.TensorNumeric[T], 0, len(params))
 	for _, p := range params {
 		frozen = append(frozen, p.Value)
@@ -647,6 +695,16 @@ func (n *pleSliceNode[T]) Forward(ctx context.Context, _ ...*tensor.TensorNumeri
 	projNormed, err := n.normLayer.Forward(ctx, projSlice)
 	if err != nil {
 		return nil, fmt.Errorf("pleSliceNode(layer=%d): rmsnorm: %w", n.layerIdx, err)
+	}
+	// T99.2.2 H20 fix candidate: when ZERFOO_GEMMA4_PLE_TOKEN_NORM=1, apply a
+	// per-layer RMSNorm to tokenSlice before the combine so Q4-gather noise on
+	// `ple_embed_tokens.weight` cannot compound across 35 layers.
+	if n.tokenNormLayer != nil {
+		tokenNormed, err := n.tokenNormLayer.Forward(ctx, tokenSlice)
+		if err != nil {
+			return nil, fmt.Errorf("pleSliceNode(layer=%d): token rmsnorm: %w", n.layerIdx, err)
+		}
+		tokenSlice = tokenNormed
 	}
 	// T99.2.2 H19 ablation: suppress only the target sub-path BEFORE the
 	// combine, so "token" and "proj" are truly independent. Producer cache


### PR DESCRIPTION
## Summary

Implements the H20 fix candidate proposed after T99.2.2 Waves 1-3. Adds a per-layer RMSNorm applied to `tokenSlice` in `pleSliceNode.Forward` before the combine with `projNormed`, gated behind `ZERFOO_GEMMA4_PLE_TOKEN_NORM=1` for A/B comparison on DGX.

**Bug locus (from H19 split + H17 L2 diagnostics):** Q4 gather on `ple_embed_tokens.weight` (262144x8960) and Q4 matmul on `ple_model_proj.weight` both contribute small uniform noise (~0.10 per-element RMS) that cumulatively poisons the residual stream over 35 layers. Only `projNormed` is RMSNormed today; `tokenSlice` rode in raw. H20 normalizes `tokenSlice` to absorb Q4 gather noise.

## Changes

- `inference/gemma4_edge_ple_nodes.go`:
  - `pleSliceNode` gains `tokenNormLayer *normalization.RMSNorm[T]` (nil unless env set).
  - `newPLESliceNode` parses `ZERFOO_GEMMA4_PLE_TOKEN_NORM=1` and builds a fresh `ple_token_norm.gain.layer_N` RMSNorm (shape `[pleDim]`, gain init 1.0).
  - `Forward` applies the token norm before H19 zero-ablation and before the combine.
  - `EmbeddedFrozen` registers the new gain so the graph compiler uploads it.
- `inference/arch_gemma4_test.go`: `TestPLESliceNode_TokenNormAblation` with baseline / flag-on / frozen-registration subtests.

## Baseline preservation

Flag unset: `tokenNormLayer` stays nil, Forward is unchanged from commit `8ed15b42`. No regression risk on the default path.

## Validation

- `go build ./...`: PASS
- `go vet ./...`: PASS
- `go test ./inference/ -race -timeout 300s`: PASS (57.8s)
- `TestPLESliceNode_TokenNormAblation` verifies (i) flag=1 non-zero output, (ii) output differs from baseline, (iii) max|out| strictly less than baseline on a token-dominated fixture, (iv) gain tensor registered via EmbeddedFrozen.
- `TestPLESliceNode_ZeroAblation` (regression guard for H16/H19 modes): PASS.

## Test plan

- [x] Unit: `go test ./inference/ -run TestPLESliceNode`
- [x] Full inference suite: `go test ./inference/ -race`
- [ ] DGX: Q4_K_M generate with `ZERFOO_GEMMA4_PLE_TOKEN_NORM=1` vs baseline; coherent / non-multilingual-loop output confirms H20. If still degenerate, refute H20 and file T99.2.2.7 (joint H12 + H20 revisit with both PLE tensors upgraded to Q8).

## Context

- Plan: `docs/plan.md` T99.2.2.6
- Devlog synthesis: `docs/devlog.md` 2026-04-21 "H19 split + H17 L2 diagnostic -> H20 fix candidate"
- Prior waves: PRs #492 (instruments), #493 (analysis)