### PR TITLE
feat(gguf): T99.2.2.9 H21 -- native Q4_K/Q5_K/Q6_K for embedding tensors

### DIFF
--- a/model/gguf/loader.go
+++ b/model/gguf/loader.go
@@ -6,11 +6,41 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"os"
 	"strings"
 
 	"github.com/zerfoo/float16"
 	"github.com/zerfoo/ztensor/tensor"
 )
+
+// embeddingVocabThreshold is the vocab-dimension floor used to classify a 2D
+// tensor as an embedding table. Mirrors the existing Q8_0 embedding guard in
+// decodeQ8Tensor; Gemma 4 Edge uses 262144 (per_layer_token_embd) and 256000
+// (token_embd), both well above 50000, while ordinary weight matrices stay
+// under 50000 on production transformer shapes.
+const embeddingVocabThreshold = 50000
+
+// isEmbeddingShape reports whether a tensor's shape looks like a 2D embedding
+// lookup table (shape[0] is the vocab dimension).
+func isEmbeddingShape(shape []int) bool {
+	return len(shape) == 2 && shape[0] > embeddingVocabThreshold
+}
+
+// pleNativeKQuantEnabled reports whether ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1 is set.
+// When enabled, Q4_K / Q5_K / Q6_K embedding-shaped tensors keep their native
+// K-quant storage instead of being re-quantized to Q4_0 at load time.
+//
+// Motivation (T99.2.2.9 / H21). The default decode path for K-quant tensors
+// takes a lossy round-trip: raw bytes -> K-quant storage -> f32 -> Q4_0
+// storage. For weight matrices this is fine — the GEMV kernels need the Q4_0
+// layout. For gather targets like `model.ple_embed_tokens.weight` (Gemma 4
+// Edge Q4_K_M), the doubly-lossy conversion compounds per-row noise across
+// the 35 PLE layers and was identified as the top structural candidate for
+// the T99.2.2 PLE-decode degeneracy bug. This flag gates the fix so it can
+// be A/B'd on DGX before being promoted.
+func pleNativeKQuantEnabled() bool {
+	return os.Getenv("ZERFOO_GEMMA4_PLE_NATIVE_Q4K") == "1"
+}
 
 // LoadTensors reads tensor data from a parsed GGUF file and returns them as
 // float32 tensors keyed by name. Quantized tensors (Q4_0, Q8_0) are stored
@@ -225,6 +255,13 @@ func decodeQ4KTensor(shape []int, numElements int, raw []byte) (*tensor.TensorNu
 	if err != nil {
 		return nil, fmt.Errorf("Q4_K decode: %w", err)
 	}
+	// T99.2.2.9 H21 guard: for embedding-shaped tensors, keep native Q4_K
+	// storage when ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1. Avoids the lossy
+	// Q4_K -> f32 -> Q4_0 round-trip for gather targets such as
+	// model.ple_embed_tokens.weight.
+	if pleNativeKQuantEnabled() && isEmbeddingShape(shape) {
+		return tensor.NewWithStorage[float32](shape, q4k)
+	}
 	// Re-quantize Q4_K → Q4_0 for uniform fast GEMV decode path.
 	// Q4_0 block_size=32 works with any hidden_size divisible by 32 (all models).
 	// Q4_K block_size=256 fails when hidden_size%256!=0 (e.g., Gemma3-1B=1152).
@@ -240,6 +277,12 @@ func decodeQ5KTensor(shape []int, numElements int, raw []byte) (*tensor.TensorNu
 	if err != nil {
 		return nil, fmt.Errorf("Q5_K decode: %w", err)
 	}
+	// T99.2.2.9 H21 guard: symmetric with decodeQ4KTensor. Kept behind the
+	// same flag so Q5_K_M / Q6_K_M GGUF variants of the same family inherit
+	// the embedding-precision fix.
+	if pleNativeKQuantEnabled() && isEmbeddingShape(shape) {
+		return tensor.NewWithStorage[float32](shape, q5k)
+	}
 	f32 := make([]float32, numElements)
 	q5k.Dequantize(f32)
 	q4 := tensor.QuantizeQ4(f32)
@@ -250,6 +293,10 @@ func decodeQ6KTensor(shape []int, numElements int, raw []byte) (*tensor.TensorNu
 	q6k, err := tensor.NewQ6KStorageFromRaw(raw, numElements)
 	if err != nil {
 		return nil, fmt.Errorf("Q6_K decode: %w", err)
+	}
+	// T99.2.2.9 H21 guard: see decodeQ4KTensor.
+	if pleNativeKQuantEnabled() && isEmbeddingShape(shape) {
+		return tensor.NewWithStorage[float32](shape, q6k)
 	}
 	f32 := make([]float32, numElements)
 	q6k.Dequantize(f32)

--- a/model/gguf/loader_test.go
+++ b/model/gguf/loader_test.go
@@ -1914,3 +1914,201 @@ func clampTestInt(v, lo, hi int) int {
 	}
 	return v
 }
+
+// TestDecodeKQuant_NativeEmbeddingGuard exercises the T99.2.2.9 / H21 guard:
+// when ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1 AND the tensor is 2D with shape[0] above
+// the embedding-vocab threshold (>50000), decodeQ4KTensor / decodeQ5KTensor /
+// decodeQ6KTensor must return native *Q4KStorage / *Q5KStorage / *Q6KStorage
+// instead of re-quantizing to *Q4Storage. With the flag unset, all three must
+// fall back to the existing Q4_0 path; non-embedding shapes must re-quantize
+// regardless of the flag.
+//
+// Motivation: the default decoders take a lossy round-trip
+// (K-quant -> f32 -> Q4_0) that degrades embedding gather tables on the
+// Gemma 4 Edge PLE path. See docs/plan.md T99.2.2.9 and docs/devlog.md H21.
+func TestDecodeKQuant_NativeEmbeddingGuard(t *testing.T) {
+	// Embedding-shape tensor: 2D with shape[0] = 50176 (> 50000) and 256 total
+	// elements per row chosen so numElements is a multiple of 256 for K-quant
+	// block alignment. Small shape[1] keeps raw block allocation modest.
+	const embedVocab = 50176
+	const embedDim = 2
+	const embedElements = embedVocab * embedDim // 100352 = 392 * 256
+
+	// Non-embedding shape: 2D with shape[0] below threshold. Same numElements
+	// so we can reuse the same raw buffer per type.
+	const nonEmbedRows = 1024
+	const nonEmbedCols = embedElements / nonEmbedRows // 98
+
+	type decoder func(shape []int, n int, raw []byte) (*tensor.TensorNumeric[float32], error)
+
+	type kind struct {
+		name       string
+		decode     decoder
+		blockBytes int
+		// isNativeStorage returns true if the tensor's storage is the native
+		// K-quant type (as opposed to the re-quantized *Q4Storage).
+		isNativeStorage func(t *tensor.TensorNumeric[float32]) bool
+	}
+
+	kinds := []kind{
+		{
+			name:       "Q4_K",
+			decode:     decodeQ4KTensor,
+			blockBytes: 144,
+			isNativeStorage: func(tn *tensor.TensorNumeric[float32]) bool {
+				_, ok := tn.GetStorage().(*tensor.Q4KStorage)
+				return ok
+			},
+		},
+		{
+			name:       "Q5_K",
+			decode:     decodeQ5KTensor,
+			blockBytes: 176,
+			isNativeStorage: func(tn *tensor.TensorNumeric[float32]) bool {
+				_, ok := tn.GetStorage().(*tensor.Q5KStorage)
+				return ok
+			},
+		},
+		{
+			name:       "Q6_K",
+			decode:     decodeQ6KTensor,
+			blockBytes: 210,
+			isNativeStorage: func(tn *tensor.TensorNumeric[float32]) bool {
+				_, ok := tn.GetStorage().(*tensor.Q6KStorage)
+				return ok
+			},
+		},
+	}
+
+	type scenario struct {
+		name       string
+		shape      []int
+		flag       string // value for ZERFOO_GEMMA4_PLE_NATIVE_Q4K ("" = unset)
+		wantNative bool
+	}
+
+	scenarios := []scenario{
+		{
+			name:       "flag-off-embedding-shape-rewrites-to-Q4",
+			shape:      []int{embedVocab, embedDim},
+			flag:       "",
+			wantNative: false,
+		},
+		{
+			name:       "flag-on-embedding-shape-keeps-native",
+			shape:      []int{embedVocab, embedDim},
+			flag:       "1",
+			wantNative: true,
+		},
+		{
+			name:       "flag-on-non-embedding-shape-still-rewrites-to-Q4",
+			shape:      []int{nonEmbedRows, nonEmbedCols},
+			flag:       "1",
+			wantNative: false,
+		},
+		{
+			name:       "flag-on-1D-shape-still-rewrites-to-Q4",
+			shape:      []int{embedElements},
+			flag:       "1",
+			wantNative: false,
+		},
+		// Any other truthy-looking value is treated as unset (strict "1" check).
+		{
+			name:       "flag-true-string-not-recognized-rewrites-to-Q4",
+			shape:      []int{embedVocab, embedDim},
+			flag:       "true",
+			wantNative: false,
+		},
+	}
+
+	for _, k := range kinds {
+		nBlocks := (embedElements + 255) / 256
+		raw := make([]byte, nBlocks*k.blockBytes) // zero-filled: a valid block.
+
+		for _, sc := range scenarios {
+			t.Run(k.name+"/"+sc.name, func(t *testing.T) {
+				t.Setenv("ZERFOO_GEMMA4_PLE_NATIVE_Q4K", sc.flag)
+
+				tn, err := k.decode(sc.shape, embedElements, raw)
+				if err != nil {
+					t.Fatalf("%s decode: %v", k.name, err)
+				}
+				if tn == nil {
+					t.Fatalf("%s decode returned nil tensor", k.name)
+				}
+
+				// Shape must be preserved regardless of branch taken.
+				got := tn.Shape()
+				if len(got) != len(sc.shape) {
+					t.Fatalf("shape rank = %d, want %d", len(got), len(sc.shape))
+				}
+				for i := range sc.shape {
+					if got[i] != sc.shape[i] {
+						t.Fatalf("shape[%d] = %d, want %d", i, got[i], sc.shape[i])
+					}
+				}
+
+				native := k.isNativeStorage(tn)
+				_, isQ4 := tn.GetStorage().(*tensor.Q4Storage)
+
+				switch {
+				case sc.wantNative && !native:
+					t.Fatalf("storage = %T, want native (e.g., *Q%sStorage)",
+						tn.GetStorage(), k.name)
+				case !sc.wantNative && !isQ4:
+					t.Fatalf("storage = %T, want *tensor.Q4Storage "+
+						"(re-quantized %s->Q4_0 default path)",
+						tn.GetStorage(), k.name)
+				}
+			})
+		}
+	}
+}
+
+// TestPLENativeKQuantEnabled checks the env-var helper is strictly "1".
+func TestPLENativeKQuantEnabled(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"1", true},
+		{"true", false},
+		{"yes", false},
+		{" 1 ", false}, // whitespace is not trimmed
+	}
+	for _, c := range cases {
+		t.Run("val="+c.val, func(t *testing.T) {
+			t.Setenv("ZERFOO_GEMMA4_PLE_NATIVE_Q4K", c.val)
+			if got := pleNativeKQuantEnabled(); got != c.want {
+				t.Fatalf("pleNativeKQuantEnabled()=%v, want %v (val=%q)",
+					got, c.want, c.val)
+			}
+		})
+	}
+}
+
+// TestIsEmbeddingShape validates the shape classifier used by the guard.
+func TestIsEmbeddingShape(t *testing.T) {
+	cases := []struct {
+		name  string
+		shape []int
+		want  bool
+	}{
+		{"2D-vocab-above-threshold", []int{262144, 8960}, true},
+		{"2D-vocab-at-threshold+1", []int{50001, 1}, true},
+		{"2D-vocab-at-threshold", []int{50000, 256}, false},
+		{"2D-vocab-below-threshold", []int{49999, 4096}, false},
+		{"1D-even-if-large", []int{262144}, false},
+		{"3D-even-if-large-first", []int{262144, 4, 4}, false},
+		{"empty-shape", []int{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isEmbeddingShape(c.shape); got != c.want {
+				t.Fatalf("isEmbeddingShape(%v)=%v, want %v", c.shape, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a flag-gated guard in `model/gguf/loader.go` `decodeQ4KTensor`,
`decodeQ5KTensor`, and `decodeQ6KTensor`. When
`ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1` **and** the tensor is 2D with
`shape[0] > 50000`, the decoder skips the lossy
`K-quant -> f32 -> Q4_0` re-quantization round-trip and returns
native `*Q4KStorage` / `*Q5KStorage` / `*Q6KStorage`. Mirrors the
existing `shape[0] > 50000` embedding guard in `decodeQ8Tensor`
(loader.go line 402).

**Default behavior is unchanged** -- the flag is off by default,
so all existing K-quant tensors still get re-quantized to Q4_0.

## Motivation (T99.2.2.9 / H21)

T99.2.2.8 (PR #498, merged as `34a98318`) identified that the
unconditional Q4_K -> Q4_0 round-trip silently degrades
`model.ple_embed_tokens.weight` (shape `[262144, 8960]`, a pure
gather target on the Gemma 4 Edge PLE tokenSlice path). The Q4_0
gather noise compounds uniformly across 35 PLE layers, which
matches H17's evidence profile (uniform `p100/p50 ~ 1.49x`, no
outlier rows) and explains why T99.2.2.7's
`ZERFOO_GEMMA4_PLE_EMBED_Q8` upgrade was refuted -- the Q8
upgrade runs **after** the Q4_0 demotion, so it just preserves
already-degraded values.

Unsloth's Gemma 4 documentation independently states that
`per_layer_token_embd` requires Q8_0 precision or a native
lower-precision quant (Q4_0, Q4_1, Q5_0, Q5_1) -- **not** a
doubly-lossy `Q4_K -> Q4_0` conversion.

See `docs/plan.md` T99.2.2.9 and `docs/devlog.md` H21 entry for
the full chain of refuted hypotheses that led here.

## What this PR ships

| File | Change |
|---|---|
| `model/gguf/loader.go` | `isEmbeddingShape`, `pleNativeKQuantEnabled`, and guards in `decodeQ4KTensor` / `decodeQ5KTensor` / `decodeQ6KTensor`. |
| `model/gguf/loader_test.go` | `TestDecodeKQuant_NativeEmbeddingGuard` (table-driven: 3 kinds x 5 scenarios), `TestPLENativeKQuantEnabled`, `TestIsEmbeddingShape`. |

## Not in this PR (explicit scope fence)

- **DGX A/B validation.** The 2x4 matrix
  `{PLE_NATIVE_Q4K=0,1} x {PLE_EMBED_Q8=0,1}` on the
  `"The quick brown fox"` 32-step greedy trajectory is a
  separate task that requires DGX access and a running
  gemma4_e2e binary. That is the T99.2.2.9 outcome step and will
  be reported in `docs/devlog.md` when complete.
- **ADR-089 `gguf-embedding-precision-policy.md`** -- will be
  filed only after the DGX A/B confirms the fix. If confirmed,
  the flag will be promoted to unconditional in a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -timeout 180s ./model/gguf/...` (PASS, 2.1s)
- [x] `go test -race -timeout 300s -count=1 ./inference/... ./model/...` (PASS, 55s inference)
- [x] New tests exercise all five scenarios: flag-off-embedding,
      flag-on-embedding, flag-on-non-embedding 2D, flag-on-1D,
      flag-on-unknown-truthy-string.
- [ ] DGX A/B 2x4 matrix on Q4_K_M model (separate task, requires
      gemma4_e2e rebuild + Spark submission).

Refs T99.2.2.9; addresses T99.2.2 epic novel H21 (structural).