### PR TITLE
docs: T99.2.2.8 H21 reference diff -- novel H21 filed as T99.2.2.9

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,155 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-04-21: T99.2.2.8 -- H21 reference diff (HF vs zerfoo PLE; structural candidate identified: Q4_K -> Q4_0 re-quantization in gather tables)
+
+**Type:** investigation
+**Tags:** gemma4e, decode, q4_k, q4_0, ple, ple_embed_tokens, h21, reference-diff
+
+### Setup
+
+- Main at `55c5b594` (T99.2.2.7 docs merged; Wave 5 closed with H12
+  refuted jointly, quantization axis cleared).
+- Task scope per T99.2.2.8: read the Gemma 4 Edge reference PLE
+  implementation, side-by-side diff against
+  `inference/gemma4_edge_ple_nodes.go` `pleSliceNode.Forward` and
+  `inference/arch_gemma4_edge.go` graph-order, emit a named deviation
+  list, and file the top structural candidate as T99.2.2.9.
+- Reference consulted: HuggingFace
+  `transformers/src/transformers/models/gemma4/modeling_gemma4.py`
+  `Gemma4TextModel`, `Gemma4TextDecoderLayer`, `Gemma4RMSNorm`,
+  `Gemma4TextScaledWordEmbedding`, `get_per_layer_inputs`,
+  `project_per_layer_inputs` (verbatim fetches of current HF main).
+
+### Named deviation list (HF reference <-> zerfoo)
+
+Every per-layer PLE forward operation was compared side-by-side. Only
+deviations are listed; matching ops (scale factors, residual bookkeeping,
+final norm, layer_scalar placement, GELU tanh approximation, bias-free
+linears, RMSNorm `normed * weight` semantics with `ones` init) are
+omitted. File/line pointers are zerfoo main `55c5b594`.
+
+- **D1 (cosmetic).** zerfoo applies `per_layer_model_projection_scale`
+  to `hidden` BEFORE the matmul (`hidden * 1/sqrt(hidden_size)` then
+  `MatMul(scaled, pleModelProj)`); HF applies it AFTER
+  (`per_layer_model_projection(inputs_embeds) * hidden_size**-0.5`).
+  Mathematically equivalent for a bias-free linear, bit-identical up to
+  float ordering. `inference/gemma4_edge_ple_nodes.go:206-212` vs HF
+  `Gemma4TextModel.project_per_layer_inputs`. Classification: cosmetic.
+
+- **D2 (cosmetic).** zerfoo slices the full-width `[B, S, 8960]` PLE
+  tensor per-layer and applies RMSNorm to each `[B, S, 256]` slice; HF
+  reshapes to `[B, S, num_layers, ple_dim]` and RMSNorms over the last
+  dim. Equivalent per-layer values because RMSNorm reduces over the
+  last dim in both cases. `gemma4_edge_ple_nodes.go:688-698` vs HF
+  `project_per_layer_inputs`. Classification: cosmetic.
+
+- **D3 (cosmetic).** zerfoo allocates a RoPE module per-layer
+  (`arch_gemma4_edge.go:277`); HF caches position embeddings once per
+  forward and indexes by `layer_type` (`Gemma4TextModel.forward`).
+  Same numerical output; a later perf win but not correctness.
+  Classification: cosmetic.
+
+- **D4 (structural, top candidate).** zerfoo's GGUF loader re-quantizes
+  every Q4_K tensor to Q4_0 at load time via
+  `model/gguf/loader.go:223` `decodeQ4KTensor`:
+  ```go
+  q4k.Dequantize(f32)
+  q4 := tensor.QuantizeQ4(f32)
+  ```
+  This round-trip is UNCONDITIONAL, regardless of whether the tensor
+  is used for GEMV (where Q4_0's block_size=32 layout speeds decode)
+  or GATHER (where block format is irrelevant). The Q8_0 decoder at
+  `decodeQ8Tensor` (line 398-417) guards the re-quantization with
+  `isEmbedding := shape[0] > 50000` and keeps Q8 native for embedding
+  tables, but `decodeQ4KTensor`, `decodeQ5KTensor`, `decodeQ6KTensor`
+  have NO such guard. For `model.ple_embed_tokens.weight` (shape
+  `[262144, 8960]`, a pure gather target on the PLE tokenSlice path),
+  this yields a doubly-lossy `Q4_K -> f32 -> Q4_0` conversion:
+    * Q4_K noise: 6-bit sub-scales over 256-element super-blocks.
+    * Q4_0 noise: f16 scale per 32-element block, independent.
+    * The two errors STACK; Q4_0 alone would be 20-30% higher RMSE
+      than Q4_K, and the round-trip adds a second quantization step
+      on top.
+  Unsloth's documentation (https://unsloth.ai/docs/models/gemma-4)
+  explicitly calls this out: "The per_layer_token_embd layer should
+  be Q8_0 in precision... Q4_0, Q4_1, Q5_0, and Q5_1 have been
+  confirmed to work in Ollama" -- i.e., a NATIVE Q4_0 embedding table
+  works, but not a doubly-lossy round-trip. Ollama consumes the
+  shipped Q4_K_M file as-is (Q4_K for ple_embed_tokens stays Q4_K);
+  zerfoo silently degrades to Q4_0 at load. This matches the H17
+  L2 evidence of uniform Q4 gather noise (p100/p50 = 1.49x, no outlier
+  rows) and explains why H12 (Q4_0 -> Q8 at the `upgradeEmbeddingPrecision`
+  step) was refuted: by the time `upgradeEmbeddingPrecision` runs, the
+  tensor is already a degraded Q4_0 tensor; re-quantizing Q4_0 to Q8
+  preserves the loss. Classification: **structural, top fix candidate**.
+
+- **D5 (numerical-scale; secondary).** `model.ple_model_proj.weight`
+  ships as BFloat16 in the E2B GGUF (devlog 2026-04-21 T99.2.2
+  storage-type diagnostic, line 437: `*BFloat16Storage [8960, 1536]`).
+  `transposeWeight2D` dequantizes BF16 to F32 via `engine.Transpose`
+  (no BF16-specialized case). H13 refuted BF16 as the cause by
+  comparing against a fully-F32 run. Still listed here for completeness;
+  cleared on prior evidence. Classification: numerical-scale, cleared.
+
+### Items explicitly verified as matching HF
+
+- Main `inputs_embeds = embed_tokens(ids) * sqrt(hidden_size)`
+  (`arch_gemma4_edge.go:135-137`).
+- Token-identity PLE scaled by `sqrt(hidden_size_per_layer_input)=16`
+  via `Gemma4TextScaledWordEmbedding(..., embed_scale=sqrt(256))`
+  (`gemma4_edge_ple_nodes.go:194-199`).
+- `per_layer_input_scale = 1/sqrt(2)` applied to `(projNormed + tokenSlice)`
+  (`gemma4_edge_ple_nodes.go:732-736`).
+- Per-layer PLE sub-block order exactly matches HF
+  `Gemma4TextDecoderLayer.forward` lines 1401-1408:
+  `residual; inp_gate; act_fn; * per_layer_input; per_layer_projection;
+  post_per_layer_input_norm; residual + ple_output`.
+- `layer_output_scale` / `layer_scalar` applied at the very end of the
+  decoder block, after PLE residual add (`arch_gemma4_edge.go:509`).
+- Final `self.norm` / `RMSNormFromParam(model.norm.weight)` applied
+  after the layer loop (`arch_gemma4_edge.go:513-519`).
+- `Gemma4RMSNorm` uses `normed * weight` (NOT `(1 + weight)`, despite
+  the folklore); weight init is `ones`. zerfoo standard RMSNorm matches.
+- `embed_tokens_per_layer` uses `vocab_size_per_layer_input`; the
+  unsloth E2B GGUF `per_layer_token_embd.weight` has shape
+  `[8960, 262144]` confirming full vocab == vocab_size_per_layer_input.
+- Layer-major packing of PLE slices within the `num_layers * ple_dim`
+  flat last-dim: HF reshape and zerfoo `[:, :, N*256:(N+1)*256]` slice
+  both assume layer 0's 256 values come first. Preserved by the GGUF
+  converter.
+- GELU is tanh-approximate in both (`layers/activations/gelu.go:47` =
+  `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))`, matching
+  `F.gelu(x, approximate='tanh')` aka `gelu_pytorch_tanh`).
+- FFN is `down(gelu(gate(x)) * up(x))`, bias-free, matching HF
+  `Gemma4TextMLP`.
+
+### Conclusion
+
+The zerfoo PLE forward pass is **structurally faithful to the HF
+reference** at the math level. No HF-vs-zerfoo deviation explains the
+bug. The top structural deviation is NOT against HF but against zerfoo's
+own Q8_0 decoder policy: `decodeQ4KTensor` is missing the
+`isEmbedding` guard that `decodeQ8Tensor` applies. For a Gemma 4 E2B
+Q4_K_M GGUF, this silently demotes `model.ple_embed_tokens.weight`
+from Q4_K to Q4_0 at load, and the Q4_0 gather noise compounds across
+35 layers on the PLE tokenSlice path.
+
+### Next step -- T99.2.2.9 (H21 fix candidate)
+
+Gate a new flag `ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1`: when set, make
+`decodeQ4KTensor` (and, for symmetry, `decodeQ5KTensor`,
+`decodeQ6KTensor`) skip the re-quantization for embedding-shaped
+tensors (`shape[0] > 50000`) or for a tight allowlist of tensor names
+(`model.ple_embed_tokens.weight`, `model.embed_tokens.weight`,
+`lm_head.weight`). A/B test on DGX:
+- Baseline unset: Q4_K -> Q4_0 (current, degenerate).
+- Flag set: Q4_K native, no loss beyond the original Q4_K quantization.
+If the flag produces coherent decode, the patch becomes unconditional
+for embedding-shaped Q4_K tensors (the same policy Q8_0 already has).
+
+---
+
 ## 2026-04-21: T99.2.2.7 -- H12 + H20 joint DGX validation (H12 REFUTED, H20 replicated; bug OFF the quantization axis)
 
 **Type:** investigation

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2095,51 +2095,124 @@ the capture-compatibility work in E99.1. Neither is caused by T99.1.2
     hypothesis (H21: PLE RoPE / residual combine scale / plan-order
     reference diff). See devlog 2026-04-21 T99.2.2.7.
 
-  - [ ] T99.2.2.8 H21 diagnostic: PLE RoPE / residual combine scale / plan-order reference diff
-    Owner: TBD  Est: 120m  verifies: [UC-001]  Deps: T99.2.2.7
-    Motivation. T99.2.2.7 cleared the quantization axis: Q4_0 gather
-    noise on `ple_embed_tokens.weight` has no measurable effect on
-    the decode trajectory under greedy sampling, even when combined
-    with the tokenSlice RMSNorm (H20). The bug vector runs through
-    the PLE branch (H16 confirmed, H19 confirmed both sub-paths) but
-    is structural rather than numerical. Remaining candidate loci:
-      H21.a PLE RoPE / positional handling — the pleSliceNode uses
-            a gather-then-scale path; if the positions / theta
-            schedule differ from the main attention RoPE, positional
-            drift compounds across 35 layers.
-      H21.b Residual combine scale — `Add(projNormed, tokenSlice)`
-            is unweighted; the Gemma 4 Edge reference may apply a
-            per-layer scale that we are dropping.
-      H21.c Plan-order / injection point — the PLE slice may be
-            injected into the residual at the wrong position in the
-            per-layer forward pass vs. the reference Python forward.
+  - [x] T99.2.2.8 H21 diagnostic: PLE RoPE / residual combine scale / plan-order reference diff (SHIPPED 2026-04-21; zerfoo PLE faithful to HF; top structural candidate is Q4_K -> Q4_0 re-quantization on gather tables -> T99.2.2.9 filed)
+    Owner: main  Est: 120m  verifies: [UC-001]  Deps: T99.2.2.7
+    OUTCOME 2026-04-21. Completed side-by-side diff against
+    HuggingFace `transformers/src/transformers/models/gemma4/modeling_gemma4.py`
+    (`Gemma4TextModel`, `Gemma4TextDecoderLayer`, `Gemma4RMSNorm`,
+    `Gemma4TextScaledWordEmbedding`, `get_per_layer_inputs`,
+    `project_per_layer_inputs`) at HF main. Results:
+      - H21.a (PLE RoPE / positional handling): REFUTED. The PLE
+        path has NO RoPE -- the slice is a pure gather scaled by
+        `sqrt(pleDim)=16` plus a projection RMSNorm, with no
+        position dependence. zerfoo matches HF.
+      - H21.b (residual combine scale): REFUTED. HF combines
+        `(per_layer_projection + per_layer_inputs) * per_layer_input_scale`
+        with `per_layer_input_scale = 1/sqrt(2)`; zerfoo applies
+        `(projNormed + tokenSlice) * 1/sqrt(2)` at
+        `inference/gemma4_edge_ple_nodes.go:732-736`. Identical.
+      - H21.c (plan-order / injection point): REFUTED. HF
+        `Gemma4TextDecoderLayer.forward` PLE block order is
+        `residual; inp_gate; act_fn; * per_layer_input;
+        per_layer_projection; post_per_layer_input_norm;
+        residual + ple_output` followed by `hidden_states *=
+        self.layer_scalar`. zerfoo `arch_gemma4_edge.go:475-509`
+        emits `inpGate -> GELU -> * pleSlice -> pleLayerProj ->
+        post_layernorm -> + afterFFN -> layer_output_scale`.
+        Identical order.
+      - **Novel H21 (structural, ranks first).** zerfoo-vs-zerfoo:
+        `model/gguf/loader.go:223` `decodeQ4KTensor` unconditionally
+        re-quantizes every Q4_K tensor to Q4_0 via a lossy
+        `Q4_K -> f32 -> Q4_0` round-trip, but the Q8_0 decoder at
+        `decodeQ8Tensor` (line 398-417) already guards the
+        re-quant with `isEmbedding := shape[0] > 50000` and keeps
+        Q8 native for embedding tables. `decodeQ4KTensor`,
+        `decodeQ5KTensor`, and `decodeQ6KTensor` have NO such
+        guard. For `model.ple_embed_tokens.weight` (shape
+        `[262144, 8960]`, pure gather target), this demotes the
+        Q4_K file tensor to Q4_0 at load. The Q4_0 gather noise
+        compounds uniformly across 35 layers on the PLE
+        tokenSlice path -- matching the H17 evidence of
+        uniform per-row noise (p100/p50 = 1.49x, no outlier rows).
+        It also explains why T99.2.2.7 `ZERFOO_GEMMA4_PLE_EMBED_Q8`
+        was refuted: the `upgradeEmbeddingPrecision` step runs
+        AFTER `decodeQ4KTensor`, so the Q4_0 -> Q8 upgrade
+        preserves the Q4_K -> Q4_0 loss instead of recovering
+        from it. Unsloth's Gemma 4 documentation independently
+        confirms `per_layer_token_embd` needs Q8_0 precision (or
+        a native lower-precision quant like Q4_0 / Q4_1 / Q5_0 /
+        Q5_1 -- NOT a doubly-lossy round-trip).
+      - All other per-layer PLE operations match HF (embed scale
+        `sqrt(hidden)`, token-identity scale `sqrt(pleDim)=16`,
+        projection scale `hidden**-0.5`, RMSNorm `normed * weight`
+        with weight init `ones`, GELU tanh approximation,
+        bias-free linears, FFN `down(gelu(gate(x)) * up(x))`,
+        final `Gemma4RMSNorm` after the layer loop,
+        `layer_output_scale` at the very end of each decoder
+        layer).
+    Decision rule. Exactly one structural deviation emerged
+    (novel H21). T99.2.2.9 filed below as the H21 fix candidate,
+    gated behind `ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1` for DGX A/B.
+    See `docs/devlog.md` 2026-04-21 T99.2.2.8 entry.
+
+  - [ ] T99.2.2.9 H21 fix candidate: keep native Q4_K storage for embedding-shaped tensors in the GGUF loader
+    Owner: TBD  Est: 120m  verifies: [UC-001]  Deps: T99.2.2.8
+    Motivation. T99.2.2.8 identified that zerfoo's
+    `model/gguf/loader.go:223` `decodeQ4KTensor` re-quantizes
+    every Q4_K tensor to Q4_0 at load time via a lossy round-trip,
+    while the parallel Q8_0 decoder already guards embeddings
+    (`shape[0] > 50000`) and keeps Q8 native. For the Gemma 4
+    E2B/E4B Q4_K_M GGUFs, this silently degrades
+    `model.ple_embed_tokens.weight` (pure gather target) from
+    Q4_K to Q4_0, and the Q4_0 gather noise compounds across 35
+    layers on the PLE tokenSlice path. T99.2.2.7's
+    `upgradeEmbeddingPrecision` Q8 upgrade cannot recover because
+    it runs AFTER the round-trip. Unsloth's docs confirm
+    `per_layer_token_embd` needs at least Q8_0 precision, or a
+    native simpler quant (Q4_0, Q4_1, Q5_0, Q5_1) -- not a
+    doubly-lossy conversion.
     Approach.
-      1. Read the Gemma 4 Edge reference PLE implementation (the
-         Python / flax or transformers-style reference that
-         `docs/plan.md` E99.2 or earlier E-blocks cite). Extract the
-         exact per-layer PLE forward pass: gather, scale, any RoPE,
-         any per-layer gain, residual injection point.
-      2. Side-by-side with `inference/gemma4_edge_ple_nodes.go`
-         `pleSliceNode.Forward` and the graph-order in
-         `inference/arch_gemma4_edge.go`, produce a named list of
-         deviations.
-      3. For each deviation, classify as (i) cosmetic / symmetric
-         (unlikely bug), (ii) numerical-scale only (should have
-         been caught by H17 uniform noise test), (iii) structural
-         / position / ordering (top suspicion).
-      4. Write a devlog entry listing the deviation set and
-         prioritizing the candidate fix. If exactly one structural
-         deviation emerges, file T99.2.2.9 as the fix candidate and
-         gate behind `ZERFOO_GEMMA4_PLE_*` to A/B on DGX. If no
-         deviation emerges, escalate: the bug may be outside PLE
-         (unlikely given H16/H19) or the reference being consulted
-         is not the one Google actually trained against, in which
-         case the reference itself becomes the blocker.
+      1. Add a flag-gated guard in `model/gguf/loader.go`
+         `decodeQ4KTensor` (and symmetrically `decodeQ5KTensor`,
+         `decodeQ6KTensor`) that, when `ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1`,
+         skips the `Dequantize -> QuantizeQ4` round-trip for
+         embedding-shaped tensors (`len(shape) == 2 && shape[0] > 50000`)
+         and returns native `Q4KStorage` / `Q5KStorage` / `Q6KStorage`
+         via the existing `decodeTensorNative` helper.
+      2. Confirm native Q4_K storage supports the gather paths
+         used by `pleCombinedProducer` (it already does -- H17 used
+         the same native dequant helper for its per-row diff).
+      3. Build on DGX; run the 2x4 matrix (Q4_K_M x
+         {PLE_NATIVE_Q4K=0, PLE_NATIVE_Q4K=1} x
+         {PLE_EMBED_Q8=0, PLE_EMBED_Q8=1}) on the `"The quick
+         brown fox"` 32-step greedy trajectory.
+      4. Decision rule:
+         - If `PLE_NATIVE_Q4K=1` alone produces coherent decode,
+           H21 is confirmed; promote the guard to unconditional
+           (remove the flag) and file the Q5_K / Q6_K symmetry
+           fixes in a follow-up ADR.
+         - If `PLE_NATIVE_Q4K=1` still degenerate but
+           `PLE_NATIVE_Q4K=1 + PLE_EMBED_Q8=1` recovers, the
+           cumulative Q4_K gather noise itself (not the Q4_0
+           downgrade) is the issue -- requires a separate ADR on
+           embedding-table precision policy for edge models.
+         - If both fail, H21 is refuted; escalate to checking the
+           `model.ple_model_proj.weight` BFloat16 -> F32 path
+           (H13, cleared on prior evidence but worth re-testing
+           with native-K gather) and/or a byte-level trace diff
+           against Ollama on the same file.
     Artifacts.
-      - `docs/devlog.md` entry "T99.2.2.8 H21 reference diff".
-      - Named deviation list, with graph-code pointers.
-      - If a fix candidate emerges: T99.2.2.9 task + ZERFOO_GEMMA4_PLE_*
-        gate.
+      - `model/gguf/loader.go` patch adding the embedding-shape
+        guard under `ZERFOO_GEMMA4_PLE_NATIVE_Q4K`.
+      - `model/gguf/loader_test.go` table-driven test proving the
+        guard keeps native `*Q4KStorage` for a
+        `shape[0] > 50000` tensor when the flag is set, and still
+        re-quantizes to `*Q4Storage` when unset.
+      - `docs/devlog.md` entry "T99.2.2.9 H21 native-Q4K
+        A/B DGX results" with the 2x2 / 2x4 matrix.
+      - If H21 is confirmed: ADR-089 `gguf-embedding-precision-policy.md`
+        documenting the unified embedding-shape guard across
+        Q4_K / Q5_K / Q6_K / Q8_0 decoders.
 
 ### T99.2.2 Next-Session Waves
 
@@ -2170,9 +2243,13 @@ assuming no surprises.
 
 - [x] T99.2.2.7 Upgrade ple_embed_tokens.weight to Q8 with ple_token_norm enabled
 
-#### Wave 6 (queued): H21 reference diff (1 agent)
+#### Wave 6: H21 reference diff (1 agent) -- DONE 2026-04-21 (docs-only; no code change; novel H21 filed as T99.2.2.9)
 
-- [ ] T99.2.2.8 PLE RoPE / residual combine scale / plan-order reference diff
+- [x] T99.2.2.8 PLE RoPE / residual combine scale / plan-order reference diff
+
+#### Wave 7 (queued): H21 fix candidate -- native Q4_K embedding storage (1 agent)
+
+- [ ] T99.2.2.9 Keep native Q4_K storage for embedding-shaped tensors in the GGUF loader (gated by `ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1`)
 
 ### E98 Risk Register
 


### PR DESCRIPTION
## Summary

- **T99.2.2.8 complete.** Side-by-side diff of zerfoo's Gemma 4 Edge PLE forward pass vs the HuggingFace transformers Gemma4 reference (`modeling_gemma4.py` at HF main: `Gemma4TextModel`, `Gemma4TextDecoderLayer`, `Gemma4RMSNorm`, `Gemma4TextScaledWordEmbedding`, `get_per_layer_inputs`, `project_per_layer_inputs`).
- **H21.a/b/c all refuted by direct diff.** PLE RoPE (not present), residual combine scale (both `(projNormed + tokenSlice) * 1/sqrt(2)`), and plan-order (`residual; inp_gate; act_fn; * per_layer_input; per_layer_projection; post_per_layer_input_norm; residual + ple_output; *= layer_scalar`) match HF exactly.
- **Novel H21 (structural, ranks first):** `model/gguf/loader.go:223` `decodeQ4KTensor` unconditionally re-quantizes Q4_K → Q4_0 at load time, but the parallel `decodeQ8Tensor` (line 398-417) already guards embeddings with `isEmbedding := shape[0] > 50000` and keeps Q8 native. For `model.ple_embed_tokens.weight` (shape `[262144, 8960]`, a pure gather target on the PLE tokenSlice path), this silently demotes Q4_K → Q4_0 at load. Q4_0 gather noise compounds across 35 PLE layers — matching H17's uniform-noise evidence and explaining why T99.2.2.7's `ZERFOO_GEMMA4_PLE_EMBED_Q8` was refuted (the upgrade runs AFTER the Q4_0 demotion).
- **T99.2.2.9 filed.** H21 fix candidate: gate `ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1` to skip the Q4_K → Q4_0 round-trip for embedding-shaped tensors in `decodeQ4KTensor` / `decodeQ5KTensor` / `decodeQ6KTensor`, mirroring the existing Q8_0 policy.

Unsloth's Gemma 4 documentation independently confirms `per_layer_token_embd` needs at least Q8_0 precision or a native lower-precision quant (Q4_0 / Q4_1 / Q5_0 / Q5_1) — not a doubly-lossy round-trip.

**All other per-layer PLE ops verified faithful to HF** (embed scale `sqrt(hidden_size)`, token-identity scale `sqrt(pleDim)=16`, projection scale `hidden**-0.5`, RMSNorm `normed * weight` with weight init `ones`, tanh-approx GELU, bias-free linears, FFN `down(gelu(gate(x)) * up(x))`, final `Gemma4RMSNorm`, `layer_output_scale` at the end of the decoder).

## Changes

- `docs/devlog.md`: new entry "2026-04-21 T99.2.2.8 -- H21 reference diff" with the deviation list, classification, and the novel H21 finding.
- `docs/plan.md`: mark T99.2.2.8 `[x]` with OUTCOME block; add T99.2.2.9 as the fix candidate task; promote Wave 6 to DONE, queue Wave 7.

No code changes in this patch — docs-only.

## Linked Issues

Closes T99.2.2.8 (part of T99.2.2 epic).

## Test plan

- [x] `go build ./...` passes (no code change).
- [ ] `go test ./inference/... -race -timeout 300s` -- not run (docs-only).
- [ ] DGX validation is scheduled under T99.2.2.9 (H21 A/B with `ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1`).