### PR TITLE
refactor(layout): rename shared/ to layers/shared_latent/ (T124.5.3)

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3726,7 +3726,7 @@ left behind.
 - [x] T124.5.2 Move `synth/` -> `layers/generative/synth/` (or experimental/)  Owner: TBD  Est: 1h  verifies: [infrastructure] DONE 2026-04-27
   5 files; VAE-based synthetic data generation.
 
-- [ ] T124.5.3 Rename + relocate `shared/` -> `layers/shared_latent/`  Owner: TBD  Est: 1h  verifies: [infrastructure]
+- [x] T124.5.3 Rename + relocate `shared/` -> `layers/shared_latent/`  Owner: TBD  Est: 1h  verifies: [infrastructure]  DONE 2026-04-27
   3 files; cross-model latent space. `shared/` is the canonical
   anti-pattern bucket name.
 
@@ -3829,7 +3829,7 @@ these fail in worktree isolation, drop to 4 per wave.)
 - [ ] T124.4.5 provenance/ -> training/provenance/  verifies: [infrastructure]
 - [x] T124.4.6 federated/ -> training/federated/  verifies: [infrastructure]  DONE 2026-04-27
 - [x] T124.5.2 synth/ -> layers/generative/synth/  verifies: [infrastructure] DONE 2026-04-27
-- [ ] T124.5.3 shared/ -> layers/shared_latent/  verifies: [infrastructure]
+- [x] T124.5.3 shared/ -> layers/shared_latent/  verifies: [infrastructure]  DONE 2026-04-27
 - [ ] T124.5.4 causal+features+regime -> inference/timeseries/  verifies: [infrastructure]
 - [ ] T124.5.5 modelcache+modeldsl+registry -> model/  verifies: [infrastructure]
 - [x] T124.5.6 DONE 2026-04-27 autoopt/ -> internal/autoopt/  verifies: [infrastructure]

--- a/layers/shared_latent/doc.go
+++ b/layers/shared_latent/doc.go
@@ -19,4 +19,4 @@
 // models through the shared embedding.
 //
 // (Stability: alpha)
-package shared
+package shared_latent

--- a/layers/shared_latent/latent.go
+++ b/layers/shared_latent/latent.go
@@ -1,4 +1,4 @@
-package shared
+package shared_latent
 
 import (
 	"context"

--- a/layers/shared_latent/latent_test.go
+++ b/layers/shared_latent/latent_test.go
@@ -1,4 +1,4 @@
-package shared
+package shared_latent
 
 import (
 	"context"


### PR DESCRIPTION
## Summary
- Moves the top-level `shared/` package to `layers/shared_latent/` and renames the Go package from `shared` to `shared_latent` so the name reflects its purpose (shared latent space layers).
- No external callers existed; this is a self-contained move plus package rename.
- Plan: T124.5.3 marked DONE 2026-04-27.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -w` applied
- [x] `go test ./layers/shared_latent/...` passes