### PR TITLE
chore(release): anchor release-please at v1.48.0 commit

### DIFF
--- a/model/gguf/loader.go
+++ b/model/gguf/loader.go
@@ -446,8 +446,7 @@ func decodeQ8Tensor(shape []int, numElements int, raw []byte) (*tensor.TensorNum
 	// fast GEMV decode path. Embeddings (large vocab dim) keep Q8 for precision.
 	// Without this, Q8_0 attn_v weights block the merged QKV optimization.
 	if len(shape) == 2 && numElements > 0 {
-		isEmbedding := shape[0] > 50000
-		if !isEmbedding {
+		if !isEmbeddingShape(shape) {
 			f32 := make([]float32, numElements)
 			for bi := range nBlocks {
 				s := scales[bi]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
     ".": {
       "release-type": "go",
       "release-as": "1.49.0",
+      "bootstrap-sha": "d94e62777634a3d1f3c6d3d49b8568bf37b5cef7",
+      "last-release-sha": "d94e62777634a3d1f3c6d3d49b8568bf37b5cef7",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Stops release-please from paginating the entire repo history (~500 commits with massive merge-PR file lists), which has been triggering GitHub GraphQL failures on every workflow run since #500.