### PR TITLE
docs: T99.2.2.7 H12+H20 joint DGX results -- REFUTED; T99.2.2.8 queued

### DIFF
--- a/.claude-checkpoint.md
+++ b/.claude-checkpoint.md
@@ -1,75 +1,93 @@
-## Last Updated: 2026-04-21 07:00 UTC (fourth /apply session — H16 CONFIRMED)
+## Last Updated: 2026-04-21 19:32 UTC (sixth /apply session — T99.2.2.7 shipped, joint H12 REFUTED, quantization axis cleared)
 
 ## Plan File: docs/plan.md
 
 ## Completed This Session:
-- T99.2.2 H16 ablation test wired and executed end-to-end.
-  1. Added `ZERFOO_GEMMA4_PLE_ZERO=1` env gate in
-     `inference/gemma4_edge_ple_nodes.go::pleSliceNode.Forward`
-     resolved at graph build time and applied via
-     `engine.MulScalar(scaled, 0)`. Unit test
-     `TestPLESliceNode_ZeroAblation` covers both branches.
-     Commit `cca5ea3b`, merged to main.
-  2. Local validation PASS: `go build ./...`, `go vet ./inference/...`,
-     `go test ./inference/ -race -timeout 180s` (69s).
-  3. Pushed to main, DGX pulled and rebuilt `/var/lib/zerfoo/bin/gemma4_e2e`
-     from `cca5ea3b`.
-  4. Ran the discriminating test on DGX (Q4_K_M, CPU, `-mmap=false`,
-     `-steps 32`, prompt "The quick brown fox"):
 
-     | Config | Output | Bytes | Decode |
-     |---|---|---|---|
-     | Baseline (flag unset) | `"lyes\nsn\nsn\nsn\nsn"` | 16 | 3.27 tok/s |
-     | Ablation (flag=1) | `"▁PM▁Transport🇱▁KenЛSm..."` (multilingual noise) | 204 | 2.44 tok/s |
+1. **T99.2.2.7 implementation shipped** (PR #496, merged as `7700621a`).
+   - `inference/gguf.go`: `upgradeEmbeddingPrecision` now appends
+     `model.ple_embed_tokens.weight` to the upgrade target list when
+     `ZERFOO_GEMMA4_PLE_EMBED_Q8=1`. Baseline (flag unset) is
+     bit-identical; the existing `model.embed_tokens.weight` and
+     `lm_head.weight` Q4->Q8 upgrades are unchanged.
+   - `inference/gguf_test.go`: `TestUpgradeEmbeddingPrecision_PLEEmbedQ8Flag`
+     exercises three subtests -- flag unset (PLE stays Q4), flag=1
+     with tensor (PLE becomes Q8), flag=1 with no PLE tensor (no-op).
+   - Local validation: `go build ./...`, `go vet ./inference/...`,
+     `go test ./inference/ -race -timeout 300s` (56.6s) all PASS.
+     `golangci-lint run --new-from-rev=origin/main ./inference/...`
+     reports 0 new issues.
+   - CI: all checks green on PR #496.
 
-  5. **Result: H16 CONFIRMED.** The decode trajectory changed with the
-     ablation, so the PLE branch is on the bug vector path. Output is
-     still degenerate, so PLE is likely not the sole cause; H17 is
-     promoted to top priority and H19 is added to separate the
-     token-identity Gather from the model-projection MatMul.
-  6. Documented in `docs/devlog.md` and `docs/plan.md`.
+2. **T99.2.2.7 DGX 2x2 matrix (H12 REFUTED jointly)**
+   (docs PR in progress -- devlog + plan updates staged).
+   - DGX binary rebuilt from `7700621a`.
+   - Q4_K_M, CPU, `-mmap=false`, `-steps 32`, prompt "The quick brown fox":
+
+     | # | TOKEN_NORM | PLE_EMBED_Q8 | Decode   | Output                    | Bytes |
+     |---|---|---|---|---|---|
+     | a | 0          | 0            | 3.64 t/s | `"lyes\nsn\nsn\nsn\nsn"`  | 16    |
+     | b | 1          | 0            | 4.27 t/s | `"sunnyo\n"`              | 7     |
+     | c | 0          | 1            | 0.95 t/s | `"lyes\nsn\nsn\nsn\nsn"`  | 16    |
+     | d | 1          | 1            | 1.81 t/s | `"sunnyo\n"`              | 7     |
+
+   - (a)==(c) and (b)==(d) byte-exact. The Q4->Q8 upgrade on
+     `ple_embed_tokens.weight` has **zero effect** on the decode
+     trajectory standalone or jointly with H20. **H12 is refuted
+     (joint). Quantization axis cleared.**
+   - Q8 upgrade slows decode 3.8x (3.64 -> 0.95 t/s) -- expected: the
+     table is ~2x larger (~2.3 GB vs ~1.1 GB) and the Q8 gather kernel
+     path is slower. Irrelevant for correctness.
 
 ## Session Commit Trail (main):
-1. `cca5ea3b` test(inference): T99.2.2 H16 -- ZERFOO_GEMMA4_PLE_ZERO ablation gate
+
+1. `7700621a` feat(inference): T99.2.2.7 -- ZERFOO_GEMMA4_PLE_EMBED_Q8 re-quantizes PLE table
+
+Docs PR (devlog + plan.md + this checkpoint): in progress.
 
 ## In Progress:
-- None. T99.2.2 hypothesis space tightened further. Confirmed facts:
-  - Q4->Q8 of `ple_embed_tokens.weight` does not fix (H12 refuted).
-  - F32->BF16 of `ple_model_proj.weight.tw` does not fix (H13 refuted).
-  - Zeroing per-layer PLE output changes the degenerate trajectory
-    but does not restore coherence (H16 confirms PLE involvement;
-    PLE is not the sole cause).
+
+- Docs PR with the 2x2 matrix devlog entry, T99.2.2.7 [x] + OUTCOME
+  block, T99.2.2.8 H21 task, Waves section updated (Wave 5 DONE, Wave
+  6 queued).
+
+## Confirmed facts (T99.2.2 cumulative, post-T99.2.2.7):
+
+- H12 REFUTED **twice** (standalone 2026-04-20; joint with H20
+  2026-04-21). Q4_0 gather noise on `ple_embed_tokens.weight` has no
+  measurable effect on greedy-decode token trajectory.
+- H13 refuted (BF16 projection).
+- H16 confirmed (PLE branch on bug vector).
+- H17 informative (uniform Q4 noise, no outlier rows).
+- H19 confirmed both sub-paths carry bad values.
+- H20 refuted (RMSNorm tokenSlice alone insufficient).
+- H20 + H12 joint refuted.
+- **Quantization axis is cleared.** Bug is structural in the PLE
+  subsystem.
 
 ## Next Up (priority order):
 
-1. **H17 Q4 Gather correctness** (top priority).
-   - Dequantize `ple_embed_tokens.weight` from Q4_K_M and Q8_0 GGUFs
-     into F32. Diff per-row against a reference decoder output
-     (llama.cpp's dequantizer or the Q8_0 copy).
-   - Focus on the row indices actually hit during the "The quick
-     brown fox" generate run; if those rows show outsized L2 error
-     vs neighbouring rows, the Q4 gather on 262144-row tables is
-     implicated.
+1. **T99.2.2.8 H21 reference diff** (top priority).
+   - Read the Gemma 4 Edge reference PLE forward pass.
+   - Side-by-side with `inference/gemma4_edge_ple_nodes.go`
+     `pleSliceNode.Forward` and `inference/arch_gemma4_edge.go`
+     graph-order.
+   - Emit a named deviation list, classify each as cosmetic /
+     numerical-scale / structural, prioritize the top structural
+     candidate.
+   - If exactly one structural deviation emerges, file T99.2.2.9 as
+     the fix candidate, gate behind a new `ZERFOO_GEMMA4_PLE_*`
+     flag, A/B on DGX.
 
-2. **H19 Gather vs MatMul separation**.
-   - Extend the H16 ablation: allow zeroing only the token-identity
-     PLE (`tokenSlice`) or only the projection (`projSlice`) inside
-     `pleSliceNode.Forward`. Two more runs isolate which of the two
-     PLE producers (the Q4 Gather or the Q4 MatMul) is carrying the
-     bad values.
+2. T99.1.3 re-verify capture-on (still BLOCKED by T99.2.2).
 
-3. **H18** (CompileTraced plan-order diff) -- still possible but
-   deprioritised because the same warning fires in both the baseline
-   and H16-ablation runs, showing the warning is not sensitive to the
-   PLE-branch change.
-
-4. T99.1.3 re-verify capture-on (still BLOCKED by T99.2.2).
-
-5. Release-please PR #400 (4.0.0). Review + merge.
+3. Release-please PR (next version after 4.0.0 / main `7700621a`).
 
 ## Known Blockers:
-- None for infrastructure. T99.2.2 remains an open epic-level bug but
-  is now narrowed onto the PLE subsystem.
+
+- None for infrastructure. T99.2.2 remains an open epic-level bug
+  but is narrowed to the PLE subsystem, with the quantization axis
+  cleared and T99.2.2.8 (H21 reference diff) as the next experiment.
 
 ## Network access matrix:
 
@@ -82,12 +100,14 @@
 | SSH over link-local IPv6 | WORKS |
 
 ## Merge Status:
-- main: tip `cca5ea3b`. All session commits pushed.
-- PR #400 (release-please 4.0.0): OPEN, will auto-update.
+
+- main: tip `7700621a`. All session commits pushed and merged via rebase.
+- PR #496 (T99.2.2.7 impl): MERGED (rebase) as `7700621a`.
+- PR #497 (T99.2.2.7 docs + this checkpoint): in progress.
 
 ## DGX artifact state:
-- `/var/lib/zerfoo/bin/gemma4_e2e`: built from main `cca5ea3b`. No
-  rebuild required until next source change.
+
+- `/var/lib/zerfoo/bin/gemma4_e2e`: built from main `7700621a`.
 - Models present: Q4_K_M (2.9 GB), Q8_0 (6.7 GB), gemma3 Q4_K_M (780 MB).
 
 ## Recovery commands (next session)
@@ -101,19 +121,17 @@ ssh ndungu@192.168.86.250 \
   'cd ~/zerfoo && git pull --ff-only origin main && \
    /usr/local/go/bin/go build -o /var/lib/zerfoo/bin/gemma4_e2e ./cmd/gemma4_e2e'
 
-# 3. Re-run H16 reference if needed.
-ssh ndungu@192.168.86.250 \
-  'ZERFOO_GEMMA4_PLE_ZERO=1 /var/lib/zerfoo/bin/gemma4_e2e \
-     -gguf /var/lib/zerfoo/models/gemma-4-E2B-it-Q4_K_M.gguf \
-     -mode generate -device cpu -mmap=false -steps 32 \
-     -prompt "The quick brown fox"'
-
-# 4. H17 requires a new diagnostic: write a test or CLI mode that
-#    dequantizes ple_embed_tokens.weight from both GGUFs and diffs
-#    them (see inference/gguf.go for existing Q4->Q8 upgrade hooks
-#    as the starting point).
-
-# 5. Release 4.0.0:
-gh pr view 400 --web
-gh pr merge 400 --rebase --delete-branch
+# 3. T99.2.2.8 is a read-only code-diff task against the Gemma 4 Edge
+#    reference PLE implementation. No DGX run needed until an H21 fix
+#    candidate (T99.2.2.9) lands.
 ```
+
+## Worktree hygiene
+
+- Previous worktree `wave-1-task-T99-2-2-2` was cleaned up at the
+  start of this session (branch `t99-2-2-6-docs-h20-results` was
+  patch-equivalent to `3196f105` on main).
+- This session worked directly on main with feature branch
+  `t99-2-2-7-ple-embed-q8` (now deleted after PR #496 merge via
+  `gh pr merge --rebase --delete-branch`).
+- No worktrees to clean up at end of session.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,106 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-04-21: T99.2.2.7 -- H12 + H20 joint DGX validation (H12 REFUTED, H20 replicated; bug OFF the quantization axis)
+
+**Type:** investigation
+**Tags:** gemma4e, decode, q4_k, ple, ple_embed_tokens, h12, h20, h21
+
+### Setup
+
+- Main at `7700621a` (PR #496 merged: `feat(inference): T99.2.2.7 --
+  ZERFOO_GEMMA4_PLE_EMBED_Q8 re-quantizes PLE table`).
+- DGX binary rebuilt from `7700621a`.
+- Model: `gemma-4-E2B-it-Q4_K_M.gguf`, CPU, `-mmap=false`, `-steps 32`,
+  prompt `"The quick brown fox"`.
+- Load-time log lines confirm flag routing:
+  - H20 only: one `upgraded tensor from Q4 to Q8` line for
+    `model.embed_tokens.weight` (default target).
+  - H12 on: a second `upgraded tensor from Q4 to Q8` line for
+    `model.ple_embed_tokens.weight shape=[262144 8960]` -- the gate
+    fires only when `ZERFOO_GEMMA4_PLE_EMBED_Q8=1`.
+
+### 2x2 matrix results
+
+| # | `ZERFOO_GEMMA4_PLE_TOKEN_NORM` | `ZERFOO_GEMMA4_PLE_EMBED_Q8` | Decode    | Output                    | Bytes |
+|---|---|---|---|---|---|
+| a | (unset)                        | (unset)                      | 3.64 t/s  | `"lyes\nsn\nsn\nsn\nsn"`  | 16    |
+| b | `1`                            | (unset)                      | 4.27 t/s  | `"sunnyo\n"`              | 7     |
+| c | (unset)                        | `1`                          | 0.95 t/s  | `"lyes\nsn\nsn\nsn\nsn"`  | 16    |
+| d | `1`                            | `1`                          | 1.81 t/s  | `"sunnyo\n"`              | 7     |
+
+### Interpretation
+
+- **(a) baseline** reproduces the Q4_K_M degenerate output exactly
+  (matches T99.2.2.6's 3.62 t/s / `"lyes\nsn\nsn\nsn\nsn"`). Load path
+  wiring is stable.
+- **(b) H20-only** replicates T99.2.2.6's `"sunnyo\n"` at 4.27 t/s.
+- **(c) H12-only** produces **identical** output to baseline
+  (`"lyes\nsn\nsn\nsn\nsn"`, same 16-byte string). The Q4->Q8 upgrade on
+  `model.ple_embed_tokens.weight` does not perturb the decode trajectory
+  at all. Decode throughput drops 3.8x (3.64 -> 0.95 t/s) because the Q8
+  table is ~2x larger (~2.3 GB vs ~1.1 GB) and the Q8 gather kernel path
+  is slower -- an observable but irrelevant side effect.
+- **(d) joint** produces **identical** output to H20-only
+  (`"sunnyo\n"`). Stacking the Q8 upgrade on top of the tokenSlice
+  RMSNorm gives zero additional correction.
+- Output invariance across the Q8 toggle (a==c and b==d, byte-exact) is
+  the dispositive signal: **the Q4_0 gather noise on
+  `ple_embed_tokens.weight` has no measurable effect on the sampled
+  token trajectory, even in greedy decode**, because RMSNorm downstream
+  absorbs it in `projNormed` and the additional magnitude carried by
+  `tokenSlice` changes only scale, not sign/ranking of the logits.
+
+### Decision
+
+Per the T99.2.2.7 plan clause:
+> "If (d) is coherent English: land the flags defaulted-on for gemma4e
+>  and close T99.2.2. If (d) is still degenerate: quantization is not
+>  the bug and investigation pivots off the quantization axis (new
+>  hypothesis H21 TBD -- likely the PLE RoPE/position handling or the
+>  residual combine scale)."
+
+**(d) is still degenerate. H12 is refuted (again, jointly).
+Investigation pivots off the quantization axis.**
+
+### Cumulative hypothesis status after T99.2.2.7
+
+- H12: REFUTED x2 (standalone and joint with H20).
+- H13: REFUTED (BF16 projection).
+- H16: CONFIRMED (PLE branch is on the bug vector).
+- H17: INFORMATIVE (uniform Q4 noise, no outlier rows).
+- H19: CONFIRMED (both tokenSlice and projNormed carry bad values).
+- H20: REFUTED (RMSNorm on tokenSlice alone insufficient).
+- H20 + H12 joint: REFUTED (quantization axis cleared).
+
+### Next steps (T99.2.2.8 / H21)
+
+With the quantization axis cleared, the remaining plausible loci in the
+PLE subsystem that were not yet probed are:
+
+1. **PLE RoPE / positional handling.** The pleSliceNode produces
+   per-token embeddings that carry positional information via the
+   pre-existing gather-then-scale path. If the positions used here are
+   off-by-one vs. the main attention block (or use a different theta
+   schedule than the main RoPE branch), the residual stream's positional
+   signal would silently drift across 35 layers.
+2. **Residual combine scale.** The `Add(projNormed, tokenSlice)` combine
+   is unweighted. Gemma 4 Edge's reference implementation may apply a
+   per-layer gain (similar to LayerScale in other transformers) that
+   we've dropped on the GGUF loader; an implicit 1.0 scale would skew
+   the residual balance.
+3. **PLE attention-to-MLP ordering.** The PLE slice joins the residual
+   stream at a specific plan-order location in Gemma 4 Edge; a one-off
+   ordering difference vs. the reference Python forward pass could
+   explain why both sub-paths carry "noise" that is actually structurally
+   correct but combined at the wrong step.
+
+File T99.2.2.8 to diff the GGUF-loaded PLE graph against the Gemma 4
+reference forward pass at the plan-order level, focusing on RoPE theta
+per-layer, any missing per-layer scale on the PLE combine, and the
+exact residual injection point. Expected to close T99.2.2 or expand it
+into a new epic depending on findings.
+
 ## 2026-04-21: T99.2.2.6 -- H20 DGX validation (REFUTED as standalone)
 
 **Type:** investigation

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2048,7 +2048,7 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
     **H20 is refuted as a standalone fix.** T99.2.2.7 filed for the
     joint H12 + H20 revisit. See devlog 2026-04-21 T99.2.2.6.
 
-  - [ ] T99.2.2.7 H20 + H12 joint: upgrade ple_embed_tokens.weight to Q8 with ple_token_norm enabled
+  - [x] T99.2.2.7 H20 + H12 joint: upgrade ple_embed_tokens.weight to Q8 with ple_token_norm enabled (SHIPPED 2026-04-21 via PR #496; JOINT H12 REFUTED, bug OFF the quantization axis)
     Owner: TBD  Est: 60m  verifies: [UC-001]  Deps: T99.2.2.6
     Context. H20 alone (normalize tokenSlice) leaves the decode
     degenerate but non-multilingual (see T99.2.2.6 outcome). H12
@@ -2080,6 +2080,66 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
          pivots off the quantization axis (new hypothesis H21 TBD —
          likely the PLE RoPE/position handling or the residual
          combine scale).
+    OUTCOME 2026-04-21 (DGX main `7700621a`, Q4_K_M "The quick brown fox" 32 steps):
+      | # | TOKEN_NORM | PLE_EMBED_Q8 | Decode   | Output                    | Bytes |
+      |---|---|---|---|---|---|
+      | a | 0          | 0            | 3.64 t/s | `"lyes\nsn\nsn\nsn\nsn"`  | 16    |
+      | b | 1          | 0            | 4.27 t/s | `"sunnyo\n"`              | 7     |
+      | c | 0          | 1            | 0.95 t/s | `"lyes\nsn\nsn\nsn\nsn"`  | 16    |
+      | d | 1          | 1            | 1.81 t/s | `"sunnyo\n"`              | 7     |
+    (a)==(c) and (b)==(d) byte-exact; the Q4->Q8 upgrade on
+    `ple_embed_tokens.weight` has zero effect on the decode trajectory
+    standalone or jointly with H20. **H12 is refuted (joint).
+    Quantization axis cleared.** Per the decision rule, investigation
+    pivots off quantization. T99.2.2.8 filed below for the next
+    hypothesis (H21: PLE RoPE / residual combine scale / plan-order
+    reference diff). See devlog 2026-04-21 T99.2.2.7.
+
+  - [ ] T99.2.2.8 H21 diagnostic: PLE RoPE / residual combine scale / plan-order reference diff
+    Owner: TBD  Est: 120m  verifies: [UC-001]  Deps: T99.2.2.7
+    Motivation. T99.2.2.7 cleared the quantization axis: Q4_0 gather
+    noise on `ple_embed_tokens.weight` has no measurable effect on
+    the decode trajectory under greedy sampling, even when combined
+    with the tokenSlice RMSNorm (H20). The bug vector runs through
+    the PLE branch (H16 confirmed, H19 confirmed both sub-paths) but
+    is structural rather than numerical. Remaining candidate loci:
+      H21.a PLE RoPE / positional handling — the pleSliceNode uses
+            a gather-then-scale path; if the positions / theta
+            schedule differ from the main attention RoPE, positional
+            drift compounds across 35 layers.
+      H21.b Residual combine scale — `Add(projNormed, tokenSlice)`
+            is unweighted; the Gemma 4 Edge reference may apply a
+            per-layer scale that we are dropping.
+      H21.c Plan-order / injection point — the PLE slice may be
+            injected into the residual at the wrong position in the
+            per-layer forward pass vs. the reference Python forward.
+    Approach.
+      1. Read the Gemma 4 Edge reference PLE implementation (the
+         Python / flax or transformers-style reference that
+         `docs/plan.md` E99.2 or earlier E-blocks cite). Extract the
+         exact per-layer PLE forward pass: gather, scale, any RoPE,
+         any per-layer gain, residual injection point.
+      2. Side-by-side with `inference/gemma4_edge_ple_nodes.go`
+         `pleSliceNode.Forward` and the graph-order in
+         `inference/arch_gemma4_edge.go`, produce a named list of
+         deviations.
+      3. For each deviation, classify as (i) cosmetic / symmetric
+         (unlikely bug), (ii) numerical-scale only (should have
+         been caught by H17 uniform noise test), (iii) structural
+         / position / ordering (top suspicion).
+      4. Write a devlog entry listing the deviation set and
+         prioritizing the candidate fix. If exactly one structural
+         deviation emerges, file T99.2.2.9 as the fix candidate and
+         gate behind `ZERFOO_GEMMA4_PLE_*` to A/B on DGX. If no
+         deviation emerges, escalate: the bug may be outside PLE
+         (unlikely given H16/H19) or the reference being consulted
+         is not the one Google actually trained against, in which
+         case the reference itself becomes the blocker.
+    Artifacts.
+      - `docs/devlog.md` entry "T99.2.2.8 H21 reference diff".
+      - Named deviation list, with graph-code pointers.
+      - If a fix candidate emerges: T99.2.2.9 task + ZERFOO_GEMMA4_PLE_*
+        gate.
 
 ### T99.2.2 Next-Session Waves
 
@@ -2106,9 +2166,13 @@ assuming no surprises.
 
 - [x] T99.2.2.6 H20 fix candidate: RMSNorm the tokenSlice path
 
-#### Wave 5 (queued): H20 + H12 joint revisit (1 agent)
+#### Wave 5: H20 + H12 joint revisit (1 agent) -- DONE 2026-04-21 via PR #496 (H12 REFUTED jointly)
 
-- [ ] T99.2.2.7 Upgrade ple_embed_tokens.weight to Q8 with ple_token_norm enabled
+- [x] T99.2.2.7 Upgrade ple_embed_tokens.weight to Q8 with ple_token_norm enabled
+
+#### Wave 6 (queued): H21 reference diff (1 agent)
+
+- [ ] T99.2.2.8 PLE RoPE / residual combine scale / plan-order reference diff
 
 ### E98 Risk Register
 


### PR DESCRIPTION
## Summary

- DGX 2x2 matrix for the H20 + H12 joint experiment: on main `7700621a`, Q4_K_M "The quick brown fox" 32 steps. Output is byte-invariant across the `ZERFOO_GEMMA4_PLE_EMBED_Q8` toggle: (a) baseline and (c) H12-only both produce `"lyes\nsn\nsn\nsn\nsn"`; (b) H20-only and (d) joint both produce `"sunnyo\n"`. The Q4->Q8 upgrade on `model.ple_embed_tokens.weight` has **zero effect** on the decode trajectory standalone or stacked on H20's tokenSlice RMSNorm. **H12 is refuted jointly; the quantization axis is cleared.**
- docs/devlog.md: new entry "T99.2.2.7 H12 + H20 joint DGX validation" with the matrix, the Q8-invariance finding, the decision, and the cumulative hypothesis status.
- docs/plan.md: T99.2.2.7 marked `[x]` with OUTCOME; T99.2.2.8 (H21 reference diff) added; Waves updated (Wave 5 DONE, Wave 6 queued).
- .claude-checkpoint.md: refresh for the sixth /apply session.

## Matrix

| # | `ZERFOO_GEMMA4_PLE_TOKEN_NORM` | `ZERFOO_GEMMA4_PLE_EMBED_Q8` | Decode   | Output                    | Bytes |
|---|---|---|---|---|---|
| a | (unset)                        | (unset)                      | 3.64 t/s | `"lyes\nsn\nsn\nsn\nsn"`  | 16    |
| b | `1`                            | (unset)                      | 4.27 t/s | `"sunnyo\n"`              | 7     |
| c | (unset)                        | `1`                          | 0.95 t/s | `"lyes\nsn\nsn\nsn\nsn"`  | 16    |
| d | `1`                            | `1`                          | 1.81 t/s | `"sunnyo\n"`              | 7     |

Q8 upgrade slows decode 3.8x (3.64 -> 0.95 t/s) because the table is ~2x larger and the Q8 gather kernel path is slower -- irrelevant for correctness.

## Decision

Per the T99.2.2.7 plan clause: (d) is still degenerate -> quantization axis cleared -> file T99.2.2.8 (H21) targeting PLE RoPE / per-layer scale / plan-order injection point.

## Test plan

- [x] DGX matrix executed from main `7700621a` binary (all 4 configs, 32 steps each).
- [x] Load-time logs confirm `ZERFOO_GEMMA4_PLE_EMBED_Q8=1` flag correctly routes `model.ple_embed_tokens.weight` through the Q4->Q8 upgrade (second "upgraded tensor" log line observed in (c) and (d) only).
- [x] No code or schema change in this PR -- documentation + checkpoint only.

## Linked tasks

- Closes T99.2.2.7 in docs/plan.md.
- Files T99.2.2.8 (H21 reference diff) as the next experiment.