### PR TITLE
T125.1.1 BLOCKED: cudaHostRegister wiring needs ztensor purego binding

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3883,6 +3883,11 @@ stress validation. Original plan archived at
   `cudaHostRegister` on the mmap'd region to enable fast DMA without bounce
   buffers. Acceptance: GPU upload of mmap'd tensors >= 90% speed of
   heap-allocated upload.
+  blocked: 2026-04-27 -- ztensor/internal/cuda purego layer exposes no
+  cudaHostRegister/cuMemHostRegister symbol. Must add the purego binding in
+  ztensor (runtime_purego.go) before zerfoo's mmap loader can call it. Per
+  zero-stub policy, no zerfoo-side wiring shipped until the upstream binding
+  exists. Filed as the first step of this task; tracked under repo: ztensor.
 
 - [ ] T125.1.2 Layer-at-a-time GPU transfer with prefetch  Owner: TBD  Est: 4h  verifies: [UC-MMAP-72B]
   Deps: T125.1.1


### PR DESCRIPTION
## Status: BLOCKED on ztensor

Task T125.1.1 (E125 mmap GPU integration) calls for wiring `cudaHostRegister` on mmap'd GGUF pages so `cuMemcpyHtoDAsync` can DMA directly from page cache without staging buffers.

## Why blocked

Per `docs/plan.md` E125, T125.1.1 is owned by **repo: ztensor**. Inspection of `ztensor/internal/cuda/` (purego.go, runtime_purego.go, runtime_purego_test.go, etc.) shows zero references to `cudaHostRegister`, `cuMemHostRegister`, `HostRegister`, or `HostAlloc`. The purego dlopen layer simply does not expose the symbol yet.

Zerfoo is CGo-free by default; all CUDA calls must go through ztensor's purego layer. With no upstream binding, there is nothing for zerfoo's mmap loader (`model/gguf/loader_mmap.go`) to call. Per the zero-stub policy in the task brief, no fake wiring is shipped.

## What this PR does

- Updates `docs/plan.md` to mark T125.1.1 with an explicit `blocked:` note pointing at the ztensor gap.
- Leaves zerfoo source untouched.

## Next step (separate task, ztensor repo)

1. Add `cuMemHostRegister` / `cuMemHostUnregister` (or runtime API equivalents) to `ztensor/internal/cuda/runtime_purego.go` with parity tests.
2. Then a follow-up zerfoo PR can wire `MmapStorage` -> register-on-load / unregister-on-close from the GPU engine path.
3. GPU verification runs via Spark on DGX (T125.1.2 / T125.2.x).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Do not merge until ztensor binding lands and zerfoo wiring follows.