### PR TITLE
docs: T99.2.2.6 H20 DGX results (refuted); T99.2.2.7 queued

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,54 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-04-21: T99.2.2.6 -- H20 DGX validation (REFUTED as standalone)
+
+**Type:** investigation
+**Tags:** gemma4e, decode, q4_k, ple, pleSliceNode, h20, ple_token_norm
+
+### Setup
+
+- Main at `b2e6c1d9` (PR #494 merged: `feat(inference): T99.2.2.6 H20 --
+  RMSNorm tokenSlice under ZERFOO_GEMMA4_PLE_TOKEN_NORM`).
+- DGX binary rebuilt from `b2e6c1d9`.
+- Model: `gemma-4-E2B-it-Q4_K_M.gguf`, CPU, `-mmap=false`, `-steps 32`,
+  prompt `"The quick brown fox"`.
+
+### Results
+
+| `ZERFOO_GEMMA4_PLE_TOKEN_NORM` | Decode   | Output | Bytes |
+|---|---|---|---|
+| (unset, baseline)              | 3.62 t/s | `"lyes\nsn\nsn\nsn\nsn"` | 16 |
+| `1` (H20, RMSNorm tokenSlice)  | 4.23 t/s | `"sunnyo\n"`             | 7  |
+
+### Interpretation
+
+- **H20 has a measurable effect.** The decode trajectory changed and the
+  flag-unset baseline reproduces exactly — the code path is wired
+  correctly and the norm is bounding the tokenSlice magnitude as the
+  unit test predicted.
+- **H20 does not restore coherence.** The output is non-multilingual
+  (all-ASCII Latin) and non-punctuation-loop, satisfying the plan's
+  weakest criterion — but "sunnyo\n" is not a coherent English
+  continuation of "The quick brown fox", and the generation terminates
+  into EOS almost immediately. Per the plan's explicit guidance
+  ("If still degenerate, refute H20..."), **H20 is REFUTED as a
+  standalone fix.**
+- The Q4 gather noise contributes but normalizing alone cannot recover
+  the missing information. Evidence from the H17 L2 diagnostic showed
+  uniform per-row noise (p100/p50 = 1.49x with no single-row outliers),
+  consistent with this: RMSNorm rescales but cannot restore the signal
+  swamped by additive noise at every element.
+
+### Next steps
+
+Filing T99.2.2.7 for the joint H12 + H20 revisit: upgrade both
+`ple_embed_tokens.weight` and `ple_model_proj.weight` from Q4 to Q8 at
+load time (reverting the H12 revert and pairing it with the H20
+`ple_token_norm` gate), then re-measure. If the joint combination still
+fails, the bug is not in Q4 noise at all and the investigation moves off
+the quantization axis.
+
 ## 2026-04-21: T99.2.2 -- H19 split + H17 L2 diagnostic -> H20 fix candidate
 
 **Type:** investigation

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2021,7 +2021,7 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
     a T99.2.2.6 as a new task implementing the H20 candidate.
     Refresh `.claude-checkpoint.md`.
 
-  - [ ] T99.2.2.6 H20 fix candidate: RMSNorm the tokenSlice path
+  - [x] T99.2.2.6 H20 fix candidate: RMSNorm the tokenSlice path (SHIPPED 2026-04-21 via PR #494; H20 REFUTED on DGX)
     Owner: TBD  Est: 90m  verifies: [UC-001]  Deps: T99.2.2.5
     Bug locus (from H19 split + H17 L2): Q4 gather on
     `ple_embed_tokens.weight` (262144x8960) and Q4 matmul on
@@ -2041,6 +2041,45 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
     confirms H20. If still degenerate, refute H20 and file T99.2.2.7
     to revisit H12 + H20 jointly (upgrade both PLE tensors to Q8
     together, measure).
+    OUTCOME 2026-04-21: DGX decode under Q4_K_M with
+    `ZERFOO_GEMMA4_PLE_TOKEN_NORM=1` changed trajectory from baseline
+    `"lyes\nsn\nsn\nsn\nsn"` (16 B) to `"sunnyo\n"` (7 B). Non-multilingual
+    and non-loop, but still degenerate. Per the plan's refute clause,
+    **H20 is refuted as a standalone fix.** T99.2.2.7 filed for the
+    joint H12 + H20 revisit. See devlog 2026-04-21 T99.2.2.6.
+
+  - [ ] T99.2.2.7 H20 + H12 joint: upgrade ple_embed_tokens.weight to Q8 with ple_token_norm enabled
+    Owner: TBD  Est: 60m  verifies: [UC-001]  Deps: T99.2.2.6
+    Context. H20 alone (normalize tokenSlice) leaves the decode
+    degenerate but non-multilingual (see T99.2.2.6 outcome). H12
+    (upgrade `ple_embed_tokens.weight` from Q4 to Q8 at load) was
+    refuted in isolation because it didn't fix coherence either, but
+    at that time `tokenSlice` was unnormalized and the bigger Q4
+    noise on `ple_model_proj` (H19.proj path) was not yet isolated.
+    With both axes now known to contribute, the joint experiment
+    tests whether reducing noise (Q4->Q8 on the embedding table)
+    plus bounding accumulation (RMSNorm) together restores
+    coherence.
+    Experiment plan.
+      1. In `inference/gguf.go`, extend the existing
+         `upgradeEmbeddingPrecision` hook to also re-quantize
+         `model.ple_embed_tokens.weight` Q4_K -> Q8_0. Gate behind
+         `ZERFOO_GEMMA4_PLE_EMBED_Q8=1` so the change is A/B-able and
+         the baseline is untouched.
+      2. Unit test that the flag routes the tensor through the
+         upgrade path and produces a Q8 storage type on load.
+      3. DGX run matrix (Q4_K_M GGUF, CPU, -mmap=false, -steps 32,
+         "The quick brown fox"):
+           a) baseline (no flags)                      — reproduce
+           b) ZERFOO_GEMMA4_PLE_TOKEN_NORM=1           — replicate T99.2.2.6 output
+           c) ZERFOO_GEMMA4_PLE_EMBED_Q8=1             — H12-only
+           d) ZERFOO_GEMMA4_PLE_TOKEN_NORM=1 + ZERFOO_GEMMA4_PLE_EMBED_Q8=1 — joint
+      4. Decision. If (d) is coherent English: land the flags
+         defaulted-on for gemma4e and close T99.2.2. If (d) is still
+         degenerate: quantization is not the bug and investigation
+         pivots off the quantization axis (new hypothesis H21 TBD —
+         likely the PLE RoPE/position handling or the residual
+         combine scale).
 
 ### T99.2.2 Next-Session Waves
 
@@ -2063,9 +2102,13 @@ assuming no surprises.
 
 - [x] T99.2.2.5 Analyze + propose fix candidate
 
-#### Wave 4 (queued): H20 implementation (1 agent)
+#### Wave 4: H20 implementation (1 agent) -- DONE 2026-04-21 via PR #494 (H20 REFUTED)
 
-- [ ] T99.2.2.6 H20 fix candidate: RMSNorm the tokenSlice path
+- [x] T99.2.2.6 H20 fix candidate: RMSNorm the tokenSlice path
+
+#### Wave 5 (queued): H20 + H12 joint revisit (1 agent)
+
+- [ ] T99.2.2.7 Upgrade ple_embed_tokens.weight to Q8 with ple_token_norm enabled
 
 ### E98 Risk Register
 


### PR DESCRIPTION
## Summary

Documents the T99.2.2.6 H20 DGX validation outcome and files T99.2.2.7 for the joint H12 + H20 revisit.

## DGX Results (Q4_K_M, CPU, -mmap=false, -steps 32, "The quick brown fox")

| \`ZERFOO_GEMMA4_PLE_TOKEN_NORM\` | Decode   | Output | Bytes |
|---|---|---|---|
| (unset, baseline)              | 3.62 t/s | \`"lyes\nsn\nsn\nsn\nsn"\` | 16 |
| \`1\` (H20)                    | 4.23 t/s | \`"sunnyo\n"\`             | 7  |

## Verdict

**H20 refuted as standalone fix.** The flag has a measurable effect — decode trajectory changed from a punctuation/repetition loop to a different (still-degenerate) output — but coherence is not restored. Per the plan's explicit clause ("If still degenerate, refute H20..."), this is a refute.

The baseline (flag unset) reproduces byte-exactly, so the wiring is correct and the refute signal is trustworthy.

## Follow-up: T99.2.2.7

Joint H12 + H20 revisit: re-quantize \`ple_embed_tokens.weight\` Q4_K -> Q8_0 at load (new flag \`ZERFOO_GEMMA4_PLE_EMBED_Q8=1\`) and combine with \`ple_token_norm\` in a 2x2 matrix on DGX. If the joint run still degenerates, the bug is off the quantization axis and a new hypothesis (H21) will be filed targeting PLE RoPE / residual combine scale.

## Files

- \`docs/devlog.md\`: new entry "T99.2.2.6 -- H20 DGX validation (REFUTED as standalone)" with the measurement table and reasoning.
- \`docs/plan.md\`: T99.2.2.6 marked \`[x]\` with OUTCOME note; new T99.2.2.7 task added with the experiment matrix; Waves section updated (Wave 4 DONE, Wave 5 queued).

## Test plan

- [x] No code changes — docs-only PR.
- [x] \`go build ./...\` still passes.