### PR TITLE
docs: gemma3 spark bench + deep-review 001 + plan updates

### DIFF
--- a/docs/bench/manifests/gemma3-tps.yaml
+++ b/docs/bench/manifests/gemma3-tps.yaml
@@ -1,0 +1,93 @@
+# Gemma 3 1B Q4_K_M throughput bench pod manifest.
+#
+# Recertifies the published 241 tok/s (+28% vs Ollama 188) Gemma 3 1B Q4_K_M
+# figure in docs/benchmarks.md. Uses cmd/bench_tps — the same binary that
+# originally recorded the 241 tok/s number — with greedy sampling, 128 output
+# tokens, and CUDA graph capture enabled (default).
+#
+# Submit via scripts/gemma3-spark.sh, which substitutes ${RUN_ID}, ${GGUF_PATH},
+# ${PROMPT}, ${TOKENS}, ${DEVICE}, and ${DTYPE} before POSTing to Spark.
+#
+# Prerequisites on the DGX host:
+#   1. /var/lib/zerfoo/bin/bench_tps is a linux/arm64 binary built from
+#      cmd/bench_tps/main.go. Build via:
+#         GOOS=linux GOARCH=arm64 go build -o bench_tps ./cmd/bench_tps
+#         rsync -av bench_tps ndungu@192.168.86.250:/var/lib/zerfoo/bin/
+#   2. The GGUF file is accessible at the path supplied via ${GGUF_PATH}
+#      (e.g. /var/lib/zerfoo/models/gemma-3-1b-it-Q4_K_M.gguf on the host,
+#      mounted read-only into the pod).
+#
+# Resource caps (cgroups enforced by Podman on the DGX host):
+#   memory 16Gi       (1B Q4_K_M loaded FP32 ~= 4GB; 4x margin)
+#   cpu "4"
+#   nvidia.com/gpu 1  (serialized via SPARK_GPU_MAX=1 on the host)
+#
+# NOTE: ZERFOO_DISABLE_CUDA_GRAPH is intentionally unset — the 241 tok/s
+# baseline was measured with capture enabled (184/185 instructions, 99.5%).
+# If the run fails with a capture error, set ZERFOO_DISABLE_CUDA_GRAPH=1
+# to fall back to eager mode and compare against the capture-off floor.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gemma3-tps-${RUN_ID}
+  labels:
+    app: bench
+    type: gemma3-tps
+spec:
+  restartPolicy: Never
+  containers:
+    - name: tps
+      image: docker.io/library/ubuntu:24.04
+      command:
+        - /var/lib/zerfoo/bin/bench_tps
+      args:
+        - "-model"
+        - "${GGUF_PATH}"
+        - "-prompt"
+        - "${PROMPT}"
+        - "-tokens"
+        - "${TOKENS}"
+        - "-device"
+        - "${DEVICE}"
+        - "-dtype"
+        - "${DTYPE}"
+        - "-temp"
+        - "0"
+      env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/cuda/lib64
+      resources:
+        limits:
+          memory: 16Gi
+          cpu: "4"
+          nvidia.com/gpu: "1"
+      volumeMounts:
+        - name: zerfoo-bin
+          mountPath: /var/lib/zerfoo/bin
+          readOnly: true
+        - name: zerfoo-lib
+          mountPath: /opt/zerfoo/lib
+          readOnly: true
+        - name: cuda
+          mountPath: /usr/local/cuda
+          readOnly: true
+        - name: zerfoo-models
+          mountPath: /var/lib/zerfoo/models
+          readOnly: true
+  volumes:
+    - name: zerfoo-bin
+      hostPath:
+        path: /var/lib/zerfoo/bin
+        type: Directory
+    - name: zerfoo-lib
+      hostPath:
+        path: /opt/zerfoo/lib
+        type: Directory
+    - name: cuda
+      hostPath:
+        path: /usr/local/cuda
+        type: Directory
+    - name: zerfoo-models
+      hostPath:
+        path: /var/lib/zerfoo/models
+        type: Directory

--- a/docs/deep-reviews/001-design-alignment-architectural-cleanliness.md
+++ b/docs/deep-reviews/001-design-alignment-architectural-cleanliness.md
@@ -1,0 +1,375 @@
+# Deep Architectural Review: Design Alignment, DRYness, and Composition
+
+**Date:** 2026-04-27
+**Reviewer:** Architectural deep-review
+**Scope:** Alignment of `github.com/zerfoo/zerfoo` with the original design at
+`docs/design.md@d18e20d9` (2025-08-02). Focus: package layout, composition,
+DRYness, and root-directory sprawl.
+**Method:** Read of design.md@d18e20d9 (1818 lines), design.md@HEAD, ADRs
+082/084 + the eight package-creation ADRs (004, 031, 036, 051, 056, 057, 059,
+062), `docs/dirty-architecture.md` (1087 lines, team-authored), graph
+extraction (`graphify-out/graph.json` — 16,781 nodes, 21,980 edges, 1,704
+communities), targeted file reads in `layers/`, `inference/`, `timeseries/`,
+`tests/parity/`, plus `git log` archaeology. Three independent investigation
+agents cross-validated findings.
+
+---
+
+## Executive Summary
+
+The codebase is **substantially out of alignment with the original design's
+package structure**, but **the core inference path still honors the design's
+composition principles**. The user's instinct is correct: the root directory
+has bloated from the design's 8 mandated top-level packages
+(`tensor`, `compute`, `graph`, `layers`, `training`, `model`, `device`,
+`distributed`) to ~47 today. Of the new packages, only ~9 were sanctioned by
+ADRs; the rest were introduced as unsanctioned drift. About **80 percent of
+the sprawl was added in a single 48-hour window on 2026-03-17/18**, which
+matches the in-memory note about the 10-wave parallel-agent execution where
+package skeletons were created faster than architectural review could vet
+placement.
+
+The top three architectural risks are: (1) **`timeseries/` is a parallel ML
+framework** (17,570 LOC) that operates on raw `[]float64` slices, bypassing
+`Engine[T]` and `layers/` — this directly contradicts the design's "Engine[T]
+is law" rule and is the largest DRY violation in the repo; (2) **two parallel
+APIs for the same activation math** (`layers/activations/` Node form vs
+`layers/functional/` function form) with no delegation between them, so a fix
+in one path does not propagate; (3) **at least 18 of the ~47 root-level
+directories should arguably live under existing packages** (`rl/`, `meta/`,
+`gp/`, `federated/`, `monitor/`, `recover/` belong under `training/`;
+`gnn/`, `synth/`, `shared/` belong under `layers/`; `health/`, `shutdown/`,
+`support/`, `security/`, `cloud/`, `marketplace/` belong under `serve/`;
+`integration/`, `mobile/`, `testing/` belong under `tests/`).
+
+The single most impactful recommendation: **adopt and execute ADR-082's
+composition-remediation epic on a quarterly milestone, paired with a CI lint
+that fails any new top-level package without a referenced ADR**. The team
+already has the audit, the migration recipe (5 packages were migrated in a
+single day on 2026-04-03), and a precedent for reversing scope (ADR-084 moved
+`crossasset/` to `wolf`). What is missing is a structural gate to stop the
+next 48-hour wave from undoing the cleanup. Note also: `testing/` shadows
+the Go stdlib package and should be renamed regardless of the larger
+remediation.
+
+---
+
+## Codebase Maturity Assessment
+
+| Dimension                  | Level | Evidence |
+|----------------------------|-------|----------|
+| Architecture (alignment)   | 2/5   | 47 top-level dirs vs 8 designed; ~18 unsanctioned (`autoopt/`, `causal/`, `rl/`, `gp/`, `gnn/`, `synth/`, `meta/`, `shared/`, `modeldsl/`, `federated/`, `regime/`, `recover/`, `monitor/`, `provenance/`, `support/`, `health/`, `modelcache/`, `marketplace/`); `timeseries/` runs as a parallel framework outside Engine[T]. |
+| Composition (core path)    | 4/5   | `layers/core/dense.go:15-21` correctly composes `Linear` + `Bias`; `inference/arch_common.go:104` `buildTransformerGraph` is shared by `arch_qwen.go` (50 lines) and `arch_mistral.go` (49 lines) — design intent honored on the inference critical path. |
+| Composition (off-path)     | 1/5   | `timeseries/itransformer.go:190-246` keeps `linearForwardVec` (raw triple loop) AND `linearBatchEngine` AND `linearBatchCPU` all for the same op; `dirty-architecture.md` quantifies ~9,800 redundant lines, 805 unjustified `.Data()` calls, 17 reimplemented LayerNorm, 11 reimplemented Linear, 4 reimplemented GELU. |
+| DRY                        | 2/5   | Two activation API surfaces (`layers/activations/gelu.go:27` Node vs `layers/functional/activations.go:15` function) for the same math, no delegation; ~1,155 lines of builder boilerplate duplicated across 25-30 `arch_*.go` files (per dirty-architecture.md). |
+| Self-awareness             | 5/5   | `docs/dirty-architecture.md` (rev 3, 1087 lines) and ADR-082 already document and prioritize these issues; the team has a migration recipe and a precedent (ADR-084). |
+| Code quality (core)        | 4/5   | Inference path is clean; `arch_common.go` is a textbook composition example; activation registry exists at `layers/activations/registry.go`. |
+| Test coverage              | 3/5   | `tests/parity/` exists with 48 files and 19 sub-dirs of golden tests; helpers are file-private inside `layer_parity_test.go` rather than in a shared `testutil` subpackage, limiting reuse. |
+| Naming hygiene             | 1/5   | `testing/` shadows the Go stdlib `testing` package; `integration/` and `integrations/` coexist with totally different purposes (smoke tests vs LangChain/Weaviate adapters); `support/` is a multi-tenant SaaS feature (customer-support handlers), not "support utilities." |
+
+**Overall maturity: 2.6/5 (Level 2 — ad-hoc, with strong self-awareness).** The
+team is performing at Level 4 inside the inference path and Level 1 at the
+root; the variance reflects who built what and when, not the team's
+capability. The gap between `dirty-architecture.md` and the code is the
+remediation work-in-flight.
+
+---
+
+## Original Design vs Current Layout
+
+### What the design mandated (design.md@d18e20d9)
+
+The design specified exactly 8 top-level packages, listed under "Modular
+Package Structure":
+
+```
+tensor/        compute/       graph/         layers/
+training/      model/         device/        distributed/
+```
+
+Three constraints framed everything else:
+
+1. **Engine[T] is the hardware abstraction.** "All computations are
+   parameterized by a generic type `T` ... All methods on the `Engine`
+   interface ..." The design.md@d18e20d9 wording: *"Each operation in Zerfoo
+   knows how to compute its gradient ... The Engine is often used to perform
+   these computations"* (line 198).
+2. **Composition over inheritance.** "Complex layers that can be built by
+   composing simpler layers must not re-implement the code in simpler layers"
+   (design.md@d18e20d9 line 219). A Dense layer = Linear + Bias, not a
+   monolith.
+3. **Each operation in one place.** "If two different layer types both need a
+   certain transform, we prefer to implement that as either a utility
+   function or its own small Node" (line 217).
+
+### What the codebase looks like now
+
+47 top-level directories. Categorized by sanctioning mechanism:
+
+| Category | Count | Examples |
+|---|---|---|
+| Original 8 (still here) | 4 | `layers/`, `training/`, `model/`, `distributed/` |
+| Original 8 (extracted to ztensor by ADR-036) | 4 | (`tensor/`, `compute/`, `graph/`, `device/` are external) |
+| Standard Go layout | 6 | `cmd/`, `internal/`, `tests/`, `docs/`, `examples/`, `scripts/` |
+| Sanctioned by ADR | 9 | `inference/` (ADR-004), `generate/` (ADR-004), `serve/` (ADR-031), `tabular/` (ADR-062), `mobile/` (ADR-059), `cloud/` (ADR-056 as `serve/cloud/`, later flattened), plus `benchmarks/`, `bin/`, `deploy/`, `infra/`, `config/` (operational) |
+| **Unsanctioned drift** | **~18** | **`autoopt/`, `causal/`, `features/`, `federated/`, `gnn/`, `gp/`, `health/`, `meta/`, `modelcache/`, `modeldsl/`, `monitor/`, `provenance/`, `recover/`, `regime/`, `registry/`, `rl/`, `security/`, `shared/`, `shutdown/`, `support/`, `synth/`, `testing/`, `compliance/`, `marketplace/`, `integration/`, `integrations/`** |
+
+(Some categories overlap; counts approximate.)
+
+### Timeline of drift
+
+```
+2025-08-02  design.md committed (d18e20d9)        — 8 packages
+2025-08-25  features/ added                         — first drift
+2026-03-02  health/ + ADR-004 wave (inference, generate)
+2026-03-17  BIG-BANG SPRAWL: ~21 top-level packages added in 24-48h
+2026-03-18  cont'd. Coincides with 5-year roadmap / 10-wave Claude Code army.
+2026-03-19+ Enterprise tier: marketplace/, security/, support/, compliance/
+2026-03-30  timeseries/ extracts internal "shared" math — parallel framework crystallizes
+2026-04-02  ADR-082 acknowledges drift, proposes 5-phase remediation (E61-E65)
+2026-04-03  5 packages migrated in a single day — recipe proven
+2026-04-12  ADR-084: crossasset/ extracted to feza-ai/wolf — first reversal
+```
+
+This timeline appears in `git log` traces; the in-memory note about
+"Max 3-4 agents per wave; 10 agents consistently freeze" describes the same
+incident that produced the sprawl.
+
+---
+
+## High-Impact Architectural Findings
+
+### A1. timeseries/ is a parallel ML framework that bypasses Engine[T]
+
+**Impact: High.** This is the single largest violation of the original
+design.
+
+**Evidence:**
+
+- `timeseries/itransformer.go:190-199` defines `linearForwardVec` — a raw
+  triple-nested loop computing `x * W + b` directly on `[]float64`.
+- `timeseries/itransformer.go:204-246` defines `linearBatchF64` which calls
+  `cpuEngine64.MatMul`, but on error falls back to the hand loop at line 190.
+  The same op exists in two implementations in the same file.
+- `timeseries/itransformer_engine.go:16,64` defines `linearBatchEngine` AND
+  `linearBatchCPU` for the same op.
+- `timeseries/itransformer_backward.go:363,426,518` — `linearBackwardF64`,
+  `layerNormBackwardFunctional`, `multiHeadAttentionBackwardF64` are all
+  hand-rolled instead of using `Engine[T]` + autodiff.
+- `timeseries/dlinear.go:52,207,234,244,261,347,424` — `normalizeWindows`,
+  `movingAverage`, twin `cpuDecompose`/`engineDecompose`, twin
+  `cpuLinearProject`/`engineLinearProject`. Five duplicated paths.
+- `timeseries/frets_engine.go:312,329` — `fretsEngineMatMul` and
+  `fretsScalarMatMul`. Same op, two paths.
+
+`docs/dirty-architecture.md` (rev 3) confirms with hard numbers: 17,570
+lines, 254 `.Data()` calls in this package alone, 17 reimplemented LayerNorm,
+11 reimplemented Linear, 4 reimplemented GELU, 6 reimplemented attention.
+Estimated ~9,800 redundant lines across the 3 worst packages
+(`timeseries/`, `tabular/`, `modeldsl/`).
+
+**Why the design is broken here:** the *engine path* was bolted on without
+retiring the *cpu path*. Bug fixes and GPU acceleration in `Engine[T]` never
+reach `timeseries/` users. The package is effectively a separate framework
+that happens to live in the same repo.
+
+**Recommendation:** apply ADR-082 phase E62 (Time Series Migration). Build
+`timeseries/` models as `graph.Node[T]` graphs the way `inference/arch_*.go`
+do. Delete every `*F64` / `cpu*` / `*Vec` helper after the migration. The
+2026-04-03 migration of 5 packages in a day shows the recipe scales.
+
+### A2. Activations have two parallel API surfaces
+
+**Impact: High.** Same math, two implementations, no delegation.
+
+**Evidence:**
+
+- `layers/activations/gelu.go:27` defines `NewGelu` — the canonical Node
+  implementation.
+- `layers/activations/fast_gelu.go` — separate `FastGelu` Node.
+- `layers/functional/activations.go:15` — functional `GELU(...)` that
+  reimplements the math instead of delegating to `NewGelu`.
+- `layers/functional/gelu_backward.go:20` — separate functional backward.
+- An activation registry exists at `layers/activations/registry.go` but
+  `layers/functional/` bypasses it entirely.
+- At least 8 callers wire activations differently: `layers/core/ffn.go`,
+  `layers/vision/clip_encoder.go`, `layers/audio/whisper_encoder.go`,
+  several `tabular/*.go` files.
+
+**Recommendation:** make `layers/functional/activations.go` thin wrappers
+around the activation Node registry — one source of arithmetic per
+activation. This is an afternoon's work and removes a recurring source of
+correctness drift.
+
+### A3. Root sprawl: ~18 unsanctioned top-level packages
+
+**Impact: High.** Each new package widens the cognitive surface, multiplies
+import paths, and invites the next "let's also create a top-level dir for
+this" shortcut.
+
+The following dirs should arguably live elsewhere (proposed home in
+parentheses, severity from the investigation agent):
+
+| Move under `training/` | `rl/`, `meta/`, `gp/`, `federated/`, `monitor/`, `recover/`, `provenance/` |
+| Move under `layers/` | `gnn/`, `synth/`, `shared/` |
+| Move under `serve/` | `health/`, `shutdown/`, `support/`, `security/`, `cloud/`, `marketplace/` |
+| Move under `inference/timeseries/` | `causal/`, `features/`, `regime/` |
+| Move under `model/` | `modelcache/`, `modeldsl/`, `registry/` |
+| Move under `tests/` | `integration/`, `mobile/`, `testing/` |
+| Move under `internal/` or `ztensor/` | `autoopt/` (kernel codegen) |
+| Rename | `integrations/` → `sdk/integrations/` (it's LangChain + Weaviate adapters, not test integration) |
+
+Cross-import signals already make consolidation mechanical. Examples:
+`recover/retrain.go` already imports `monitor`; `cmd/cli/{serve,worker,signal}.go`
+already import `health`/`shutdown`/`security` together. Moving the latter
+three into `serve/` is a `git mv` plus an import-path rewrite.
+
+### A4. Naming hazards
+
+**Impact: Medium.**
+
+- `testing/` shadows the Go stdlib `testing` package. This is harmful
+  regardless of any larger remediation. Rename to `testutil/` or move under
+  `tests/testutil/`.
+- `integration/` (2 files: production smoke tests) and `integrations/`
+  (4 files: LangChain + Weaviate adapters) coexist with confusingly similar
+  names and unrelated purposes. Consensus rename: `integration/` →
+  `tests/integration/`, `integrations/` → `sdk/integrations/`.
+- `support/` (8 files) implements customer-support webhook handlers — not
+  "support utilities." Rename or move under `serve/support/`.
+- `shared/` is the canonical "anti-pattern bucket" name; it currently holds 3
+  files (cross-model latent space). Move under `layers/` with a more specific
+  name, e.g., `layers/shared_latent/`.
+
+### A5. Test-helper concentration without a shared package
+
+**Impact: Medium.** Graphify identified `makeTensor`, `setup`, `loadGolden`,
+`getFloat32s`, `assertClose` as the most-connected nodes in the entire
+codebase (each 76-88 edges). They live in
+`tests/parity/layer_parity_test.go` — file-private, single-package. The
+helpers can't be reused by GPU parity files or other parity-style tests in
+adjacent suites without copy-paste.
+
+**Recommendation:** move them to `tests/parity/testutil/` (or a non-`_test.go`
+package importable by other test packages) so the parity helpers are the
+single source of truth for golden-file loading and tolerance assertions
+across all parity-style suites.
+
+---
+
+## What the codebase does well (calibrating trust in the findings)
+
+- **`inference/arch_common.go:104`** — `buildTransformerGraph` is a textbook
+  composition example. `arch_qwen.go` (50 lines) and `arch_mistral.go` (49
+  lines) are thin config adapters. Adding a new vanilla decoder-only arch
+  costs ~50 lines.
+- **`layers/core/dense.go:15-21`** — `Dense` is correctly composed of
+  `Linear` + `Bias` + optional activation, exactly as design.md@d18e20d9
+  prescribed at line 219.
+- **The team has already done this audit.** `docs/dirty-architecture.md`
+  (rev 3, 2026-04-03, 1087 lines) is one of the most thorough and honest
+  internal architectural-debt documents I have read in any codebase. It
+  enumerates violations with file:line refs and categorizes by severity.
+  ADR-082 prescribes a 5-phase remediation (E61-E65). ADR-084 set the
+  precedent for reversing scope by extracting `crossasset/` to `wolf`.
+- **5 packages were migrated in a single day on 2026-04-03**
+  (`crossasset/`, `rl/`, `synth/`, `meta/`, `shared/` per the rev-3 doc) —
+  the migration recipe is proven and fast.
+
+The variance between the inference critical path (Level 4) and the off-path
+domain packages (Level 1) is the variance between "code reviewed by a
+careful human" and "skeleton dropped by a parallel-agent wave." The fix is
+not to lower the ceiling; it is to raise the floor.
+
+---
+
+## Prioritized Remediation Roadmap
+
+### Fix this week (low cost, high signal)
+
+1. **Rename `testing/`.** Single most dangerous name in the tree. Probably
+   ~30 minutes of rewrites.
+2. **Resolve `integration/` vs `integrations/`.** Move former to
+   `tests/integration/`, latter to `sdk/integrations/`.
+3. **Add a CI lint that fails any new top-level Go package not listed in an
+   allowlist.** The allowlist is the design's 8 + ADR-sanctioned additions.
+   New top-level requires a referenced ADR. This stops the next 48-hour
+   wave from re-creating the cleanup target. (See the in-memory note about
+   the team's existing wave-runner setup — this is the single highest-ROI
+   guardrail.)
+
+### Fix this sprint (architectural cleanup)
+
+4. **Collapse `layers/functional/activations.go` onto the activation Node
+   registry** (A2). Half a day. Eliminates a recurring correctness-drift
+   vector.
+5. **Move `health/`, `shutdown/`, `support/`, `security/` under `serve/`**
+   (A3). Cross-imports already exist; this is `git mv` plus rewrites. Half a
+   day.
+6. **Move `rl/`, `meta/`, `gp/`, `monitor/`, `recover/`, `provenance/`
+   under `training/`** (A3). One day. Several already cross-import.
+7. **Move `gnn/`, `synth/`, `shared/` under `layers/`** (A3). Half a day.
+8. **Move parity test helpers to `tests/parity/testutil/`** (A5). Two
+   hours.
+
+### Fix this quarter (the big one)
+
+9. **Execute ADR-082's E62 (timeseries) phase.** Migrate `timeseries/` to
+   `Engine[T]` + `graph.Node[T]`. This is the largest single source of
+   redundant code in the repo (~9,800 lines across `timeseries/` +
+   `tabular/` + `modeldsl/`). The 2026-04-03 single-day migration of 5
+   packages shows it can be done; this one is bigger but bounded.
+10. **Decide whether `cloud/`, `marketplace/`, `compliance/` belong in this
+    repo or in a sibling `zerfoo-enterprise/` repo** per ADR-057's
+    open-core-licensing direction. ADR-084 set the precedent for splitting
+    out scope; the same reasoning applies here.
+
+### Track as tech debt
+
+11. Refresh `docs/design.md` to either mandate the post-extraction layout
+    (4 original + sanctioned additions) or explicitly mark which packages
+    are aspirational. Right now it documents the drift rather than gating
+    it.
+12. Continue ADR-082 phases E63-E65 (`tabular/`, `modeldsl/`, generate/serve
+    structural cleanup).
+
+---
+
+## Statistics
+
+- Source files in codebase (Go, non-vendor): ~1,637 (graphify code count)
+- Top-level Go directories: 47 (vs 8 in original design)
+- Original-design top-level packages still present in this repo: 4
+  (`layers/`, `training/`, `model/`, `distributed/`)
+- Original-design packages legitimately extracted: 4 (`tensor/`, `compute/`,
+  `graph/`, `device/` → ztensor per ADR-036)
+- ADR-sanctioned additions: ~9
+- Unsanctioned top-level dirs: ~18
+- Findings: High [3], Medium [2], Info-positive [3]
+- Test files in `tests/parity/`: 48 across 19 sub-dirs
+- Graph stats from `graphify-out/graph.json`: 16,781 nodes, 21,980 edges,
+  1,704 communities; cohesion of top communities 0.01-0.11 (low — each
+  community is internally weakly connected)
+- Lines of acknowledged duplicated code (per `dirty-architecture.md` rev 3):
+  ~9,800 across `timeseries/` + `tabular/` + `modeldsl/`
+- Unjustified `.Data()` bypass calls (per `dirty-architecture.md` rev 3):
+  ~805 of ~2,599 total
+- ADRs reviewed: 004, 031, 036, 051, 056, 057, 059, 062, 082, 084
+- Days from design.md to first drift: ~23
+- Days from design.md to big-bang sprawl: ~227
+- Days from big-bang sprawl to acknowledgement (ADR-082): ~16
+
+---
+
+## Closing Note
+
+The user's instinct prompted the right question. The repo is healthier than
+the directory listing suggests — the inference critical path is exemplary —
+but the root has accumulated ~18 packages that the original design would
+have placed under existing parents, and one of them (`timeseries/`) has
+metastasized into a parallel framework. The team already knows this
+(`dirty-architecture.md` is unusually candid) and has a recipe. The missing
+piece is a CI guardrail that prevents the next parallel-agent wave from
+undoing the next round of cleanup. Add that, finish ADR-082's E62, rename
+`testing/`, and the framework will be substantially back in line with the
+2025-08 vision.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2649,6 +2649,30 @@ Task details removed during /tidy --apply. See git history for full lists.
 
 ## Progress Log
 
+### 2026-04-27: E124 added -- Architectural layout cleanup from deep-review-001
+
+- **Change summary.** Added E124 (Architectural Layout Cleanup) covering the
+  findings from `docs/deep-reviews/001-design-alignment-architectural-cleanliness.md`
+  that are NOT already covered by the composition epics (E61-E89). Scope: root-
+  level package consolidation (~18 unsanctioned dirs to move under existing
+  parents), naming hazards (`testing/` shadows stdlib; `integration/` vs
+  `integrations/`), activation API unification (Node + functional surfaces
+  collapsed), CI layout-allowlist lint, open-core scope ADR for
+  `cloud/`/`marketplace/`/`compliance/`, and a `design.md` refresh.
+- **Tasks added:** T124.1.1-T124.1.4 (quick wins), T124.2.1-T124.2.4
+  (activations), T124.3.1-T124.3.5 (serve/), T124.4.1-T124.4.7 (training/),
+  T124.5.1-T124.5.7 (layers+inference+model), T124.6.1-T124.6.3 (tests),
+  T124.7.1-T124.7.2 (open-core), T124.8.1 (design.md refresh). Six waves,
+  largest is 10 agents (with R124.1 mitigation noted).
+- **Milestone added:** M-LAYOUT-1 targeting 2026-Q3.
+- **No ADRs created yet.** T124.7.1 will create the open-core scope ADR.
+  T124.8.1 may either revise design.md in place or spawn an ADR depending on
+  the decision shape.
+- **Cross-references.** E89 (timeseries Engine[T] migration, DONE) is the
+  composition counterpart; E124 only covers the structural sweep that
+  composition epics left behind. The deep review explicitly does not redo
+  E89's work.
+
 ### 2026-04-21: T99.2.2 next-session plan -- H17/H19 subtasks queued
 
 - **Change summary.** T99.2.2 H16 ablation test completed this session
@@ -3513,3 +3537,300 @@ PRs: #334, #336, #338, #341. Detailed task breakdowns removed during /tidy. See 
 | M-COMP-2 | Composition Phase 2 Complete | E66-E73 all compose from layers/ or Engine; architecture test in CI | DONE 2026-04-03 |
 | M-COMP-3 | Composition Phase 3 Complete | E74 backward composition done; E75 inference .Data() eliminated; E76 allowlist removed; zero raw backward loops in timeseries/; dirty-architecture.md violations at 0 | 2026-Q3 |
 | M-COMP-4 | Composition Phase 4 Complete | E77-E84 complete; dirty-architecture.md violations reduced from ~9,800 to <2,000 lines; tabular/, layers/, generate/, inference/, training/, serve/, modeldsl/ all compose from layers/ or Engine | DONE 2026-04-06 |
+
+---
+
+## E124: Architectural Layout Cleanup (from deep-review-001)
+
+### Context
+
+Source: docs/deep-reviews/001-design-alignment-architectural-cleanliness.md
+(2026-04-27). The composition-remediation work (E61-E84, E89) eliminated the
+worst arithmetic violations, but the physical package layout still drifts
+from the original design.md@d18e20d9. Specifically:
+
+- 47 top-level Go directories vs 8 in the original design. Approximately 18
+  unsanctioned top-level dirs created in a 48-hour parallel-agent wave on
+  2026-03-17/18. Cross-imports already make most consolidations a mechanical
+  `git mv`.
+- `testing/` shadows the Go stdlib `testing` package. `integration/` and
+  `integrations/` coexist with totally different purposes (smoke tests vs
+  LangChain/Weaviate adapters).
+- `layers/activations/` (Node form) and `layers/functional/activations.go`
+  (function form) are parallel API surfaces for the same math; no
+  delegation, so a fix in one path does not propagate.
+- `cloud/`, `marketplace/`, `compliance/` carry SaaS/enterprise concerns
+  that ADR-057 (open-core licensing) suggests may belong in a sibling
+  `zerfoo-enterprise/` repo. Decision deferred for explicit ADR.
+
+E89 already covered the `timeseries/` Engine[T] migration (DONE). E124 does
+NOT redo that work; it covers the structural sweep the composition epics
+left behind.
+
+### Acceptance Criteria
+
+- Root-level Go directory count reduced from ~47 to <=20.
+- `testing/` directory no longer exists at root (renamed or absorbed).
+- `integration/` and `integrations/` no longer coexist at root.
+- A CI lint fails any PR that creates a new top-level Go package without a
+  referenced ADR slug in the package's `doc.go`.
+- `layers/functional/activations.go` delegates to the `layers/activations/`
+  Node registry instead of reimplementing math.
+- All test suites green; no new files added under root that were not on the
+  allowlist.
+
+### Work Breakdown
+
+#### E124.1: Quick wins (this week)
+
+- [ ] T124.1.1 Rename `testing/` to `tests/testutil/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  Move all Go files under `testing/{benchmark,compare,...}` to
+  `tests/testutil/...`. Update all imports. Run `go test ./...` and
+  `go vet ./...`. The directory name `testing/` shadows the stdlib package
+  and is harmful regardless of any larger remediation.
+  Acceptance: `find . -maxdepth 1 -name testing -type d` returns empty;
+  `go build ./...` and `go test ./...` pass.
+
+- [ ] T124.1.2 Resolve `integration/` vs `integrations/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  `integration/` (2 files: production smoke tests) -> `tests/integration/`.
+  `integrations/` (4 files: LangChain + Weaviate adapters) -> `sdk/integrations/`.
+  Update imports and any CI workflow refs.
+  Acceptance: `ls -d integration integrations` returns "No such file";
+  `go build ./...` and `go test ./...` pass.
+
+- [ ] T124.1.3 Add CI lint: top-level package allowlist  Owner: TBD  Est: 2h  verifies: [infrastructure]
+  Add `tests/architecture/layout_test.go` (or extend the existing
+  composition_test.go) that lists allowed top-level Go directories. The
+  allowlist is the original design's 8 + ADR-sanctioned additions:
+  `layers, training, model, distributed, inference, generate, serve,
+  tabular, mobile, cloud (until enterprise split decision), cmd, internal,
+  tests, docs, examples, scripts, benchmarks, bin, deploy, infra, config`.
+  Any other top-level dir with `*.go` files fails the test unless its
+  `doc.go` references an ADR slug (e.g., `// See docs/adr/NNN-...md`).
+  Acceptance: test passes today (with grandfathered exemptions for current
+  unsanctioned dirs); fails when a new top-level pkg is added without an
+  ADR ref.
+  Decision rationale: deep-review-001 identifies this as the highest-ROI
+  guardrail to prevent the next 48-hour wave from undoing cleanup.
+
+- [ ] T124.1.4 Run linters + go vet after E124.1  Owner: TBD  Est: 0.5h  verifies: [infrastructure]
+  Deps: T124.1.1, T124.1.2, T124.1.3
+  Acceptance: `golangci-lint run`, `go vet ./...`, `go build ./...` clean.
+
+#### E124.2: Activation API unification (this sprint)
+
+- [ ] T124.2.1 Audit activation parallel paths  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  Enumerate every implementation of GELU, ReLU, Sigmoid, SiLU, Softmax,
+  FastGelu in `layers/activations/`, `layers/functional/`, and any
+  remaining inline copies in `inference/`, `tabular/`, `layers/vision/`,
+  `layers/audio/`. Output a table: activation -> [Node loc, functional loc,
+  inline copies].
+  Acceptance: audit table written to `docs/activation-audit.md`.
+
+- [ ] T124.2.2 Make `layers/functional/activations.go` thin wrappers  Owner: TBD  Est: 3h  verifies: [infrastructure]
+  Deps: T124.2.1
+  Convert each function in `layers/functional/activations.go` to construct
+  the corresponding Node from `layers/activations/registry.go` and
+  delegate. Delete duplicated math. Same for `gelu_backward.go`.
+  Acceptance: `layers/functional/activations.go` contains no arithmetic
+  loops; all callers compile; parity tests pass.
+
+- [ ] T124.2.3 Replace inline activation copies  Owner: TBD  Est: 2h  verifies: [infrastructure]
+  Deps: T124.2.2
+  Replace inline GELU/SiLU computations in `layers/core/ffn.go`,
+  `layers/vision/clip_encoder.go`, `layers/audio/whisper_encoder.go`, and
+  any tabular files with calls to the canonical Node or functional
+  wrapper.
+  Acceptance: `grep -rn "math.Erf\|math.Tanh.*0.044715" layers/ inference/
+  tabular/` returns only `layers/activations/`.
+
+- [ ] T124.2.4 Tests + lint  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  Deps: T124.2.3
+  Run full parity suite, race detector, golangci-lint.
+  Acceptance: all green.
+
+#### E124.3: serve/ consolidation (this sprint)
+
+- [ ] T124.3.1 Move `health/` -> `serve/health/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  3 files; pure HTTP liveness/readiness probes. `cmd/cli/serve.go` already
+  imports it.
+
+- [ ] T124.3.2 Move `shutdown/` -> `serve/shutdown/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  3 files; graceful shutdown coordinator used only by `cmd/cli/`.
+
+- [ ] T124.3.3 Move `support/` -> `serve/support/` (or rename to clarify SaaS scope)  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  8 files; customer-support webhook handlers (multi-tenant SaaS feature).
+  Note: this is a candidate for the open-core split (T124.6.1).
+
+- [ ] T124.3.4 Move `security/` -> `serve/security/`  Owner: TBD  Est: 2h  verifies: [infrastructure]
+  SOC 2 access control, API keys, rate limit. All HTTP-server-side.
+
+- [ ] T124.3.5 Tests + lint after serve/ consolidation  Owner: TBD  Est: 0.5h  verifies: [infrastructure]
+  Deps: T124.3.1, T124.3.2, T124.3.3, T124.3.4
+
+#### E124.4: training/ consolidation (this sprint)
+
+- [ ] T124.4.1 Move `rl/` -> `training/rl/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  8 files; RL is a training paradigm.
+
+- [ ] T124.4.2 Move `meta/` -> `training/meta/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  3 files; MAML meta-learning.
+
+- [ ] T124.4.3 Move `gp/` -> `training/gp/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  3 files; tree-based genetic programming.
+
+- [ ] T124.4.4 Move `monitor/` + `recover/` -> `training/mlops/{monitor,recover}/`  Owner: TBD  Est: 1.5h  verifies: [infrastructure]
+  6 files total. `recover/retrain.go` already imports `monitor`.
+
+- [ ] T124.4.5 Move `provenance/` -> `training/provenance/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  Hash-chain model lifecycle audit.
+
+- [ ] T124.4.6 Move `federated/` -> `training/federated/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  FedAvg coordinator.
+
+- [ ] T124.4.7 Tests + lint after training/ consolidation  Owner: TBD  Est: 0.5h  verifies: [infrastructure]
+  Deps: T124.4.1, T124.4.2, T124.4.3, T124.4.4, T124.4.5, T124.4.6
+
+#### E124.5: layers/ + inference/ consolidation (this sprint)
+
+- [ ] T124.5.1 Move `gnn/` -> `layers/gnn/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  4 files; literal GNN layers.
+
+- [ ] T124.5.2 Move `synth/` -> `layers/generative/synth/` (or experimental/)  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  5 files; VAE-based synthetic data generation.
+
+- [ ] T124.5.3 Rename + relocate `shared/` -> `layers/shared_latent/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  3 files; cross-model latent space. `shared/` is the canonical
+  anti-pattern bucket name.
+
+- [ ] T124.5.4 Move `causal/`, `features/`, `regime/` -> `inference/timeseries/{causal,features,regime}/`  Owner: TBD  Est: 1.5h  verifies: [infrastructure]
+  All three are TS-domain experimental packages (13 files total).
+
+- [ ] T124.5.5 Move `modelcache/`, `modeldsl/`, `registry/` -> `model/{cache,dsl,registry}/`  Owner: TBD  Est: 1.5h  verifies: [infrastructure]
+  Tightly coupled to model loading/serving.
+
+- [ ] T124.5.6 Move `autoopt/` -> `internal/autoopt/` (or upstream to ztensor/internal/codegen/)  Owner: TBD  Est: 1h  verifies: [infrastructure]
+  15 files; kernel/codegen concern, not a top-level ML package.
+
+- [ ] T124.5.7 Tests + lint after layers/inference/model consolidation  Owner: TBD  Est: 0.5h  verifies: [infrastructure]
+  Deps: T124.5.1 .. T124.5.6
+
+#### E124.6: tests/ + parity helpers
+
+- [ ] T124.6.1 Move `mobile/` -> `tests/mobile/`  Owner: TBD  Est: 0.5h  verifies: [infrastructure]
+  Single test file; not a framework package.
+
+- [ ] T124.6.2 Extract parity helpers to `tests/parity/testutil/`  Owner: TBD  Est: 1.5h  verifies: [infrastructure]
+  Move `makeTensor`, `setup`, `loadGolden`, `getFloat32s`, `getInts`,
+  `getFloat`, `assertClose` from `tests/parity/layer_parity_test.go` into
+  a non-`_test.go` `testutil` subpackage so all parity-style suites can
+  import them. Graphify identified these as the most-connected nodes in
+  the entire graph (76-88 edges each) -- single source of truth needed.
+  Acceptance: `tests/parity/testutil/` exists with these helpers; all
+  parity tests still pass.
+
+- [ ] T124.6.3 Tests + lint  Owner: TBD  Est: 0.5h  verifies: [infrastructure]
+  Deps: T124.6.1, T124.6.2
+
+#### E124.7: Open-core split decision (this quarter)
+
+- [ ] T124.7.1 Write ADR: scope of `cloud/`, `marketplace/`, `compliance/` in zerfoo OSS  Owner: TBD  Est: 3h  verifies: [infrastructure]
+  Decide whether SaaS-billing/marketplace/compliance code belongs in this
+  Apache-2.0 repo or in a sibling `zerfoo-enterprise/` repo per
+  ADR-057's open-core direction. ADR-084 is the precedent (crossasset/
+  -> wolf). Output: docs/adr/NNN-zerfoo-oss-scope.md.
+  Acceptance: ADR Accepted; clear placement decision with rationale.
+
+- [ ] T124.7.2 Execute the placement decision (move or keep + document)  Owner: TBD  Est: 4h  verifies: [infrastructure]
+  Deps: T124.7.1
+  If split: extract dirs to new repo. If keep: add doc.go ADR refs to
+  satisfy T124.1.3 lint. Either way, update the layout-test allowlist.
+
+#### E124.8: Refresh design.md
+
+- [ ] T124.8.1 Refresh `docs/design.md` to mandate the post-cleanup layout  Owner: TBD  Est: 2h  verifies: [infrastructure]
+  Deps: E124.1-E124.7 substantially complete
+  Update the "Modular Package Structure" section to reflect the
+  consolidated layout: original 8 (with ztensor extraction noted), plus
+  ADR-sanctioned additions, plus aspirational sub-packages. Make it a
+  GATE again, not a reflective inventory.
+  Acceptance: design.md describes the current layout AND lists the rule
+  ("new top-level packages require an ADR"). The lint in T124.1.3
+  references this section.
+
+### E124 Parallel Tracks
+
+| Track | Tasks | Notes |
+|-------|-------|-------|
+| Track A: Quick wins | T124.1.1, T124.1.2, T124.1.3 | All independent of each other. |
+| Track B: Activations | T124.2.1 -> T124.2.2 -> T124.2.3 -> T124.2.4 | Sequential within track. |
+| Track C: serve/ | T124.3.1, T124.3.2, T124.3.3, T124.3.4 (parallel) -> T124.3.5 | `git mv` ops are independent. |
+| Track D: training/ | T124.4.1..T124.4.6 (parallel) -> T124.4.7 | Independent moves. |
+| Track E: layers+inference+model | T124.5.1..T124.5.6 (parallel) -> T124.5.7 | Independent moves. |
+| Track F: tests/ | T124.6.1, T124.6.2 (parallel) -> T124.6.3 | Independent. |
+| Track G: Open core | T124.7.1 -> T124.7.2 | Sequential; ADR first. |
+| Track H: Design refresh | T124.8.1 | After A-F substantially done. |
+
+Tracks A-F can all run concurrently; G can start anytime; H is the final
+sync.
+
+### E124 Waves
+
+#### Wave E124-1: Quick wins + activation audit (4 agents)
+- [ ] T124.1.1 Rename testing/  verifies: [infrastructure]
+- [ ] T124.1.2 Resolve integration/ vs integrations/  verifies: [infrastructure]
+- [ ] T124.1.3 CI layout lint  verifies: [infrastructure]
+- [ ] T124.2.1 Activation parallel-paths audit  verifies: [infrastructure]
+
+#### Wave E124-2: Bulk consolidation (10 agents)
+- [ ] T124.3.1 health/ -> serve/health/  verifies: [infrastructure]
+- [ ] T124.3.2 shutdown/ -> serve/shutdown/  verifies: [infrastructure]
+- [ ] T124.3.3 support/ -> serve/support/  verifies: [infrastructure]
+- [ ] T124.3.4 security/ -> serve/security/  verifies: [infrastructure]
+- [ ] T124.4.1 rl/ -> training/rl/  verifies: [infrastructure]
+- [ ] T124.4.2 meta/ -> training/meta/  verifies: [infrastructure]
+- [ ] T124.4.3 gp/ -> training/gp/  verifies: [infrastructure]
+- [ ] T124.4.4 monitor+recover -> training/mlops/  verifies: [infrastructure]
+- [ ] T124.5.1 gnn/ -> layers/gnn/  verifies: [infrastructure]
+- [ ] T124.6.2 Parity helpers to tests/parity/testutil/  verifies: [infrastructure]
+
+(Note: 10-agent cap from MEMORY-recorded pre-flight wisdom -- if any of
+these fail in worktree isolation, drop to 4 per wave.)
+
+#### Wave E124-3: Tail consolidation + activation unification (8 agents)
+- [ ] T124.4.5 provenance/ -> training/provenance/  verifies: [infrastructure]
+- [ ] T124.4.6 federated/ -> training/federated/  verifies: [infrastructure]
+- [ ] T124.5.2 synth/ -> layers/generative/synth/  verifies: [infrastructure]
+- [ ] T124.5.3 shared/ -> layers/shared_latent/  verifies: [infrastructure]
+- [ ] T124.5.4 causal+features+regime -> inference/timeseries/  verifies: [infrastructure]
+- [ ] T124.5.5 modelcache+modeldsl+registry -> model/  verifies: [infrastructure]
+- [ ] T124.5.6 autoopt/ -> internal/autoopt/  verifies: [infrastructure]
+- [ ] T124.6.1 mobile/ -> tests/mobile/  verifies: [infrastructure]
+
+#### Wave E124-4: Activation unification (1 agent, sequential)
+- [ ] T124.2.2 -> T124.2.3 -> T124.2.4
+
+#### Wave E124-5: Validation + ADR (3 agents)
+- [ ] T124.1.4 Lint sweep  verifies: [infrastructure]
+- [ ] T124.3.5 + T124.4.7 + T124.5.7 + T124.6.3 (combined into one validation run)
+- [ ] T124.7.1 Open-core scope ADR  verifies: [infrastructure]
+
+#### Wave E124-6: Open-core execute + design refresh (2 agents)
+- [ ] T124.7.2 Execute placement decision  verifies: [infrastructure]
+- [ ] T124.8.1 Refresh docs/design.md  verifies: [infrastructure]
+
+### E124 Risk Register
+
+| ID | Risk | Impact | Likelihood | Mitigation |
+|----|------|--------|------------|------------|
+| R124.1 | Worktree isolation freezes when wave size >4 (per MEMORY feedback_agent_parallelism) | Wave stalls mid-way | Medium | Cap waves at 4 agents in practice; the 10-agent wave above is best-case. Manual-rerun fallback documented. |
+| R124.2 | A `git mv` cascade breaks an external integration that depends on the old import path | Downstream breakage | Low | Use `gofmt -r` style import rewrites; run `go build ./...` after each move; CI catches before merge. |
+| R124.3 | The CI layout lint (T124.1.3) traps an unrelated PR that legitimately needs a new top-level dir | Friction | Medium | Lint message must say "add an ADR ref to your doc.go to allowlist". Easy escape valve. |
+| R124.4 | Activation unification (T124.2.2) changes numerical behavior on a subtle edge case | Parity test fail | Low | E86 PyTorch parity suite catches deviations to 1e-6; run before merge. |
+| R124.5 | Open-core split (T124.7) gets stuck in legal/licensing review | Blocked indefinitely | Medium | T124.7.2 has a "keep + document" branch that does not require legal sign-off; ADR can land first and execution deferred. |
+
+### E124 Milestone
+
+| ID | Milestone | Exit Criteria | Target |
+|----|-----------|---------------|--------|
+| M-LAYOUT-1 | Architectural layout aligned with design | E124.1-E124.6 complete; root-level Go dirs <=20; CI layout lint passes; activation API unified; design.md refreshed (T124.8.1) | 2026-Q3 |

--- a/scripts/gemma3-spark.sh
+++ b/scripts/gemma3-spark.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# gemma3-spark.sh — submit the Gemma 3 1B Q4_K_M throughput bench to Spark on
+# the DGX host, poll the pod until it terminates, stream its logs, and exit
+# with its status.
+#
+# Purpose: recertify (or refute) the published 241 tok/s / +28% vs Ollama
+# figure in docs/benchmarks.md. The original 241 tok/s was measured with a
+# different binary; after the ztensor module extraction the same kernel hit
+# 186 tok/s. This script runs cmd/bench_tps against the current main branch
+# to establish the real current number.
+#
+# Usage:
+#   scripts/gemma3-spark.sh \
+#     [-gguf /var/lib/zerfoo/models/gemma-3-1b-it-Q4_K_M.gguf] \
+#     [-prompt "The quick brown fox"] \
+#     [-tokens 128] \
+#     [-device cuda] \
+#     [-dtype fp32] \
+#     [-cleanup]
+#
+# Prerequisites (one-time DGX staging):
+#   - Build the binary for linux/arm64 and place it on the DGX host at
+#     /var/lib/zerfoo/bin/bench_tps:
+#
+#         GOOS=linux GOARCH=arm64 go build -o bench_tps ./cmd/bench_tps
+#         rsync -av bench_tps ndungu@192.168.86.250:/var/lib/zerfoo/bin/
+#
+#   - Stage the GGUF at /var/lib/zerfoo/models/ on the DGX (the manifest mounts
+#     /var/lib/zerfoo/models read-only into the pod).
+#
+# Submit wrapper only — does no staging of binaries or models. See
+# docs/adr/083-spark-bench-runner.md for the host-access policy.
+
+set -euo pipefail
+
+SPARK_HOST="${SPARK_HOST:-192.168.86.250:8080}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MANIFEST_TEMPLATE="${REPO_ROOT}/docs/bench/manifests/gemma3-tps.yaml"
+
+GGUF_PATH="/var/lib/zerfoo/models/gemma-3-1b-it-Q4_K_M.gguf"
+PROMPT="The quick brown fox"
+TOKENS="128"
+DEVICE="cuda"
+DTYPE="fp32"
+CLEANUP=0
+
+usage() {
+  cat >&2 <<USAGE
+Usage: $0 [-gguf PATH] [-prompt TEXT] [-tokens N]
+          [-device cpu|cuda] [-dtype fp32|fp16] [-cleanup]
+
+Submits docs/bench/manifests/gemma3-tps.yaml to Spark at \${SPARK_HOST}
+(currently ${SPARK_HOST}), polls until the pod terminates, prints logs,
+and exits with the pod's success/failure status.
+
+Defaults (match the 2026-03-31 baseline params):
+  -gguf    ${GGUF_PATH}
+  -prompt  ${PROMPT}
+  -tokens  ${TOKENS}
+  -device  ${DEVICE}
+  -dtype   ${DTYPE}
+USAGE
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -gguf)     GGUF_PATH="$2"; shift 2 ;;
+    -prompt)   PROMPT="$2"; shift 2 ;;
+    -tokens)   TOKENS="$2"; shift 2 ;;
+    -device)   DEVICE="$2"; shift 2 ;;
+    -dtype)    DTYPE="$2"; shift 2 ;;
+    -cleanup)  CLEANUP=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+[[ -f "${MANIFEST_TEMPLATE}" ]] || { echo "missing manifest: ${MANIFEST_TEMPLATE}" >&2; exit 3; }
+
+RUN_ID="$(date -u +%Y%m%d-%H%M%S)"
+POD_NAME="gemma3-tps-${RUN_ID}"
+
+MANIFEST_RENDERED="$(
+  sed \
+    -e "s|\${RUN_ID}|${RUN_ID}|g" \
+    -e "s|\${GGUF_PATH}|${GGUF_PATH}|g" \
+    -e "s|\${PROMPT}|${PROMPT}|g" \
+    -e "s|\${TOKENS}|${TOKENS}|g" \
+    -e "s|\${DEVICE}|${DEVICE}|g" \
+    -e "s|\${DTYPE}|${DTYPE}|g" \
+    "${MANIFEST_TEMPLATE}"
+)"
+
+echo "gemma3-spark: submitting ${POD_NAME} to http://${SPARK_HOST}"
+SUBMIT_RESP="$(
+  printf '%s' "${MANIFEST_RENDERED}" | curl -sf -X POST \
+    -H 'Content-Type: application/yaml' \
+    --data-binary @- \
+    "http://${SPARK_HOST}/api/v1/pods"
+)" || { echo "gemma3-spark: submit failed" >&2; exit 5; }
+
+echo "gemma3-spark: submitted"
+printf '%s\n' "${SUBMIT_RESP}" | head -c 500
+echo
+
+PHASE=""
+for _ in $(seq 1 1200); do  # 1h cap at 3s/tick; tps bench is fast
+  STATUS_JSON="$(curl -sf "http://${SPARK_HOST}/api/v1/pods/${POD_NAME}" || echo '{}')"
+  PHASE="$(
+    printf '%s' "${STATUS_JSON}" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(""); sys.exit(0)
+s = d.get("status", "")
+print(s if isinstance(s, str) else "")
+'
+  )"
+  case "${PHASE}" in
+    completed|failed) break ;;
+    "")               echo "gemma3-spark: pod not found yet; retrying" >&2 ;;
+    *)                ;;
+  esac
+  sleep 3
+done
+
+echo "gemma3-spark: pod status=${PHASE}; fetching logs"
+curl -sf "http://${SPARK_HOST}/api/v1/pods/${POD_NAME}/logs" || echo "(log fetch failed)"
+
+if [[ "${CLEANUP}" -eq 1 ]]; then
+  echo
+  echo "gemma3-spark: deleting pod ${POD_NAME}"
+  curl -sf -X DELETE "http://${SPARK_HOST}/api/v1/pods/${POD_NAME}" >/dev/null || true
+fi
+
+case "${PHASE}" in
+  completed) exit 0 ;;
+  failed)    exit 1 ;;
+  *)         exit 2 ;;
+esac


### PR DESCRIPTION
## Summary
- Add Spark pod manifest (`docs/bench/manifests/gemma3-tps.yaml`) and submit wrapper (`scripts/gemma3-spark.sh`) for gemma3 throughput benches
- Add first deep-review report: `docs/deep-reviews/001-design-alignment-architectural-cleanliness.md`
- Update `docs/plan.md`

## Test plan
- [ ] Bench script submits cleanly to Spark and returns logs