### PR TITLE
chore(release): pin next release to v1.49.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "go",
+      "release-as": "1.49.0",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Forces release-please to cut v1.49.0 instead of v4.0.0. The crossasset breaking-change footers reflect an internal package extraction to feza-ai/wolf, not a public API break.