### PR TITLE
feat(inference): T99.2.2.7 -- ZERFOO_GEMMA4_PLE_EMBED_Q8 re-quantizes PLE table

### DIFF
--- a/inference/gguf.go
+++ b/inference/gguf.go
@@ -270,10 +270,20 @@ func loadGGUFMmapSplit(sf *gguf.SplitFile) (*GGUFModel, io.Closer, error) {
 // so the Q4_0 GEMV speed advantage does not apply. The extra precision from Q8
 // (256 quantization levels vs 16) prevents the cumulative numerical errors that
 // cause garbage output in Q4_K models like Mistral 7B and Llama 3.x.
+//
+// T99.2.2.7 (Gemma 4 Edge PLE): when ZERFOO_GEMMA4_PLE_EMBED_Q8=1, also upgrade
+// `model.ple_embed_tokens.weight` (Q4_K re-quantized to Q4_0 at decode) to Q8.
+// This is the gather table for the PLE tokenSlice path; H12+H20 joint tests
+// whether lower gather noise plus the tokenSlice RMSNorm (H20) restores Q4_K_M
+// decode coherence. Baseline (flag unset) is bit-identical to the pre-T99.2.2.7
+// load path.
 func upgradeEmbeddingPrecision(tensors map[string]*tensor.TensorNumeric[float32]) {
 	targets := []string{
 		"model.embed_tokens.weight",
 		"lm_head.weight",
+	}
+	if os.Getenv("ZERFOO_GEMMA4_PLE_EMBED_Q8") == "1" {
+		targets = append(targets, "model.ple_embed_tokens.weight")
 	}
 	for _, name := range targets {
 		t, ok := tensors[name]

--- a/inference/gguf_test.go
+++ b/inference/gguf_test.go
@@ -156,3 +156,88 @@ func TestLoadGGUF_InvalidFile(t *testing.T) {
 		t.Error("expected error for invalid GGUF file")
 	}
 }
+
+// newQ4Tensor builds a Q4-backed tensor of numElements values filled with a
+// smooth ramp. Size must be a multiple of 32 (Q4_0 block size).
+func newQ4Tensor(t *testing.T, numElements int) *tensor.TensorNumeric[float32] {
+	t.Helper()
+	if numElements%32 != 0 {
+		t.Fatalf("numElements=%d must be a multiple of 32", numElements)
+	}
+	src := make([]float32, numElements)
+	for i := range src {
+		src[i] = float32(i-numElements/2) / float32(numElements/2)
+	}
+	q4 := tensor.QuantizeQ4(src)
+	tn, err := tensor.NewWithStorage[float32]([]int{numElements}, q4)
+	if err != nil {
+		t.Fatalf("NewWithStorage Q4: %v", err)
+	}
+	return tn
+}
+
+// TestUpgradeEmbeddingPrecision_PLEEmbedQ8Flag validates the T99.2.2.7 gate:
+// ZERFOO_GEMMA4_PLE_EMBED_Q8=1 routes `model.ple_embed_tokens.weight` through
+// the Q4->Q8 upgrade path; when the flag is unset, the PLE table is untouched
+// (baseline bit-identical). The default `model.embed_tokens.weight` and
+// `lm_head.weight` upgrades happen in both cases.
+func TestUpgradeEmbeddingPrecision_PLEEmbedQ8Flag(t *testing.T) {
+	makeTensors := func() map[string]*tensor.TensorNumeric[float32] {
+		return map[string]*tensor.TensorNumeric[float32]{
+			"model.embed_tokens.weight":     newQ4Tensor(t, 128),
+			"lm_head.weight":                newQ4Tensor(t, 128),
+			"model.ple_embed_tokens.weight": newQ4Tensor(t, 256),
+		}
+	}
+
+	t.Run("flag_unset_keeps_ple_embed_q4", func(t *testing.T) {
+		t.Setenv("ZERFOO_GEMMA4_PLE_EMBED_Q8", "")
+		tensors := makeTensors()
+		upgradeEmbeddingPrecision(tensors)
+
+		if _, ok := tensors["model.embed_tokens.weight"].GetStorage().(*tensor.Q8Storage); !ok {
+			t.Errorf("embed_tokens: expected Q8Storage, got %T",
+				tensors["model.embed_tokens.weight"].GetStorage())
+		}
+		if _, ok := tensors["lm_head.weight"].GetStorage().(*tensor.Q8Storage); !ok {
+			t.Errorf("lm_head: expected Q8Storage, got %T",
+				tensors["lm_head.weight"].GetStorage())
+		}
+		if _, ok := tensors["model.ple_embed_tokens.weight"].GetStorage().(*tensor.Q4Storage); !ok {
+			t.Errorf("ple_embed_tokens: expected Q4Storage (unchanged), got %T",
+				tensors["model.ple_embed_tokens.weight"].GetStorage())
+		}
+	})
+
+	t.Run("flag_set_upgrades_ple_embed_to_q8", func(t *testing.T) {
+		t.Setenv("ZERFOO_GEMMA4_PLE_EMBED_Q8", "1")
+		tensors := makeTensors()
+		upgradeEmbeddingPrecision(tensors)
+
+		if _, ok := tensors["model.embed_tokens.weight"].GetStorage().(*tensor.Q8Storage); !ok {
+			t.Errorf("embed_tokens: expected Q8Storage, got %T",
+				tensors["model.embed_tokens.weight"].GetStorage())
+		}
+		if _, ok := tensors["lm_head.weight"].GetStorage().(*tensor.Q8Storage); !ok {
+			t.Errorf("lm_head: expected Q8Storage, got %T",
+				tensors["lm_head.weight"].GetStorage())
+		}
+		if _, ok := tensors["model.ple_embed_tokens.weight"].GetStorage().(*tensor.Q8Storage); !ok {
+			t.Errorf("ple_embed_tokens: expected Q8Storage, got %T",
+				tensors["model.ple_embed_tokens.weight"].GetStorage())
+		}
+	})
+
+	t.Run("flag_set_no_ple_tensor_is_noop", func(t *testing.T) {
+		t.Setenv("ZERFOO_GEMMA4_PLE_EMBED_Q8", "1")
+		tensors := map[string]*tensor.TensorNumeric[float32]{
+			"model.embed_tokens.weight": newQ4Tensor(t, 128),
+		}
+		// Must not panic when ple_embed_tokens is absent.
+		upgradeEmbeddingPrecision(tensors)
+		if _, ok := tensors["model.embed_tokens.weight"].GetStorage().(*tensor.Q8Storage); !ok {
+			t.Errorf("embed_tokens: expected Q8Storage, got %T",
+				tensors["model.embed_tokens.weight"].GetStorage())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Extend `upgradeEmbeddingPrecision` (inference/gguf.go) to optionally upgrade `model.ple_embed_tokens.weight` Q4_0 -> Q8_0 when `ZERFOO_GEMMA4_PLE_EMBED_Q8=1`. Baseline load path is bit-identical when the flag is unset.
- Add `TestUpgradeEmbeddingPrecision_PLEEmbedQ8Flag` covering flag-unset, flag-set-with-tensor, and flag-set-without-tensor cases.

## Why

T99.2.2.6 H20 (per-layer RMSNorm on the PLE `tokenSlice`) shipped and was refuted on DGX: Q4_K_M decode shifted from `"lyes\nsn\nsn\nsn\nsn"` to `"sunnyo\n"` but remained degenerate. T99.2.2.7 prepares the joint H12 + H20 experiment -- reduce gather noise on `ple_embed_tokens.weight` (Q4->Q8) AND normalize `tokenSlice` -- under a 2x2 DGX matrix:

| # | TOKEN_NORM | PLE_EMBED_Q8 | Expected role |
|---|---|---|---|
| a | 0 | 0 | baseline reproduction |
| b | 1 | 0 | H20-only (T99.2.2.6 replica) |
| c | 0 | 1 | H12-only (noise-only) |
| d | 1 | 1 | joint (decision point) |

Decision rule (from plan):
- (d) coherent English -> land flags defaulted-on for gemma4e, close T99.2.2.
- (d) still degenerate -> bug is off the quantization axis; file T99.2.2.8 (H21 PLE RoPE / residual combine scale).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./inference/...`
- [x] `go test ./inference/ -race -timeout 300s` (56.6s, PASS)
- [x] `golangci-lint run --new-from-rev=origin/main ./inference/...` (0 new issues)
- [ ] DGX 2x2 matrix on Q4_K_M "The quick brown fox" (follow-up PR with devlog + plan update)

## Linked tasks

- Implements T99.2.2.7 (see docs/plan.md).
- Follow-up: devlog + `.claude-checkpoint.md` refresh after the 2x2 DGX run.