### PR TITLE
refactor(test): extract parity helpers to tests/parity/testutil/ (T124.6.2)

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3747,7 +3747,7 @@ left behind.
 - [x] T124.6.1 Move `mobile/` -> `tests/mobile/`  Owner: TBD  Est: 0.5h  verifies: [infrastructure]  DONE 2026-04-27
   Single test file; not a framework package.
 
-- [ ] T124.6.2 Extract parity helpers to `tests/parity/testutil/`  Owner: TBD  Est: 1.5h  verifies: [infrastructure]
+- [x] DONE 2026-04-27 T124.6.2 Extract parity helpers to `tests/parity/testutil/`  Owner: TBD  Est: 1.5h  verifies: [infrastructure]
   Move `makeTensor`, `setup`, `loadGolden`, `getFloat32s`, `getInts`,
   `getFloat`, `assertClose` from `tests/parity/layer_parity_test.go` into
   a non-`_test.go` `testutil` subpackage so all parity-style suites can
@@ -3820,7 +3820,7 @@ sync.
 - [x] T124.4.3 gp/ -> training/gp/  verifies: [infrastructure]  DONE 2026-04-27
 - [ ] T124.4.4 monitor+recover -> training/mlops/  verifies: [infrastructure]
 - [ ] T124.5.1 gnn/ -> layers/gnn/  verifies: [infrastructure]
-- [ ] T124.6.2 Parity helpers to tests/parity/testutil/  verifies: [infrastructure]
+- [x] DONE 2026-04-27 T124.6.2 Parity helpers to tests/parity/testutil/  verifies: [infrastructure]
 
 (Note: 10-agent cap from MEMORY-recorded pre-flight wisdom -- if any of
 these fail in worktree isolation, drop to 4 per wave.)

--- a/tests/parity/commandr_test.go
+++ b/tests/parity/commandr_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var commandRConfig = modelParityConfig{
+var commandRConfig = testutil.ModelParityConfig{
 	Name:           "Command R",
 	ZMFEnvVar:      "COMMANDR_ZMF_PATH",
 	ModelDirEnvVar: "COMMANDR_MODEL_DIR",
@@ -16,15 +18,15 @@ var commandRConfig = modelParityConfig{
 
 func TestCommandRForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, commandRConfig)
+	testutil.RunModelForwardPass(t, commandRConfig)
 }
 
 func TestCommandRGreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, commandRConfig)
+	testutil.RunModelGreedyDecode(t, commandRConfig)
 }
 
 func TestCommandRGeneration(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, commandRConfig)
+	testutil.RunModelGeneration(t, commandRConfig)
 }

--- a/tests/parity/deepseek_test.go
+++ b/tests/parity/deepseek_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var deepseekV3Config = modelParityConfig{
+var deepseekV3Config = testutil.ModelParityConfig{
 	Name:           "DeepSeek-V3",
 	ZMFEnvVar:      "DEEPSEEK_ZMF_PATH",
 	ModelDirEnvVar: "DEEPSEEK_MODEL_DIR",
@@ -16,15 +18,15 @@ var deepseekV3Config = modelParityConfig{
 
 func TestDeepSeekV3ForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, deepseekV3Config)
+	testutil.RunModelForwardPass(t, deepseekV3Config)
 }
 
 func TestDeepSeekV3GreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, deepseekV3Config)
+	testutil.RunModelGreedyDecode(t, deepseekV3Config)
 }
 
 func TestDeepSeekV3Generation(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, deepseekV3Config)
+	testutil.RunModelGeneration(t, deepseekV3Config)
 }

--- a/tests/parity/falcon_test.go
+++ b/tests/parity/falcon_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var falconConfig = modelParityConfig{
+var falconConfig = testutil.ModelParityConfig{
 	Name:           "Falcon",
 	ZMFEnvVar:      "FALCON_ZMF_PATH",
 	ModelDirEnvVar: "FALCON_MODEL_DIR",
@@ -16,15 +18,15 @@ var falconConfig = modelParityConfig{
 
 func TestFalconForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, falconConfig)
+	testutil.RunModelForwardPass(t, falconConfig)
 }
 
 func TestFalconGreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, falconConfig)
+	testutil.RunModelGreedyDecode(t, falconConfig)
 }
 
 func TestFalconGeneration(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, falconConfig)
+	testutil.RunModelGeneration(t, falconConfig)
 }

--- a/tests/parity/gemma3_q4_test.go
+++ b/tests/parity/gemma3_q4_test.go
@@ -9,13 +9,15 @@ import (
 	"github.com/zerfoo/zerfoo/inference"
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 	"github.com/zerfoo/zerfoo/registry"
+
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
 )
 
 // Q4 model tests use separate env vars:
 //   GEMMA3_Q4_ZMF_PATH  = path to Q4 quantized model.zmf
 //   GEMMA3_Q4_MODEL_DIR = directory containing config.json, tokenizer.json, model.zmf (Q4)
 
-var gemma3Q4Config = modelParityConfig{
+var gemma3Q4Config = testutil.ModelParityConfig{
 	Name:           "Gemma 3 Q4",
 	ZMFEnvVar:      "GEMMA3_Q4_ZMF_PATH",
 	ModelDirEnvVar: "GEMMA3_Q4_MODEL_DIR",
@@ -25,17 +27,17 @@ var gemma3Q4Config = modelParityConfig{
 
 func TestGemma3Q4ForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, gemma3Q4Config)
+	testutil.RunModelForwardPass(t, gemma3Q4Config)
 }
 
 func TestGemma3Q4GreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, gemma3Q4Config)
+	testutil.RunModelGreedyDecode(t, gemma3Q4Config)
 }
 
 func TestGemma3Q4Generation(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, gemma3Q4Config)
+	testutil.RunModelGeneration(t, gemma3Q4Config)
 }
 
 func BenchmarkGemma3Q4TokPerSec(b *testing.B) {
@@ -46,8 +48,8 @@ func BenchmarkGemma3Q4TokPerSec(b *testing.B) {
 		b.Skip("GEMMA3_Q4_MODEL_DIR not set; skipping")
 	}
 
-	reg := &dirRegistry{
-		models: map[string]*registry.ModelInfo{
+	reg := &testutil.DirRegistry{
+		Models: map[string]*registry.ModelInfo{
 			gemma3Q4Config.ModelID: {ID: gemma3Q4Config.ModelID, Path: modelDir},
 		},
 	}
@@ -87,8 +89,8 @@ func BenchmarkSpeculativeVsBaseline(b *testing.B) {
 		b.Skip("GEMMA3_Q4_MODEL_DIR not set; skipping")
 	}
 
-	reg := &dirRegistry{
-		models: map[string]*registry.ModelInfo{
+	reg := &testutil.DirRegistry{
+		Models: map[string]*registry.ModelInfo{
 			gemma3Q4Config.ModelID: {ID: gemma3Q4Config.ModelID, Path: modelDir},
 		},
 	}

--- a/tests/parity/gemma3_test.go
+++ b/tests/parity/gemma3_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var gemma3Config = modelParityConfig{
+var gemma3Config = testutil.ModelParityConfig{
 	Name:           "Gemma 3",
 	ZMFEnvVar:      "GEMMA3_ZMF_PATH",
 	ModelDirEnvVar: "GEMMA3_MODEL_DIR",
@@ -16,15 +18,15 @@ var gemma3Config = modelParityConfig{
 
 func TestGemma3ForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, gemma3Config)
+	testutil.RunModelForwardPass(t, gemma3Config)
 }
 
 func TestGemma3GreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, gemma3Config)
+	testutil.RunModelGreedyDecode(t, gemma3Config)
 }
 
 func TestGemma3Generation(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, gemma3Config)
+	testutil.RunModelGeneration(t, gemma3Config)
 }

--- a/tests/parity/gemma3n_test.go
+++ b/tests/parity/gemma3n_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var gemma3nConfig = modelParityConfig{
+var gemma3nConfig = testutil.ModelParityConfig{
 	Name:           "Gemma 3n",
 	ZMFEnvVar:      "GEMMA3N_ZMF_PATH",
 	ModelDirEnvVar: "GEMMA3N_MODEL_DIR",
@@ -16,15 +18,15 @@ var gemma3nConfig = modelParityConfig{
 
 func TestGemma3nForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, gemma3nConfig)
+	testutil.RunModelForwardPass(t, gemma3nConfig)
 }
 
 func TestGemma3nGreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, gemma3nConfig)
+	testutil.RunModelGreedyDecode(t, gemma3nConfig)
 }
 
 func TestGemma3nGeneration(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, gemma3nConfig)
+	testutil.RunModelGeneration(t, gemma3nConfig)
 }

--- a/tests/parity/gpu_parity_activations_test.go
+++ b/tests/parity/gpu_parity_activations_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
+
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
 )
 
 // gpuSetup creates CPU and GPU engines for GPU parity tests.
@@ -85,14 +87,14 @@ func TestGPUParity_ReLU(t *testing.T) {
 	n := 2 * 4 * 8
 	inputData := deterministicInput(n)
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLayer := activations.NewReLU(cpuEng, ops)
 	cpuOut, err := cpuLayer.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}
@@ -112,14 +114,14 @@ func TestGPUParity_GELU(t *testing.T) {
 	n := 2 * 4 * 8
 	inputData := deterministicInput(n)
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLayer := activations.NewGelu(cpuEng, ops)
 	cpuOut, err := cpuLayer.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}
@@ -139,14 +141,14 @@ func TestGPUParity_Sigmoid(t *testing.T) {
 	n := 2 * 4 * 8
 	inputData := deterministicInput(n)
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLayer := activations.NewSigmoid(cpuEng, ops)
 	cpuOut, err := cpuLayer.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}
@@ -166,14 +168,14 @@ func TestGPUParity_Tanh(t *testing.T) {
 	n := 2 * 4 * 8
 	inputData := deterministicInput(n)
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLayer := activations.NewTanh(cpuEng, ops)
 	cpuOut, err := cpuLayer.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}
@@ -193,14 +195,14 @@ func TestGPUParity_Softmax(t *testing.T) {
 	n := 2 * 4 * 8
 	inputData := deterministicInput(n)
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLayer := activations.NewSoftmax[float32](cpuEng, -1)
 	cpuOut, err := cpuLayer.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}
@@ -220,14 +222,14 @@ func TestGPUParity_LeakyReLU(t *testing.T) {
 	n := 2 * 4 * 8
 	inputData := deterministicInput(n)
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLayer := activations.NewLeakyReLU(cpuEng, ops, activations.WithAlpha[float32](0.01))
 	cpuOut, err := cpuLayer.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}
@@ -248,14 +250,14 @@ func TestGPUParity_SwiGLU(t *testing.T) {
 	n := 2 * 4 * 8
 	inputData := deterministicInput(n)
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLayer := activations.NewSwiGLU[float32](cpuEng, ops)
 	cpuOut, err := cpuLayer.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}
@@ -275,14 +277,14 @@ func TestGPUParity_Erf(t *testing.T) {
 	n := 2 * 4 * 8
 	inputData := deterministicInput(n)
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLayer := activations.NewErf(cpuEng, ops)
 	cpuOut, err := cpuLayer.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}
@@ -302,14 +304,14 @@ func TestGPUParity_FastGelu(t *testing.T) {
 	n := 2 * 4 * 8
 	inputData := deterministicInput(n)
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLayer := activations.NewFastGelu[float32](cpuEng)
 	cpuOut, err := cpuLayer.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}
@@ -343,9 +345,9 @@ func TestGPUParity_LayerNorm(t *testing.T) {
 	}
 
 	// CPU path
-	cpuInput := makeTensor(t, inputData, shape)
-	cpuGamma := makeParam(t, "gamma", gammaData, []int{hiddenSize})
-	cpuBeta := makeParam(t, "beta", betaData, []int{hiddenSize})
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
+	cpuGamma := testutil.MakeParam(t, "gamma", gammaData, []int{hiddenSize})
+	cpuBeta := testutil.MakeParam(t, "beta", betaData, []int{hiddenSize})
 	cpuLN := normalization.NewLayerNormalizationFromParams(cpuEng, float32(1e-5), cpuGamma, cpuBeta)
 	cpuOut, err := cpuLN.Forward(ctx, cpuInput)
 	if err != nil {
@@ -353,9 +355,9 @@ func TestGPUParity_LayerNorm(t *testing.T) {
 	}
 
 	// GPU path
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
-	gpuGamma := makeParam(t, "gamma", append([]float32(nil), gammaData...), []int{hiddenSize})
-	gpuBeta := makeParam(t, "beta", append([]float32(nil), betaData...), []int{hiddenSize})
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuGamma := testutil.MakeParam(t, "gamma", append([]float32(nil), gammaData...), []int{hiddenSize})
+	gpuBeta := testutil.MakeParam(t, "beta", append([]float32(nil), betaData...), []int{hiddenSize})
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{
 		gpuInput, gpuGamma.Value, gpuBeta.Value,
 	}); err != nil {
@@ -385,8 +387,8 @@ func TestGPUParity_RMSNorm(t *testing.T) {
 	}
 
 	// CPU path
-	cpuInput := makeTensor(t, inputData, shape)
-	cpuGain := makeParam(t, "gain", gainData, []int{hiddenSize})
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
+	cpuGain := testutil.MakeParam(t, "gain", gainData, []int{hiddenSize})
 	cpuRMS, err := normalization.NewRMSNormFromParam(cpuEng, ops, float32(1e-5), cpuGain)
 	if err != nil {
 		t.Fatalf("NewRMSNormFromParam CPU: %v", err)
@@ -397,8 +399,8 @@ func TestGPUParity_RMSNorm(t *testing.T) {
 	}
 
 	// GPU path
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
-	gpuGain := makeParam(t, "gain", append([]float32(nil), gainData...), []int{hiddenSize})
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuGain := testutil.MakeParam(t, "gain", append([]float32(nil), gainData...), []int{hiddenSize})
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{
 		gpuInput, gpuGain.Value,
 	}); err != nil {
@@ -438,11 +440,11 @@ func TestGPUParity_BatchNorm(t *testing.T) {
 	}
 
 	// CPU path
-	cpuInput := makeTensor(t, inputData, shape)
-	cpuScale := makeTensor(t, scaleData, []int{numChannels})
-	cpuBias := makeTensor(t, biasData, []int{numChannels})
-	cpuMean := makeTensor(t, meanData, []int{numChannels})
-	cpuVar := makeTensor(t, varData, []int{numChannels})
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
+	cpuScale := testutil.MakeTensor(t, scaleData, []int{numChannels})
+	cpuBias := testutil.MakeTensor(t, biasData, []int{numChannels})
+	cpuMean := testutil.MakeTensor(t, meanData, []int{numChannels})
+	cpuVar := testutil.MakeTensor(t, varData, []int{numChannels})
 	cpuBN := normalization.NewBatchNormalization[float32](cpuEng, ops, float32(1e-5))
 	cpuOut, err := cpuBN.Forward(ctx, cpuInput, cpuScale, cpuBias, cpuMean, cpuVar)
 	if err != nil {
@@ -450,11 +452,11 @@ func TestGPUParity_BatchNorm(t *testing.T) {
 	}
 
 	// GPU path
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
-	gpuScale := makeTensor(t, append([]float32(nil), scaleData...), []int{numChannels})
-	gpuBias := makeTensor(t, append([]float32(nil), biasData...), []int{numChannels})
-	gpuMean := makeTensor(t, append([]float32(nil), meanData...), []int{numChannels})
-	gpuVar := makeTensor(t, append([]float32(nil), varData...), []int{numChannels})
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuScale := testutil.MakeTensor(t, append([]float32(nil), scaleData...), []int{numChannels})
+	gpuBias := testutil.MakeTensor(t, append([]float32(nil), biasData...), []int{numChannels})
+	gpuMean := testutil.MakeTensor(t, append([]float32(nil), meanData...), []int{numChannels})
+	gpuVar := testutil.MakeTensor(t, append([]float32(nil), varData...), []int{numChannels})
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{
 		gpuInput, gpuScale, gpuBias, gpuMean, gpuVar,
 	}); err != nil {
@@ -485,7 +487,7 @@ func TestGPUParity_RotaryEmbedding(t *testing.T) {
 	inputData := deterministicInput(n)
 
 	// CPU path
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuRoPE, err := embeddings.NewRotaryPositionalEmbedding[float32](
 		ctx, cpuEng, headDim, seqLen, embeddings.WithRotaryBase(10000.0),
 	)
@@ -498,7 +500,7 @@ func TestGPUParity_RotaryEmbedding(t *testing.T) {
 	}
 
 	// GPU path
-	gpuInput := makeTensor(t, append([]float32(nil), inputData...), shape)
+	gpuInput := testutil.MakeTensor(t, append([]float32(nil), inputData...), shape)
 	if err := gpuEng.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
 	}

--- a/tests/parity/gpu_parity_ops_test.go
+++ b/tests/parity/gpu_parity_ops_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
+
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
 	"github.com/zerfoo/ztensor/types"
 )
 
@@ -86,8 +88,8 @@ func TestGPUParity_Linear(t *testing.T) {
 	weightData := deterministicData(inFeatures * outFeatures)
 
 	// CPU
-	cpuInput := makeTensor(t, inputData, []int{2, inFeatures})
-	cpuWeightParam := makeParam(t, "weight", weightData, []int{inFeatures, outFeatures})
+	cpuInput := testutil.MakeTensor(t, inputData, []int{2, inFeatures})
+	cpuWeightParam := testutil.MakeParam(t, "weight", weightData, []int{inFeatures, outFeatures})
 	cpuLinear := core.NewLinearFromParam(cpuEng, cpuWeightParam)
 	cpuOut, err := cpuLinear.Forward(ctx, cpuInput)
 	if err != nil {
@@ -95,8 +97,8 @@ func TestGPUParity_Linear(t *testing.T) {
 	}
 
 	// GPU
-	gpuInput := makeTensor(t, cloneF32(inputData), []int{2, inFeatures})
-	gpuWeightParam := makeParam(t, "weight", cloneF32(weightData), []int{inFeatures, outFeatures})
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), []int{2, inFeatures})
+	gpuWeightParam := testutil.MakeParam(t, "weight", cloneF32(weightData), []int{inFeatures, outFeatures})
 	gpuLinear := core.NewLinearFromParam(gpuEng, gpuWeightParam)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput, gpuWeightParam.Value}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -117,8 +119,8 @@ func TestGPUParity_MatMul(t *testing.T) {
 	bData := deterministicData(4 * 3)
 
 	// CPU
-	cpuA := makeTensor(t, aData, []int{2, 4})
-	cpuB := makeTensor(t, bData, []int{4, 3})
+	cpuA := testutil.MakeTensor(t, aData, []int{2, 4})
+	cpuB := testutil.MakeTensor(t, bData, []int{4, 3})
 	cpuMM := core.NewMatMul[float32](cpuEng)
 	cpuOut, err := cpuMM.Forward(ctx, cpuA, cpuB)
 	if err != nil {
@@ -126,8 +128,8 @@ func TestGPUParity_MatMul(t *testing.T) {
 	}
 
 	// GPU
-	gpuA := makeTensor(t, cloneF32(aData), []int{2, 4})
-	gpuB := makeTensor(t, cloneF32(bData), []int{4, 3})
+	gpuA := testutil.MakeTensor(t, cloneF32(aData), []int{2, 4})
+	gpuB := testutil.MakeTensor(t, cloneF32(bData), []int{4, 3})
 	gpuMM := core.NewMatMul[float32](gpuEng)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuA, gpuB}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -148,7 +150,7 @@ func TestGPUParity_Conv1D(t *testing.T) {
 	inputData := deterministicData(batch * seqLen * inCh)
 
 	// CPU
-	cpuInput := makeTensor(t, inputData, []int{batch, seqLen, inCh})
+	cpuInput := testutil.MakeTensor(t, inputData, []int{batch, seqLen, inCh})
 	cpuConv, err := core.NewConv1D[float32]("test_conv", cpuEng, ops, inCh, outCh, kernel)
 	if err != nil {
 		t.Fatalf("CPU NewConv1D: %v", err)
@@ -169,7 +171,7 @@ func TestGPUParity_Conv1D(t *testing.T) {
 	}
 
 	// GPU
-	gpuInput := makeTensor(t, cloneF32(inputData), []int{batch, seqLen, inCh})
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), []int{batch, seqLen, inCh})
 	gpuConv, err := core.NewConv1D[float32]("test_conv", gpuEng, ops, inCh, outCh, kernel)
 	if err != nil {
 		t.Fatalf("GPU NewConv1D: %v", err)
@@ -207,7 +209,7 @@ func TestGPUParity_FFN(t *testing.T) {
 	inputData := deterministicData(2 * inputDim)
 
 	// CPU
-	cpuInput := makeTensor(t, inputData, []int{2, inputDim})
+	cpuInput := testutil.MakeTensor(t, inputData, []int{2, inputDim})
 	cpuFFN, err := core.NewFFN[float32]("test_ffn", cpuEng, ops, inputDim, hiddenDim, outputDim, core.WithFFNNoBias[float32]())
 	if err != nil {
 		t.Fatalf("CPU NewFFN: %v", err)
@@ -228,7 +230,7 @@ func TestGPUParity_FFN(t *testing.T) {
 	}
 
 	// GPU
-	gpuInput := makeTensor(t, cloneF32(inputData), []int{2, inputDim})
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), []int{2, inputDim})
 	gpuFFN, err := core.NewFFN[float32]("test_ffn", gpuEng, ops, inputDim, hiddenDim, outputDim, core.WithFFNNoBias[float32]())
 	if err != nil {
 		t.Fatalf("GPU NewFFN: %v", err)
@@ -270,9 +272,9 @@ func TestGPUParity_SDPA_Causal(t *testing.T) {
 	vData := deterministicData(n)
 
 	// CPU
-	cpuQ := makeTensor(t, qData, []int{batch, seq, headDim})
-	cpuK := makeTensor(t, kData, []int{batch, seq, headDim})
-	cpuV := makeTensor(t, vData, []int{batch, seq, headDim})
+	cpuQ := testutil.MakeTensor(t, qData, []int{batch, seq, headDim})
+	cpuK := testutil.MakeTensor(t, kData, []int{batch, seq, headDim})
+	cpuV := testutil.MakeTensor(t, vData, []int{batch, seq, headDim})
 	cpuSDPA := attention.NewScaledDotProductAttention[float32](cpuEng, headDim)
 	cpuSDPA.SetCausal(true)
 	cpuOut, err := cpuSDPA.Forward(ctx, cpuQ, cpuK, cpuV, nil)
@@ -281,9 +283,9 @@ func TestGPUParity_SDPA_Causal(t *testing.T) {
 	}
 
 	// GPU
-	gpuQ := makeTensor(t, cloneF32(qData), []int{batch, seq, headDim})
-	gpuK := makeTensor(t, cloneF32(kData), []int{batch, seq, headDim})
-	gpuV := makeTensor(t, cloneF32(vData), []int{batch, seq, headDim})
+	gpuQ := testutil.MakeTensor(t, cloneF32(qData), []int{batch, seq, headDim})
+	gpuK := testutil.MakeTensor(t, cloneF32(kData), []int{batch, seq, headDim})
+	gpuV := testutil.MakeTensor(t, cloneF32(vData), []int{batch, seq, headDim})
 	gpuSDPA := attention.NewScaledDotProductAttention[float32](gpuEng, headDim)
 	gpuSDPA.SetCausal(true)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuQ, gpuK, gpuV}); err != nil {
@@ -308,9 +310,9 @@ func TestGPUParity_SDPA_Bidirectional(t *testing.T) {
 	vData := deterministicData(n)
 
 	// CPU
-	cpuQ := makeTensor(t, qData, []int{batch, seq, headDim})
-	cpuK := makeTensor(t, kData, []int{batch, seq, headDim})
-	cpuV := makeTensor(t, vData, []int{batch, seq, headDim})
+	cpuQ := testutil.MakeTensor(t, qData, []int{batch, seq, headDim})
+	cpuK := testutil.MakeTensor(t, kData, []int{batch, seq, headDim})
+	cpuV := testutil.MakeTensor(t, vData, []int{batch, seq, headDim})
 	cpuSDPA := attention.NewBidirectionalSDPA[float32](cpuEng, headDim)
 	cpuOut, err := cpuSDPA.Forward(ctx, cpuQ, cpuK, cpuV, nil)
 	if err != nil {
@@ -318,9 +320,9 @@ func TestGPUParity_SDPA_Bidirectional(t *testing.T) {
 	}
 
 	// GPU
-	gpuQ := makeTensor(t, cloneF32(qData), []int{batch, seq, headDim})
-	gpuK := makeTensor(t, cloneF32(kData), []int{batch, seq, headDim})
-	gpuV := makeTensor(t, cloneF32(vData), []int{batch, seq, headDim})
+	gpuQ := testutil.MakeTensor(t, cloneF32(qData), []int{batch, seq, headDim})
+	gpuK := testutil.MakeTensor(t, cloneF32(kData), []int{batch, seq, headDim})
+	gpuV := testutil.MakeTensor(t, cloneF32(vData), []int{batch, seq, headDim})
 	gpuSDPA := attention.NewBidirectionalSDPA[float32](gpuEng, headDim)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuQ, gpuK, gpuV}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -356,7 +358,7 @@ func TestGPUParity_GQA(t *testing.T) {
 		paramWeights[i] = wd
 	}
 
-	cpuInput := makeTensor(t, inputData, []int{1, 2, dModel})
+	cpuInput := testutil.MakeTensor(t, inputData, []int{1, 2, dModel})
 	cpuOut, err := cpuGQA.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
@@ -374,7 +376,7 @@ func TestGPUParity_GQA(t *testing.T) {
 		copy(p.Value.Data(), paramWeights[i])
 	}
 
-	gpuInput := makeTensor(t, cloneF32(inputData), []int{1, 2, dModel})
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), []int{1, 2, dModel})
 	toUpload := []*tensor.TensorNumeric[float32]{gpuInput}
 	for _, p := range gpuParams {
 		toUpload = append(toUpload, p.Value)
@@ -404,20 +406,20 @@ func TestGPUParity_ReLU_Backward(t *testing.T) {
 	shape := []int{2, 8}
 
 	// CPU
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuRelu := activations.NewReLU(cpuEng, ops)
 	cpuOut, err := cpuRelu.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuGradOut := makeTensor(t, gradOutData, cpuOut.Shape())
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, cpuOut.Shape())
 	cpuGrads, err := cpuRelu.Backward(ctx, types.FullBackprop, cpuGradOut, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
 	// GPU
-	gpuInput := makeTensor(t, cloneF32(inputData), shape)
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), shape)
 	gpuRelu := activations.NewReLU(gpuEng, ops)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -426,7 +428,7 @@ func TestGPUParity_ReLU_Backward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -446,19 +448,19 @@ func TestGPUParity_GELU_Backward(t *testing.T) {
 	gradOutData := deterministicData(2 * 8)
 	shape := []int{2, 8}
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuGelu := activations.NewGelu(cpuEng, ops)
 	cpuOut, err := cpuGelu.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuGradOut := makeTensor(t, gradOutData, cpuOut.Shape())
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, cpuOut.Shape())
 	cpuGrads, err := cpuGelu.Backward(ctx, types.FullBackprop, cpuGradOut, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, cloneF32(inputData), shape)
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), shape)
 	gpuGelu := activations.NewGelu(gpuEng, ops)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -467,7 +469,7 @@ func TestGPUParity_GELU_Backward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -487,19 +489,19 @@ func TestGPUParity_Sigmoid_Backward(t *testing.T) {
 	gradOutData := deterministicData(2 * 8)
 	shape := []int{2, 8}
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuSigmoid := activations.NewSigmoid(cpuEng, ops)
 	cpuOut, err := cpuSigmoid.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuGradOut := makeTensor(t, gradOutData, cpuOut.Shape())
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, cpuOut.Shape())
 	cpuGrads, err := cpuSigmoid.Backward(ctx, types.FullBackprop, cpuGradOut, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, cloneF32(inputData), shape)
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), shape)
 	gpuSigmoid := activations.NewSigmoid(gpuEng, ops)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -508,7 +510,7 @@ func TestGPUParity_Sigmoid_Backward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -528,19 +530,19 @@ func TestGPUParity_Tanh_Backward(t *testing.T) {
 	gradOutData := deterministicData(2 * 8)
 	shape := []int{2, 8}
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuTanh := activations.NewTanh(cpuEng, ops)
 	cpuOut, err := cpuTanh.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuGradOut := makeTensor(t, gradOutData, cpuOut.Shape())
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, cpuOut.Shape())
 	cpuGrads, err := cpuTanh.Backward(ctx, types.FullBackprop, cpuGradOut, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, cloneF32(inputData), shape)
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), shape)
 	gpuTanh := activations.NewTanh(gpuEng, ops)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -549,7 +551,7 @@ func TestGPUParity_Tanh_Backward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -570,19 +572,19 @@ func TestGPUParity_LeakyReLU_Backward(t *testing.T) {
 	shape := []int{2, 8}
 	alpha := 0.01
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLRelu := activations.NewLeakyReLU(cpuEng, ops, activations.WithAlpha[float32](alpha))
 	cpuOut, err := cpuLRelu.Forward(ctx, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuGradOut := makeTensor(t, gradOutData, cpuOut.Shape())
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, cpuOut.Shape())
 	cpuGrads, err := cpuLRelu.Backward(ctx, types.FullBackprop, cpuGradOut, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, cloneF32(inputData), shape)
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), shape)
 	gpuLRelu := activations.NewLeakyReLU(gpuEng, ops, activations.WithAlpha[float32](alpha))
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -591,7 +593,7 @@ func TestGPUParity_LeakyReLU_Backward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -611,7 +613,7 @@ func TestGPUParity_SwiGLU_Backward(t *testing.T) {
 	inputData := deterministicData(2 * 8)
 	shape := []int{2, 8}
 
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuSwiGLU := activations.NewSwiGLU[float32](cpuEng, ops)
 	cpuOut, err := cpuSwiGLU.Forward(ctx, cpuInput)
 	if err != nil {
@@ -619,13 +621,13 @@ func TestGPUParity_SwiGLU_Backward(t *testing.T) {
 	}
 
 	gradOutData := deterministicData(len(cpuOut.Data()))
-	cpuGradOut := makeTensor(t, gradOutData, cpuOut.Shape())
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, cpuOut.Shape())
 	cpuGrads, err := cpuSwiGLU.Backward(ctx, types.FullBackprop, cpuGradOut, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
-	gpuInput := makeTensor(t, cloneF32(inputData), shape)
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), shape)
 	gpuSwiGLU := activations.NewSwiGLU[float32](gpuEng, ops)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -634,7 +636,7 @@ func TestGPUParity_SwiGLU_Backward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -660,23 +662,23 @@ func TestGPUParity_LayerNorm_Backward(t *testing.T) {
 	betaData := deterministicData(features)
 
 	// CPU
-	cpuGammaParam := makeParam(t, "gamma", gammaData, []int{features})
-	cpuBetaParam := makeParam(t, "beta", betaData, []int{features})
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuGammaParam := testutil.MakeParam(t, "gamma", gammaData, []int{features})
+	cpuBetaParam := testutil.MakeParam(t, "beta", betaData, []int{features})
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuLN := normalization.NewLayerNormalizationFromParams(cpuEng, eps, cpuGammaParam, cpuBetaParam)
 	if _, err := cpuLN.Forward(ctx, cpuInput); err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuGradOut := makeTensor(t, gradOutData, shape)
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, shape)
 	cpuGrads, err := cpuLN.Backward(ctx, types.FullBackprop, cpuGradOut, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
 	// GPU
-	gpuGammaParam := makeParam(t, "gamma", cloneF32(gammaData), []int{features})
-	gpuBetaParam := makeParam(t, "beta", cloneF32(betaData), []int{features})
-	gpuInput := makeTensor(t, cloneF32(inputData), shape)
+	gpuGammaParam := testutil.MakeParam(t, "gamma", cloneF32(gammaData), []int{features})
+	gpuBetaParam := testutil.MakeParam(t, "beta", cloneF32(betaData), []int{features})
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), shape)
 	gpuLN := normalization.NewLayerNormalizationFromParams(gpuEng, eps, gpuGammaParam, gpuBetaParam)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput, gpuGammaParam.Value, gpuBetaParam.Value}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -684,7 +686,7 @@ func TestGPUParity_LayerNorm_Backward(t *testing.T) {
 	if _, err := gpuLN.Forward(ctx, gpuInput); err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), shape)
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), shape)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -709,8 +711,8 @@ func TestGPUParity_RMSNorm_Backward(t *testing.T) {
 	gainData := deterministicData(features)
 
 	// CPU
-	cpuGainParam := makeParam(t, "gain", gainData, []int{features})
-	cpuInput := makeTensor(t, inputData, shape)
+	cpuGainParam := testutil.MakeParam(t, "gain", gainData, []int{features})
+	cpuInput := testutil.MakeTensor(t, inputData, shape)
 	cpuRMS, err := normalization.NewRMSNormFromParam(cpuEng, ops, eps, cpuGainParam)
 	if err != nil {
 		t.Fatalf("CPU NewRMSNorm: %v", err)
@@ -718,15 +720,15 @@ func TestGPUParity_RMSNorm_Backward(t *testing.T) {
 	if _, err := cpuRMS.Forward(ctx, cpuInput); err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuGradOut := makeTensor(t, gradOutData, shape)
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, shape)
 	cpuGrads, err := cpuRMS.Backward(ctx, types.FullBackprop, cpuGradOut, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
 	// GPU
-	gpuGainParam := makeParam(t, "gain", cloneF32(gainData), []int{features})
-	gpuInput := makeTensor(t, cloneF32(inputData), shape)
+	gpuGainParam := testutil.MakeParam(t, "gain", cloneF32(gainData), []int{features})
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), shape)
 	gpuRMS, err := normalization.NewRMSNormFromParam(gpuEng, ops, eps, gpuGainParam)
 	if err != nil {
 		t.Fatalf("GPU NewRMSNorm: %v", err)
@@ -737,7 +739,7 @@ func TestGPUParity_RMSNorm_Backward(t *testing.T) {
 	if _, err := gpuRMS.Forward(ctx, gpuInput); err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), shape)
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), shape)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -759,21 +761,21 @@ func TestGPUParity_Linear_Backward(t *testing.T) {
 	gradOutData := deterministicData(2 * outFeatures)
 
 	// CPU
-	cpuInput := makeTensor(t, inputData, []int{2, inFeatures})
-	cpuWeightParam := makeParam(t, "weight", weightData, []int{inFeatures, outFeatures})
+	cpuInput := testutil.MakeTensor(t, inputData, []int{2, inFeatures})
+	cpuWeightParam := testutil.MakeParam(t, "weight", weightData, []int{inFeatures, outFeatures})
 	cpuLinear := core.NewLinearFromParam(cpuEng, cpuWeightParam)
 	if _, err := cpuLinear.Forward(ctx, cpuInput); err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuGradOut := makeTensor(t, gradOutData, []int{2, outFeatures})
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, []int{2, outFeatures})
 	cpuGrads, err := cpuLinear.Backward(ctx, types.FullBackprop, cpuGradOut, cpuInput)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
 	// GPU
-	gpuInput := makeTensor(t, cloneF32(inputData), []int{2, inFeatures})
-	gpuWeightParam := makeParam(t, "weight", cloneF32(weightData), []int{inFeatures, outFeatures})
+	gpuInput := testutil.MakeTensor(t, cloneF32(inputData), []int{2, inFeatures})
+	gpuWeightParam := testutil.MakeParam(t, "weight", cloneF32(weightData), []int{inFeatures, outFeatures})
 	gpuLinear := core.NewLinearFromParam(gpuEng, gpuWeightParam)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuInput, gpuWeightParam.Value}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -781,7 +783,7 @@ func TestGPUParity_Linear_Backward(t *testing.T) {
 	if _, err := gpuLinear.Forward(ctx, gpuInput); err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), []int{2, outFeatures})
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), []int{2, outFeatures})
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -809,21 +811,21 @@ func TestGPUParity_MatMul_Backward(t *testing.T) {
 	gradOutData := deterministicData(2 * 3)
 
 	// CPU
-	cpuA := makeTensor(t, aData, []int{2, 4})
-	cpuB := makeTensor(t, bData, []int{4, 3})
+	cpuA := testutil.MakeTensor(t, aData, []int{2, 4})
+	cpuB := testutil.MakeTensor(t, bData, []int{4, 3})
 	cpuMM := core.NewMatMul[float32](cpuEng)
 	if _, err := cpuMM.Forward(ctx, cpuA, cpuB); err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuGradOut := makeTensor(t, gradOutData, []int{2, 3})
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, []int{2, 3})
 	cpuGrads, err := cpuMM.Backward(ctx, types.FullBackprop, cpuGradOut, cpuA, cpuB)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
 	// GPU
-	gpuA := makeTensor(t, cloneF32(aData), []int{2, 4})
-	gpuB := makeTensor(t, cloneF32(bData), []int{4, 3})
+	gpuA := testutil.MakeTensor(t, cloneF32(aData), []int{2, 4})
+	gpuB := testutil.MakeTensor(t, cloneF32(bData), []int{4, 3})
 	gpuMM := core.NewMatMul[float32](gpuEng)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuA, gpuB}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -831,7 +833,7 @@ func TestGPUParity_MatMul_Backward(t *testing.T) {
 	if _, err := gpuMM.Forward(ctx, gpuA, gpuB); err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), []int{2, 3})
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), []int{2, 3})
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -853,21 +855,21 @@ func TestGPUParity_MSELoss_Backward(t *testing.T) {
 	shape := []int{2, 4}
 
 	// CPU
-	cpuPred := makeTensor(t, predData, shape)
-	cpuTarget := makeTensor(t, targetData, shape)
+	cpuPred := testutil.MakeTensor(t, predData, shape)
+	cpuTarget := testutil.MakeTensor(t, targetData, shape)
 	cpuMSE := loss.NewMSE(cpuEng, ops)
 	if _, err := cpuMSE.Forward(ctx, cpuPred, cpuTarget); err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuDOut := makeTensor(t, []float32{1.0}, []int{1})
+	cpuDOut := testutil.MakeTensor(t, []float32{1.0}, []int{1})
 	cpuGrads, err := cpuMSE.Backward(ctx, types.FullBackprop, cpuDOut, cpuPred, cpuTarget)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
 	// GPU
-	gpuPred := makeTensor(t, cloneF32(predData), shape)
-	gpuTarget := makeTensor(t, cloneF32(targetData), shape)
+	gpuPred := testutil.MakeTensor(t, cloneF32(predData), shape)
+	gpuTarget := testutil.MakeTensor(t, cloneF32(targetData), shape)
 	gpuMSE := loss.NewMSE(gpuEng, ops)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuPred, gpuTarget}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -875,7 +877,7 @@ func TestGPUParity_MSELoss_Backward(t *testing.T) {
 	if _, err := gpuMSE.Forward(ctx, gpuPred, gpuTarget); err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuDOut := makeTensor(t, []float32{1.0}, []int{1})
+	gpuDOut := testutil.MakeTensor(t, []float32{1.0}, []int{1})
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuDOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -897,21 +899,21 @@ func TestGPUParity_BCELoss_Backward(t *testing.T) {
 	shape := []int{2, 4}
 
 	// CPU
-	cpuPred := makeTensor(t, predData, shape)
-	cpuTarget := makeTensor(t, targetData, shape)
+	cpuPred := testutil.MakeTensor(t, predData, shape)
+	cpuTarget := testutil.MakeTensor(t, targetData, shape)
 	cpuBCE := loss.NewBCELoss(cpuEng, ops)
 	if _, err := cpuBCE.Forward(ctx, cpuPred, cpuTarget); err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuDOut := makeTensor(t, []float32{1.0}, []int{1})
+	cpuDOut := testutil.MakeTensor(t, []float32{1.0}, []int{1})
 	cpuGrads, err := cpuBCE.Backward(ctx, types.FullBackprop, cpuDOut, cpuPred, cpuTarget)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
 	// GPU
-	gpuPred := makeTensor(t, cloneF32(predData), shape)
-	gpuTarget := makeTensor(t, cloneF32(targetData), shape)
+	gpuPred := testutil.MakeTensor(t, cloneF32(predData), shape)
+	gpuTarget := testutil.MakeTensor(t, cloneF32(targetData), shape)
 	gpuBCE := loss.NewBCELoss(gpuEng, ops)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuPred, gpuTarget}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -919,7 +921,7 @@ func TestGPUParity_BCELoss_Backward(t *testing.T) {
 	if _, err := gpuBCE.Forward(ctx, gpuPred, gpuTarget); err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuDOut := makeTensor(t, []float32{1.0}, []int{1})
+	gpuDOut := testutil.MakeTensor(t, []float32{1.0}, []int{1})
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuDOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -941,21 +943,21 @@ func TestGPUParity_CrossEntropyLoss_Backward(t *testing.T) {
 	logitShape := []int{3, 5}
 
 	// CPU
-	cpuLogits := makeTensor(t, logitData, logitShape)
-	cpuTargets := makeTensor(t, targetData, []int{3})
+	cpuLogits := testutil.MakeTensor(t, logitData, logitShape)
+	cpuTargets := testutil.MakeTensor(t, targetData, []int{3})
 	cpuCEL := loss.NewCrossEntropyLoss[float32](cpuEng)
 	if _, err := cpuCEL.Forward(ctx, cpuLogits, cpuTargets); err != nil {
 		t.Fatalf("CPU Forward: %v", err)
 	}
-	cpuDOut := makeTensor(t, []float32{1.0}, []int{1})
+	cpuDOut := testutil.MakeTensor(t, []float32{1.0}, []int{1})
 	cpuGrads, err := cpuCEL.Backward(ctx, types.FullBackprop, cpuDOut)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
 	// GPU
-	gpuLogits := makeTensor(t, cloneF32(logitData), logitShape)
-	gpuTargets := makeTensor(t, cloneF32(targetData), []int{3})
+	gpuLogits := testutil.MakeTensor(t, cloneF32(logitData), logitShape)
+	gpuTargets := testutil.MakeTensor(t, cloneF32(targetData), []int{3})
 	gpuCEL := loss.NewCrossEntropyLoss[float32](gpuEng)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuLogits, gpuTargets}); err != nil {
 		t.Fatalf("UploadWeights: %v", err)
@@ -963,7 +965,7 @@ func TestGPUParity_CrossEntropyLoss_Backward(t *testing.T) {
 	if _, err := gpuCEL.Forward(ctx, gpuLogits, gpuTargets); err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuDOut := makeTensor(t, []float32{1.0}, []int{1})
+	gpuDOut := testutil.MakeTensor(t, []float32{1.0}, []int{1})
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuDOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}
@@ -987,9 +989,9 @@ func TestGPUParity_SDPA_Backward(t *testing.T) {
 	shape := []int{batch, seq, headDim}
 
 	// CPU
-	cpuQ := makeTensor(t, qData, shape)
-	cpuK := makeTensor(t, kData, shape)
-	cpuV := makeTensor(t, vData, shape)
+	cpuQ := testutil.MakeTensor(t, qData, shape)
+	cpuK := testutil.MakeTensor(t, kData, shape)
+	cpuV := testutil.MakeTensor(t, vData, shape)
 	cpuSDPA := attention.NewScaledDotProductAttention[float32](cpuEng, headDim)
 	cpuSDPA.SetCausal(true)
 	cpuOut, err := cpuSDPA.Forward(ctx, cpuQ, cpuK, cpuV, nil)
@@ -997,16 +999,16 @@ func TestGPUParity_SDPA_Backward(t *testing.T) {
 		t.Fatalf("CPU Forward: %v", err)
 	}
 	gradOutData := deterministicData(len(cpuOut.Data()))
-	cpuGradOut := makeTensor(t, gradOutData, cpuOut.Shape())
+	cpuGradOut := testutil.MakeTensor(t, gradOutData, cpuOut.Shape())
 	cpuGrads, err := cpuSDPA.Backward(ctx, types.FullBackprop, cpuGradOut, cpuQ, cpuK, cpuV)
 	if err != nil {
 		t.Fatalf("CPU Backward: %v", err)
 	}
 
 	// GPU
-	gpuQ := makeTensor(t, cloneF32(qData), shape)
-	gpuK := makeTensor(t, cloneF32(kData), shape)
-	gpuV := makeTensor(t, cloneF32(vData), shape)
+	gpuQ := testutil.MakeTensor(t, cloneF32(qData), shape)
+	gpuK := testutil.MakeTensor(t, cloneF32(kData), shape)
+	gpuV := testutil.MakeTensor(t, cloneF32(vData), shape)
 	gpuSDPA := attention.NewScaledDotProductAttention[float32](gpuEng, headDim)
 	gpuSDPA.SetCausal(true)
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuQ, gpuK, gpuV}); err != nil {
@@ -1016,7 +1018,7 @@ func TestGPUParity_SDPA_Backward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GPU Forward: %v", err)
 	}
-	gpuGradOut := makeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
+	gpuGradOut := testutil.MakeTensor(t, cloneF32(gradOutData), gpuOut.Shape())
 	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGradOut}); err != nil {
 		t.Fatalf("UploadWeights grad: %v", err)
 	}

--- a/tests/parity/layer_parity_test.go
+++ b/tests/parity/layer_parity_test.go
@@ -2,12 +2,8 @@ package parity_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/zerfoo/zerfoo/layers/activations"
@@ -35,250 +31,129 @@ import (
 	"github.com/zerfoo/zerfoo/training/loss"
 	"github.com/zerfoo/zerfoo/training/optimizer"
 	"github.com/zerfoo/zerfoo/training/rl"
-	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
 	"github.com/zerfoo/ztensor/types"
+
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
 )
-
-// goldenDir returns the path to tests/golden/layers/.
-func goldenDir() string {
-	_, f, _, _ := runtime.Caller(0)
-	return filepath.Join(filepath.Dir(f), "..", "golden", "layers")
-}
-
-// loadGolden loads a golden JSON file and returns the raw map.
-func loadGolden(t *testing.T, name string) map[string]interface{} {
-	t.Helper()
-	path := filepath.Join(goldenDir(), name+".json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("load golden %s: %v", name, err)
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(data, &m); err != nil {
-		t.Fatalf("parse golden %s: %v", name, err)
-	}
-	return m
-}
-
-// getFloat32s extracts a float32 slice from a JSON array.
-func getFloat32s(m map[string]interface{}, key string) []float32 {
-	arr, ok := m[key].([]interface{})
-	if !ok {
-		return nil
-	}
-	out := make([]float32, len(arr))
-	for i, v := range arr {
-		out[i] = float32(v.(float64))
-	}
-	return out
-}
-
-// getInts extracts an int slice from a JSON array.
-func getInts(m map[string]interface{}, key string) []int {
-	arr, ok := m[key].([]interface{})
-	if !ok {
-		return nil
-	}
-	out := make([]int, len(arr))
-	for i, v := range arr {
-		out[i] = int(v.(float64))
-	}
-	return out
-}
-
-// getFloat extracts a float64 from a JSON value.
-func getFloat(m map[string]interface{}, key string) float64 {
-	return m[key].(float64)
-}
-
-// makeTensor creates a tensor from golden data.
-func makeTensor(t *testing.T, data []float32, shape []int) *tensor.TensorNumeric[float32] {
-	t.Helper()
-	tn, err := tensor.New[float32](shape, data)
-	if err != nil {
-		t.Fatalf("create tensor shape=%v: %v", shape, err)
-	}
-	return tn
-}
-
-// makeParam creates a graph.Parameter from golden data.
-func makeParam(t *testing.T, name string, data []float32, shape []int) *graph.Parameter[float32] {
-	t.Helper()
-	tn := makeTensor(t, data, shape)
-	p, err := graph.NewParameter[float32](name, tn, tensor.New[float32])
-	if err != nil {
-		t.Fatalf("create param %s: %v", name, err)
-	}
-	return p
-}
-
-// compareSlices compares two float32 slices with tolerance.
-// Returns the number of mismatches and the max absolute difference.
-func compareSlices(got, want []float32, tol float64) (mismatches int, maxDiff float64) {
-	if len(got) != len(want) {
-		return len(got) + len(want), math.Inf(1)
-	}
-	for i := range got {
-		diff := math.Abs(float64(got[i] - want[i]))
-		if diff > maxDiff {
-			maxDiff = diff
-		}
-		if diff > tol {
-			mismatches++
-		}
-	}
-	return
-}
-
-// assertClose compares output data against expected with tolerance.
-func assertClose(t *testing.T, label string, got, want []float32, tol float64) {
-	t.Helper()
-	if len(got) != len(want) {
-		t.Fatalf("%s: length mismatch: got %d, want %d", label, len(got), len(want))
-	}
-	mismatches, maxDiff := compareSlices(got, want, tol)
-	if mismatches > 0 {
-		// Show first few mismatches
-		shown := 0
-		for i := range got {
-			diff := math.Abs(float64(got[i] - want[i]))
-			if diff > tol {
-				t.Errorf("%s[%d]: got %g, want %g (diff=%g)", label, i, got[i], want[i], diff)
-				shown++
-				if shown >= 5 {
-					break
-				}
-			}
-		}
-		t.Errorf("%s: %d/%d values exceed tolerance %g (maxDiff=%g)", label, mismatches, len(got), tol, maxDiff)
-	}
-}
-
-// setup creates engine and ops for all tests.
-func setup() (compute.Engine[float32], *numeric.Float32Ops) {
-	ops := &numeric.Float32Ops{}
-	engine := compute.NewCPUEngine[float32](ops)
-	return engine, ops
-}
 
 // ---------------------------------------------------------------------------
 // Activation tests
 // ---------------------------------------------------------------------------
 
 func TestParity_ReLU(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_relu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_relu")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	relu := activations.NewReLU(engine, ops)
 	output, err := relu.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "relu_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "relu_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_GELU(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_gelu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_gelu")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	gelu := activations.NewGelu(engine, ops)
 	output, err := gelu.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "gelu_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "gelu_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Sigmoid(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_sigmoid")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_sigmoid")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	sigmoid := activations.NewSigmoid(engine, ops)
 	output, err := sigmoid.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "sigmoid_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "sigmoid_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Tanh(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_tanh")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_tanh")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	tanh := activations.NewTanh(engine, ops)
 	output, err := tanh.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "tanh_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "tanh_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Softmax(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "activation_softmax")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_softmax")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	sm := activations.NewSoftmax[float32](engine, -1)
 	output, err := sm.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "softmax_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "softmax_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_LeakyReLU(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_leaky_relu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_leaky_relu")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	alpha := getFloat(g, "alpha")
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	alpha := testutil.GetFloat(g, "alpha")
 	lrelu := activations.NewLeakyReLU(engine, ops, activations.WithAlpha[float32](alpha))
 	output, err := lrelu.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "leaky_relu_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "leaky_relu_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_SwiGLU(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_swiglu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_swiglu")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	swiglu := activations.NewSwiGLU[float32](engine, ops)
 	output, err := swiglu.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "swiglu_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "swiglu_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Erf(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_erf")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_erf")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	erf := activations.NewErf(engine, ops)
 	output, err := erf.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "erf_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "erf_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -286,113 +161,113 @@ func TestParity_Erf(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_Functional_ReLU(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_relu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_relu")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	output, err := functional.ReLU(context.Background(), engine, ops, input)
 	if err != nil {
 		t.Fatalf("functional.ReLU: %v", err)
 	}
-	assertClose(t, "functional_relu", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "functional_relu", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Functional_GELU(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_gelu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_gelu")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	output, err := functional.GELU(context.Background(), engine, ops, input)
 	if err != nil {
 		t.Fatalf("functional.GELU: %v", err)
 	}
-	assertClose(t, "functional_gelu", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "functional_gelu", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Functional_Sigmoid(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_sigmoid")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_sigmoid")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	output, err := functional.Sigmoid(context.Background(), engine, ops, input)
 	if err != nil {
 		t.Fatalf("functional.Sigmoid: %v", err)
 	}
-	assertClose(t, "functional_sigmoid", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "functional_sigmoid", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Functional_SiLU(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_silu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_silu")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	output, err := functional.SiLU(context.Background(), engine, ops, input)
 	if err != nil {
 		t.Fatalf("functional.SiLU: %v", err)
 	}
-	assertClose(t, "functional_silu", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "functional_silu", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Functional_Softmax(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "activation_softmax")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_softmax")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	output, err := functional.Softmax(context.Background(), engine, input, -1)
 	if err != nil {
 		t.Fatalf("functional.Softmax: %v", err)
 	}
-	assertClose(t, "functional_softmax", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "functional_softmax", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Functional_LayerNorm(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "norm_layer_norm")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "norm_layer_norm")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	gamma := makeTensor(t, getFloat32s(g, "gamma"), getInts(g, "gamma_shape"))
-	beta := makeTensor(t, getFloat32s(g, "beta"), getInts(g, "beta_shape"))
-	eps := float32(getFloat(g, "epsilon"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	gamma := testutil.MakeTensor(t, testutil.GetFloat32s(g, "gamma"), testutil.GetInts(g, "gamma_shape"))
+	beta := testutil.MakeTensor(t, testutil.GetFloat32s(g, "beta"), testutil.GetInts(g, "beta_shape"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
 
 	output, err := functional.LayerNorm(context.Background(), engine, input, gamma, beta, eps)
 	if err != nil {
 		t.Fatalf("functional.LayerNorm: %v", err)
 	}
-	assertClose(t, "functional_layernorm", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "functional_layernorm", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Functional_RMSNorm(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "norm_rms_norm")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "norm_rms_norm")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	gain := makeTensor(t, getFloat32s(g, "gain"), getInts(g, "gain_shape"))
-	eps := float32(getFloat(g, "epsilon"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	gain := testutil.MakeTensor(t, testutil.GetFloat32s(g, "gain"), testutil.GetInts(g, "gain_shape"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
 
 	output, err := functional.RMSNorm(context.Background(), engine, input, gain, eps)
 	if err != nil {
 		t.Fatalf("functional.RMSNorm: %v", err)
 	}
-	assertClose(t, "functional_rmsnorm", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "functional_rmsnorm", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Functional_Linear(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "core_dense")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_dense")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	// functional.Linear expects weight as [out_features, in_features] (PyTorch convention)
 	// and does x @ W^T + bias. Golden file has weight as [in, out], so we transpose.
-	wShape := getInts(g, "weight_shape")
-	wData := getFloat32s(g, "weight")
+	wShape := testutil.GetInts(g, "weight_shape")
+	wData := testutil.GetFloat32s(g, "weight")
 	inF, outF := wShape[0], wShape[1]
 	// Transpose [in, out] -> [out, in]
 	wT := make([]float32, len(wData))
@@ -401,14 +276,14 @@ func TestParity_Functional_Linear(t *testing.T) {
 			wT[j*inF+i] = wData[i*outF+j]
 		}
 	}
-	weight := makeTensor(t, wT, []int{outF, inF})
-	bias := makeTensor(t, getFloat32s(g, "bias"), getInts(g, "bias_shape"))
+	weight := testutil.MakeTensor(t, wT, []int{outF, inF})
+	bias := testutil.MakeTensor(t, testutil.GetFloat32s(g, "bias"), testutil.GetInts(g, "bias_shape"))
 
 	output, err := functional.Linear(context.Background(), engine, input, weight, bias)
 	if err != nil {
 		t.Fatalf("functional.Linear: %v", err)
 	}
-	assertClose(t, "functional_linear", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "functional_linear", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -416,17 +291,17 @@ func TestParity_Functional_Linear(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_LayerNorm(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "norm_layer_norm")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "norm_layer_norm")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	gamma := makeTensor(t, getFloat32s(g, "gamma"), getInts(g, "gamma_shape"))
-	beta := makeTensor(t, getFloat32s(g, "beta"), getInts(g, "beta_shape"))
-	eps := float32(getFloat(g, "epsilon"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	gamma := testutil.MakeTensor(t, testutil.GetFloat32s(g, "gamma"), testutil.GetInts(g, "gamma_shape"))
+	beta := testutil.MakeTensor(t, testutil.GetFloat32s(g, "beta"), testutil.GetInts(g, "beta_shape"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
 
-	gammaParam := makeParam(t, "gamma", getFloat32s(g, "gamma"), getInts(g, "gamma_shape"))
-	betaParam := makeParam(t, "beta", getFloat32s(g, "beta"), getInts(g, "beta_shape"))
+	gammaParam := testutil.MakeParam(t, "gamma", testutil.GetFloat32s(g, "gamma"), testutil.GetInts(g, "gamma_shape"))
+	betaParam := testutil.MakeParam(t, "beta", testutil.GetFloat32s(g, "beta"), testutil.GetInts(g, "beta_shape"))
 
 	_ = gamma
 	_ = beta
@@ -436,18 +311,18 @@ func TestParity_LayerNorm(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "layer_norm_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "layer_norm_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_RMSNorm(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "norm_rms_norm")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "norm_rms_norm")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	eps := float32(getFloat(g, "epsilon"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
 
-	gainParam := makeParam(t, "gain", getFloat32s(g, "gain"), getInts(g, "gain_shape"))
+	gainParam := testutil.MakeParam(t, "gain", testutil.GetFloat32s(g, "gain"), testutil.GetInts(g, "gain_shape"))
 
 	rms, err := normalization.NewRMSNormFromParam(engine, ops, eps, gainParam)
 	if err != nil {
@@ -457,7 +332,7 @@ func TestParity_RMSNorm(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "rms_norm_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "rms_norm_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -465,48 +340,48 @@ func TestParity_RMSNorm(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_Linear(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "core_linear")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_linear")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	weightParam := makeParam(t, "weight", getFloat32s(g, "weight"), getInts(g, "weight_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	weightParam := testutil.MakeParam(t, "weight", testutil.GetFloat32s(g, "weight"), testutil.GetInts(g, "weight_shape"))
 
 	linear := core.NewLinearFromParam(engine, weightParam)
 	output, err := linear.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "linear_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "linear_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_MatMul(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "core_matmul")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_matmul")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	a := makeTensor(t, getFloat32s(g, "input_a"), getInts(g, "input_a_shape"))
-	b := makeTensor(t, getFloat32s(g, "input_b"), getInts(g, "input_b_shape"))
+	a := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_a"), testutil.GetInts(g, "input_a_shape"))
+	b := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_b"), testutil.GetInts(g, "input_b_shape"))
 
 	mm := core.NewMatMul[float32](engine)
 	output, err := mm.Forward(context.Background(), a, b)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "matmul_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "matmul_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Conv1D(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "core_conv1d")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_conv1d")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	inCh := int(getFloat(g, "in_channels"))
-	outCh := int(getFloat(g, "out_channels"))
-	kernel := int(getFloat(g, "kernel_size"))
-	stride := int(getFloat(g, "stride"))
-	padding := int(getFloat(g, "padding"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	inCh := int(testutil.GetFloat(g, "in_channels"))
+	outCh := int(testutil.GetFloat(g, "out_channels"))
+	kernel := int(testutil.GetFloat(g, "kernel_size"))
+	stride := int(testutil.GetFloat(g, "stride"))
+	padding := int(testutil.GetFloat(g, "padding"))
 
 	conv, err := core.NewConv1D[float32]("test_conv1d", engine, ops, inCh, outCh, kernel,
 		core.Conv1DStride(stride), core.Conv1DPadding(padding))
@@ -516,8 +391,8 @@ func TestParity_Conv1D(t *testing.T) {
 
 	// Set weights from golden data
 	params := conv.Parameters()
-	weightData := getFloat32s(g, "weight")
-	biasData := getFloat32s(g, "bias")
+	weightData := testutil.GetFloat32s(g, "weight")
+	biasData := testutil.GetFloat32s(g, "bias")
 
 	// The Conv1D weight shape from PyTorch is [out_ch, in_ch, kernel],
 	// need to check if Zerfoo expects the same layout
@@ -534,7 +409,7 @@ func TestParity_Conv1D(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "conv1d_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "conv1d_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -542,57 +417,57 @@ func TestParity_Conv1D(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_SDPA_Causal(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "attention_sdpa_causal")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "attention_sdpa_causal")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	q := makeTensor(t, getFloat32s(g, "query"), getInts(g, "query_shape"))
-	k := makeTensor(t, getFloat32s(g, "key"), getInts(g, "key_shape"))
-	v := makeTensor(t, getFloat32s(g, "value"), getInts(g, "value_shape"))
+	q := testutil.MakeTensor(t, testutil.GetFloat32s(g, "query"), testutil.GetInts(g, "query_shape"))
+	k := testutil.MakeTensor(t, testutil.GetFloat32s(g, "key"), testutil.GetInts(g, "key_shape"))
+	v := testutil.MakeTensor(t, testutil.GetFloat32s(g, "value"), testutil.GetInts(g, "value_shape"))
 
-	headDim := getInts(g, "query_shape")[2]
+	headDim := testutil.GetInts(g, "query_shape")[2]
 	sdpa := attention.NewScaledDotProductAttention[float32](engine, headDim)
 	sdpa.SetCausal(true)
 	output, err := sdpa.Forward(context.Background(), q, k, v, nil)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "sdpa_causal_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "sdpa_causal_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_SDPA_Bidirectional(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "attention_sdpa_bidirectional")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "attention_sdpa_bidirectional")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	q := makeTensor(t, getFloat32s(g, "query"), getInts(g, "query_shape"))
-	k := makeTensor(t, getFloat32s(g, "key"), getInts(g, "key_shape"))
-	v := makeTensor(t, getFloat32s(g, "value"), getInts(g, "value_shape"))
+	q := testutil.MakeTensor(t, testutil.GetFloat32s(g, "query"), testutil.GetInts(g, "query_shape"))
+	k := testutil.MakeTensor(t, testutil.GetFloat32s(g, "key"), testutil.GetInts(g, "key_shape"))
+	v := testutil.MakeTensor(t, testutil.GetFloat32s(g, "value"), testutil.GetInts(g, "value_shape"))
 
-	headDim := getInts(g, "query_shape")[2]
+	headDim := testutil.GetInts(g, "query_shape")[2]
 	sdpa := attention.NewBidirectionalSDPA[float32](engine, headDim)
 	output, err := sdpa.Forward(context.Background(), q, k, v, nil)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "sdpa_bidirectional_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "sdpa_bidirectional_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_MultiHeadAttention(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "attention_multi_head")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "attention_multi_head")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	q := makeTensor(t, getFloat32s(g, "query"), getInts(g, "query_shape"))
-	k := makeTensor(t, getFloat32s(g, "key"), getInts(g, "key_shape"))
-	v := makeTensor(t, getFloat32s(g, "value"), getInts(g, "value_shape"))
-	nHeads := int(getFloat(g, "n_heads"))
+	q := testutil.MakeTensor(t, testutil.GetFloat32s(g, "query"), testutil.GetInts(g, "query_shape"))
+	k := testutil.MakeTensor(t, testutil.GetFloat32s(g, "key"), testutil.GetInts(g, "key_shape"))
+	v := testutil.MakeTensor(t, testutil.GetFloat32s(g, "value"), testutil.GetInts(g, "value_shape"))
+	nHeads := int(testutil.GetFloat(g, "n_heads"))
 
 	output, err := functional.MultiHeadAttention(context.Background(), engine, q, k, v, nHeads)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "mha_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "mha_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -600,13 +475,13 @@ func TestParity_MultiHeadAttention(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_TokenEmbedding(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "embedding_token")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "embedding_token")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	tableData := getFloat32s(g, "table")
-	tableShape := getInts(g, "table_shape")
-	tableParam := makeParam(t, "embedding_table", tableData, tableShape)
+	tableData := testutil.GetFloat32s(g, "table")
+	tableShape := testutil.GetInts(g, "table_shape")
+	tableParam := testutil.MakeParam(t, "embedding_table", tableData, tableShape)
 
 	emb, err := embeddings.NewTokenEmbeddingFromParam(engine, tableParam)
 	if err != nil {
@@ -619,25 +494,25 @@ func TestParity_TokenEmbedding(t *testing.T) {
 	for i, v := range idxRaw {
 		idxData[i] = float32(v.(float64))
 	}
-	idxTensor := makeTensor(t, idxData, []int{len(idxData)})
+	idxTensor := testutil.MakeTensor(t, idxData, []int{len(idxData)})
 
 	output, err := emb.Forward(context.Background(), idxTensor)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "token_embedding_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "token_embedding_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_RotaryEmbedding(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "embedding_rotary")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "embedding_rotary")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	inputShape := getInts(g, "input_shape")
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	inputShape := testutil.GetInts(g, "input_shape")
 	headDim := inputShape[2]
 	seqLen := inputShape[1]
-	base := getFloat(g, "base")
+	base := testutil.GetFloat(g, "base")
 
 	rope, err := embeddings.NewRotaryPositionalEmbedding[float32](
 		context.Background(), engine, headDim, seqLen,
@@ -651,7 +526,7 @@ func TestParity_RotaryEmbedding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "rotary_embedding_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "rotary_embedding_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -659,12 +534,12 @@ func TestParity_RotaryEmbedding(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_MSELoss(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "loss_mse")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "loss_mse")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	pred := makeTensor(t, getFloat32s(g, "predictions"), getInts(g, "predictions_shape"))
-	target := makeTensor(t, getFloat32s(g, "targets"), getInts(g, "targets_shape"))
+	pred := testutil.MakeTensor(t, testutil.GetFloat32s(g, "predictions"), testutil.GetInts(g, "predictions_shape"))
+	target := testutil.MakeTensor(t, testutil.GetFloat32s(g, "targets"), testutil.GetInts(g, "targets_shape"))
 
 	mse := loss.NewMSE(engine, ops)
 	output, err := mse.Forward(context.Background(), pred, target)
@@ -672,7 +547,7 @@ func TestParity_MSELoss(t *testing.T) {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	expectedLoss := float32(getFloat(g, "expected_loss"))
+	expectedLoss := float32(testutil.GetFloat(g, "expected_loss"))
 	gotLoss := output.Data()[0]
 	diff := math.Abs(float64(gotLoss - expectedLoss))
 	if diff > tol {
@@ -681,12 +556,12 @@ func TestParity_MSELoss(t *testing.T) {
 }
 
 func TestParity_BCELoss(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "loss_bce")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "loss_bce")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	pred := makeTensor(t, getFloat32s(g, "predictions"), getInts(g, "predictions_shape"))
-	target := makeTensor(t, getFloat32s(g, "targets"), getInts(g, "targets_shape"))
+	pred := testutil.MakeTensor(t, testutil.GetFloat32s(g, "predictions"), testutil.GetInts(g, "predictions_shape"))
+	target := testutil.MakeTensor(t, testutil.GetFloat32s(g, "targets"), testutil.GetInts(g, "targets_shape"))
 
 	bce := loss.NewBCELoss(engine, ops)
 	output, err := bce.Forward(context.Background(), pred, target)
@@ -694,7 +569,7 @@ func TestParity_BCELoss(t *testing.T) {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	expectedLoss := float32(getFloat(g, "expected_loss"))
+	expectedLoss := float32(testutil.GetFloat(g, "expected_loss"))
 	gotLoss := output.Data()[0]
 	diff := math.Abs(float64(gotLoss - expectedLoss))
 	if diff > tol {
@@ -703,11 +578,11 @@ func TestParity_BCELoss(t *testing.T) {
 }
 
 func TestParity_CrossEntropyLoss(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "loss_cross_entropy")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "loss_cross_entropy")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	logits := makeTensor(t, getFloat32s(g, "logits"), getInts(g, "logits_shape"))
+	logits := testutil.MakeTensor(t, testutil.GetFloat32s(g, "logits"), testutil.GetInts(g, "logits_shape"))
 
 	// Create target tensor (class indices as float32)
 	targetsRaw := g["targets"].([]interface{})
@@ -715,7 +590,7 @@ func TestParity_CrossEntropyLoss(t *testing.T) {
 	for i, v := range targetsRaw {
 		targetData[i] = float32(v.(float64))
 	}
-	targets := makeTensor(t, targetData, []int{len(targetData)})
+	targets := testutil.MakeTensor(t, targetData, []int{len(targetData)})
 
 	cel := loss.NewCrossEntropyLoss[float32](engine)
 	output, err := cel.Forward(context.Background(), logits, targets)
@@ -723,7 +598,7 @@ func TestParity_CrossEntropyLoss(t *testing.T) {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	expectedLoss := float32(getFloat(g, "expected_loss"))
+	expectedLoss := float32(testutil.GetFloat(g, "expected_loss"))
 	gotLoss := output.Data()[0]
 	diff := math.Abs(float64(gotLoss - expectedLoss))
 	if diff > tol {
@@ -736,43 +611,43 @@ func TestParity_CrossEntropyLoss(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_ReduceSum(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_reduce_sum")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_reduce_sum")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	axes := getInts(g, "axes")
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	axes := testutil.GetInts(g, "axes")
 
 	rs := reducesum.New[float32](engine, axes, true)
 	output, err := rs.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "reduce_sum_keepdims", output.Data(), getFloat32s(g, "expected_output_keepdims"), tol)
+	testutil.AssertClose(t, "reduce_sum_keepdims", output.Data(), testutil.GetFloat32s(g, "expected_output_keepdims"), tol)
 }
 
 func TestParity_Transpose(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_transpose")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_transpose")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	axes := getInts(g, "axes")
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	axes := testutil.GetInts(g, "axes")
 
 	tr := ltranspose.New[float32](engine, axes)
 	output, err := tr.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "transpose_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "transpose_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Gather(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_gather")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_gather")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	table := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	table := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 
 	// Indices as int tensor
 	idxRaw := g["indices"].([]interface{})
@@ -792,13 +667,13 @@ func TestParity_Gather(t *testing.T) {
 	for i, v := range idxData {
 		idxFloat[i] = float32(v)
 	}
-	idxFloatTensor := makeTensor(t, idxFloat, []int{len(idxFloat)})
+	idxFloatTensor := testutil.MakeTensor(t, idxFloat, []int{len(idxFloat)})
 
 	output, err := ga.Forward(context.Background(), idxFloatTensor)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "gather_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "gather_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -806,23 +681,23 @@ func TestParity_Gather(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_Conv2D(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "core_conv2d")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_conv2d")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	weight := makeTensor(t, getFloat32s(g, "weight"), getInts(g, "weight_shape"))
-	bias := makeTensor(t, getFloat32s(g, "bias"), getInts(g, "bias_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	weight := testutil.MakeTensor(t, testutil.GetFloat32s(g, "weight"), testutil.GetInts(g, "weight_shape"))
+	bias := testutil.MakeTensor(t, testutil.GetFloat32s(g, "bias"), testutil.GetInts(g, "bias_shape"))
 
-	strides := getInts(g, "stride")
-	pads := getInts(g, "padding")
+	strides := testutil.GetInts(g, "stride")
+	pads := testutil.GetInts(g, "padding")
 
 	conv := core.NewConv2d[float32](engine, ops, strides, pads, []int{1, 1}, 1)
 	output, err := conv.Forward(context.Background(), input, weight, bias)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "conv2d_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "conv2d_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -841,15 +716,15 @@ func transposeWeight2D(data []float32, rows, cols int) []float32 {
 }
 
 func TestParity_FFN(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "core_ffn")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_ffn")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 
-	inputShape := getInts(g, "input_shape")
-	w1Shape := getInts(g, "w1_shape")
-	w2Shape := getInts(g, "w2_shape")
+	inputShape := testutil.GetInts(g, "input_shape")
+	w1Shape := testutil.GetInts(g, "w1_shape")
+	w2Shape := testutil.GetInts(g, "w2_shape")
 
 	inputDim := inputShape[1] // 4
 	hiddenDim := w1Shape[1]   // 32
@@ -865,9 +740,9 @@ func TestParity_FFN(t *testing.T) {
 	// FFN has w1, w2, w3 Dense layers. Each Dense has a Linear with weights [in, out].
 	// Golden data has weights in [in, out] format (matching Zerfoo's layout).
 	params := ffn.Parameters()
-	w1Data := getFloat32s(g, "w1")
-	w2Data := getFloat32s(g, "w2")
-	w3Data := getFloat32s(g, "w3")
+	w1Data := testutil.GetFloat32s(g, "w1")
+	w2Data := testutil.GetFloat32s(g, "w2")
+	w3Data := testutil.GetFloat32s(g, "w3")
 
 	for _, p := range params {
 		pdata := p.Value.Data()
@@ -897,7 +772,7 @@ func TestParity_FFN(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "ffn_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "ffn_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -905,24 +780,24 @@ func TestParity_FFN(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_BatchNorm(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "norm_batch_norm")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "norm_batch_norm")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	scale := makeTensor(t, getFloat32s(g, "scale"), getInts(g, "scale_shape"))
-	bias := makeTensor(t, getFloat32s(g, "bias"), getInts(g, "bias_shape"))
-	runningMean := makeTensor(t, getFloat32s(g, "running_mean"), getInts(g, "scale_shape"))
-	runningVar := makeTensor(t, getFloat32s(g, "running_var"), getInts(g, "scale_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	scale := testutil.MakeTensor(t, testutil.GetFloat32s(g, "scale"), testutil.GetInts(g, "scale_shape"))
+	bias := testutil.MakeTensor(t, testutil.GetFloat32s(g, "bias"), testutil.GetInts(g, "bias_shape"))
+	runningMean := testutil.MakeTensor(t, testutil.GetFloat32s(g, "running_mean"), testutil.GetInts(g, "scale_shape"))
+	runningVar := testutil.MakeTensor(t, testutil.GetFloat32s(g, "running_var"), testutil.GetInts(g, "scale_shape"))
 
-	eps := float32(getFloat(g, "epsilon"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
 	bn := normalization.NewBatchNormalization[float32](engine, ops, eps)
 
 	output, err := bn.Forward(context.Background(), input, scale, bias, runningMean, runningVar)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "batch_norm_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "batch_norm_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -930,12 +805,12 @@ func TestParity_BatchNorm(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_Dropout(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "op_dropout")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_dropout")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	rate := float32(getFloat(g, "rate"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	rate := float32(testutil.GetFloat(g, "rate"))
 
 	dropout := regularization.NewDropout[float32](engine, ops, rate)
 	// Eval mode (default): output should be identical to input
@@ -943,7 +818,7 @@ func TestParity_Dropout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "dropout_eval", output.Data(), getFloat32s(g, "expected_output_eval"), tol)
+	testutil.AssertClose(t, "dropout_eval", output.Data(), testutil.GetFloat32s(g, "expected_output_eval"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -951,18 +826,18 @@ func TestParity_Dropout(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_AdamW(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "optimizer_adamw")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "optimizer_adamw")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	lr := float32(getFloat(g, "lr"))
-	beta1 := float32(getFloat(g, "beta1"))
-	beta2 := float32(getFloat(g, "beta2"))
-	eps := float32(getFloat(g, "epsilon"))
-	wd := float32(getFloat(g, "weight_decay"))
+	lr := float32(testutil.GetFloat(g, "lr"))
+	beta1 := float32(testutil.GetFloat(g, "beta1"))
+	beta2 := float32(testutil.GetFloat(g, "beta2"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
+	wd := float32(testutil.GetFloat(g, "weight_decay"))
 
-	param := makeParam(t, "test_param", getFloat32s(g, "param_before"), getInts(g, "param_shape"))
-	gradTensor := makeTensor(t, getFloat32s(g, "grad"), getInts(g, "param_shape"))
+	param := testutil.MakeParam(t, "test_param", testutil.GetFloat32s(g, "param_before"), testutil.GetInts(g, "param_shape"))
+	gradTensor := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad"), testutil.GetInts(g, "param_shape"))
 	param.Gradient = gradTensor
 
 	adamw := optimizer.NewAdamW[float32](engine, lr, beta1, beta2, eps, wd)
@@ -970,7 +845,7 @@ func TestParity_AdamW(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Step: %v", err)
 	}
-	assertClose(t, "adamw_step", param.Value.Data(), getFloat32s(g, "expected_param_after"), tol)
+	testutil.AssertClose(t, "adamw_step", param.Value.Data(), testutil.GetFloat32s(g, "expected_param_after"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -978,14 +853,14 @@ func TestParity_AdamW(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_SGD(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "optimizer_sgd")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "optimizer_sgd")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	lr := float32(getFloat(g, "lr"))
+	lr := float32(testutil.GetFloat(g, "lr"))
 
-	param := makeParam(t, "test_param", getFloat32s(g, "param_before"), getInts(g, "param_shape"))
-	gradTensor := makeTensor(t, getFloat32s(g, "grad"), getInts(g, "param_shape"))
+	param := testutil.MakeParam(t, "test_param", testutil.GetFloat32s(g, "param_before"), testutil.GetInts(g, "param_shape"))
+	gradTensor := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad"), testutil.GetInts(g, "param_shape"))
 	param.Gradient = gradTensor
 
 	sgd := optimizer.NewSGD[float32](engine, ops, lr)
@@ -993,7 +868,7 @@ func TestParity_SGD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Step: %v", err)
 	}
-	assertClose(t, "sgd_step", param.Value.Data(), getFloat32s(g, "expected_param_after"), tol)
+	testutil.AssertClose(t, "sgd_step", param.Value.Data(), testutil.GetFloat32s(g, "expected_param_after"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1001,18 +876,18 @@ func TestParity_SGD(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_EMA(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "optimizer_ema")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "optimizer_ema")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	decay := float32(getFloat(g, "decay"))
-	lr := float32(getFloat(g, "lr"))
-	shape := getInts(g, "param_shape")
+	decay := float32(testutil.GetFloat(g, "decay"))
+	lr := float32(testutil.GetFloat(g, "lr"))
+	shape := testutil.GetInts(g, "param_shape")
 
 	// Build param with param_before data and set gradient so inner SGD step
 	// produces param_after_inner = param_before - lr*grad.
-	param := makeParam(t, "test_param", getFloat32s(g, "param_before"), shape)
-	gradTensor := makeTensor(t, getFloat32s(g, "grad"), shape)
+	param := testutil.MakeParam(t, "test_param", testutil.GetFloat32s(g, "param_before"), shape)
+	gradTensor := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad"), shape)
 	param.Gradient = gradTensor
 
 	// Use SGD as inner optimizer (simple: param -= lr * grad).
@@ -1045,19 +920,19 @@ func TestParity_EMA(t *testing.T) {
 	// We compute expected = decay * param_before + (1-decay) * param_after_inner
 	// and compare against the golden expected_shadow_after.
 
-	paramBefore := getFloat32s(g, "param_before")
-	paramAfterInner := getFloat32s(g, "param_after_inner")
-	expectedShadow := getFloat32s(g, "expected_shadow_after")
+	paramBefore := testutil.GetFloat32s(g, "param_before")
+	paramAfterInner := testutil.GetFloat32s(g, "param_after_inner")
+	expectedShadow := testutil.GetFloat32s(g, "expected_shadow_after")
 
 	// Verify golden data is self-consistent: expected = decay * before + (1-decay) * after_inner
 	computed := make([]float32, len(paramBefore))
 	for i := range computed {
 		computed[i] = decay*paramBefore[i] + (1-decay)*paramAfterInner[i]
 	}
-	assertClose(t, "ema_golden_consistency", computed, expectedShadow, tol)
+	testutil.AssertClose(t, "ema_golden_consistency", computed, expectedShadow, tol)
 
 	// Verify the actual param after SGD step matches param_after_inner
-	assertClose(t, "ema_inner_step", param.Value.Data(), paramAfterInner, tol)
+	testutil.AssertClose(t, "ema_inner_step", param.Value.Data(), paramAfterInner, tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1065,16 +940,16 @@ func TestParity_EMA(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_SWA(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "optimizer_swa")
-	tol := getFloat(g, "tolerance")
-	shape := getInts(g, "param_shape")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "optimizer_swa")
+	tol := testutil.GetFloat(g, "tolerance")
+	shape := testutil.GetInts(g, "param_shape")
 
-	param0Data := getFloat32s(g, "param0")
-	param1Data := getFloat32s(g, "param1")
+	param0Data := testutil.GetFloat32s(g, "param0")
+	param1Data := testutil.GetFloat32s(g, "param1")
 
 	// Create parameter with first epoch values
-	param := makeParam(t, "test_param", param0Data, shape)
+	param := testutil.MakeParam(t, "test_param", param0Data, shape)
 
 	inner := optimizer.NewSGD[float32](engine, ops, 0) // lr=0 so Step is a no-op
 	swa := optimizer.NewSWA[float32](inner, engine, 0) // startEpoch=0
@@ -1100,7 +975,7 @@ func TestParity_SWA(t *testing.T) {
 		t.Fatalf("SwapWeights: %v", err)
 	}
 
-	assertClose(t, "swa_avg", param.Value.Data(), getFloat32s(g, "expected_avg_after"), tol)
+	testutil.AssertClose(t, "swa_avg", param.Value.Data(), testutil.GetFloat32s(g, "expected_avg_after"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1190,15 +1065,15 @@ func TestParity_HeInitializer(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_SimpleRNN(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "recurrent_simple_rnn")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "recurrent_simple_rnn")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	inputDim := int(getFloat(g, "input_dim"))
-	hiddenDim := int(getFloat(g, "hidden_dim"))
+	inputDim := int(testutil.GetFloat(g, "input_dim"))
+	hiddenDim := int(testutil.GetFloat(g, "hidden_dim"))
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	inputShape := getInts(g, "input_shape")
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	inputShape := testutil.GetInts(g, "input_shape")
 	batchSize := inputShape[0]
 	seqLen := inputShape[1]
 
@@ -1213,19 +1088,19 @@ func TestParity_SimpleRNN(t *testing.T) {
 	params := rnn.Parameters()
 	// inputWeights: Linear with weights [inputDim, hiddenDim]
 	// PyTorch weight_ih: [hiddenDim, inputDim] -> transpose
-	wihShape := getInts(g, "weight_ih_shape")
-	wihData := transposeWeight2D(getFloat32s(g, "weight_ih"), wihShape[0], wihShape[1])
+	wihShape := testutil.GetInts(g, "weight_ih_shape")
+	wihData := transposeWeight2D(testutil.GetFloat32s(g, "weight_ih"), wihShape[0], wihShape[1])
 	copy(params[0].Value.Data(), wihData)
 
 	// hiddenWeights: Linear with weights [hiddenDim, hiddenDim]
 	// PyTorch weight_hh: [hiddenDim, hiddenDim] -> transpose (symmetric dims but data differs)
-	whhShape := getInts(g, "weight_hh_shape")
-	whhData := transposeWeight2D(getFloat32s(g, "weight_hh"), whhShape[0], whhShape[1])
+	whhShape := testutil.GetInts(g, "weight_hh_shape")
+	whhData := transposeWeight2D(testutil.GetFloat32s(g, "weight_hh"), whhShape[0], whhShape[1])
 	copy(params[1].Value.Data(), whhData)
 
 	// Bias: Zerfoo has a single bias, PyTorch has bias_ih + bias_hh
-	biasIH := getFloat32s(g, "bias_ih")
-	biasHH := getFloat32s(g, "bias_hh")
+	biasIH := testutil.GetFloat32s(g, "bias_ih")
+	biasHH := testutil.GetFloat32s(g, "bias_hh")
 	combinedBias := make([]float32, len(biasIH))
 	for i := range combinedBias {
 		combinedBias[i] = biasIH[i] + biasHH[i]
@@ -1241,7 +1116,7 @@ func TestParity_SimpleRNN(t *testing.T) {
 		for b := 0; b < batchSize; b++ {
 			copy(stepData[b*inputDim:(b+1)*inputDim], inData[b*seqLen*inputDim+step*inputDim:b*seqLen*inputDim+step*inputDim+inputDim])
 		}
-		stepInput := makeTensor(t, stepData, []int{batchSize, inputDim})
+		stepInput := testutil.MakeTensor(t, stepData, []int{batchSize, inputDim})
 		stepOutput, err := rnn.Forward(context.Background(), stepInput)
 		if err != nil {
 			t.Fatalf("Forward step %d: %v", step, err)
@@ -1251,7 +1126,7 @@ func TestParity_SimpleRNN(t *testing.T) {
 
 	// Reshape outputs to [batch, seq, hidden] for comparison
 	// outputs is currently [seq * batch * hidden], need to rearrange to [batch * seq * hidden]
-	expected := getFloat32s(g, "expected_output")
+	expected := testutil.GetFloat32s(g, "expected_output")
 	reordered := make([]float32, len(outputs))
 	for b := 0; b < batchSize; b++ {
 		for s := 0; s < seqLen; s++ {
@@ -1260,7 +1135,7 @@ func TestParity_SimpleRNN(t *testing.T) {
 			}
 		}
 	}
-	assertClose(t, "simple_rnn_output", reordered, expected, tol)
+	testutil.AssertClose(t, "simple_rnn_output", reordered, expected, tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1268,13 +1143,13 @@ func TestParity_SimpleRNN(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_S4(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "ssm_s4")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "ssm_s4")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	inputDim := int(getFloat(g, "input_dim"))
-	stateDim := int(getFloat(g, "state_dim"))
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	inputDim := int(testutil.GetFloat(g, "input_dim"))
+	stateDim := int(testutil.GetFloat(g, "state_dim"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 
 	s4, err := ssm.NewS4[float32]("test_s4", engine, ops, inputDim, stateDim)
 	if err != nil {
@@ -1284,16 +1159,16 @@ func TestParity_S4(t *testing.T) {
 	// Set parameters from golden data
 	params := s4.Parameters()
 	// Parameters order: aLog, b, c, d
-	copy(params[0].Value.Data(), getFloat32s(g, "a_log"))
-	copy(params[1].Value.Data(), getFloat32s(g, "b"))
-	copy(params[2].Value.Data(), getFloat32s(g, "c"))
-	copy(params[3].Value.Data(), getFloat32s(g, "d"))
+	copy(params[0].Value.Data(), testutil.GetFloat32s(g, "a_log"))
+	copy(params[1].Value.Data(), testutil.GetFloat32s(g, "b"))
+	copy(params[2].Value.Data(), testutil.GetFloat32s(g, "c"))
+	copy(params[3].Value.Data(), testutil.GetFloat32s(g, "d"))
 
 	output, err := s4.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "s4_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "s4_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1301,17 +1176,17 @@ func TestParity_S4(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_MambaBlock(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "ssm_mamba")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "ssm_mamba")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	inputDim := int(getFloat(g, "input_dim"))
-	hiddenDim := int(getFloat(g, "hidden_dim"))
-	stateSize := int(getFloat(g, "state_size"))
-	convKernel := int(getFloat(g, "conv_kernel"))
+	inputDim := int(testutil.GetFloat(g, "input_dim"))
+	hiddenDim := int(testutil.GetFloat(g, "hidden_dim"))
+	stateSize := int(testutil.GetFloat(g, "state_size"))
+	convKernel := int(testutil.GetFloat(g, "conv_kernel"))
 	dtRank := 1 // golden file uses rank-1 dt projection
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 
 	block, err := ssm.NewMambaBlock[float32](
 		"test_mamba", engine, ops,
@@ -1335,10 +1210,10 @@ func TestParity_MambaBlock(t *testing.T) {
 		t.Fatalf("expected 8 params, got %d", len(params))
 	}
 
-	copy(params[0].Value.Data(), getFloat32s(g, "w_in"))
-	copy(params[1].Value.Data(), getFloat32s(g, "conv_weight"))
-	copy(params[2].Value.Data(), getFloat32s(g, "conv_bias"))
-	copy(params[3].Value.Data(), getFloat32s(g, "w_dt"))
+	copy(params[0].Value.Data(), testutil.GetFloat32s(g, "w_in"))
+	copy(params[1].Value.Data(), testutil.GetFloat32s(g, "conv_weight"))
+	copy(params[2].Value.Data(), testutil.GetFloat32s(g, "conv_bias"))
+	copy(params[3].Value.Data(), testutil.GetFloat32s(g, "w_dt"))
 
 	// dtProj: set to all-ones to replicate PyTorch's broadcasting behavior
 	// (golden file uses rank-1 dt without a separate dt->dInner projection)
@@ -1347,7 +1222,7 @@ func TestParity_MambaBlock(t *testing.T) {
 		dtProjData[i] = 1.0
 	}
 
-	copy(params[5].Value.Data(), getFloat32s(g, "A_log"))
+	copy(params[5].Value.Data(), testutil.GetFloat32s(g, "A_log"))
 
 	// D: set to zeros (golden file doesn't use skip connection)
 	dData := params[6].Value.Data()
@@ -1355,13 +1230,13 @@ func TestParity_MambaBlock(t *testing.T) {
 		dData[i] = 0.0
 	}
 
-	copy(params[7].Value.Data(), getFloat32s(g, "w_out"))
+	copy(params[7].Value.Data(), testutil.GetFloat32s(g, "w_out"))
 
 	output, err := block.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "mamba_block_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "mamba_block_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1378,17 +1253,17 @@ func TestParity_TransformerBlock(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_FastGelu(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "activation_fast_gelu")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_fast_gelu")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	fg := activations.NewFastGelu[float32](engine)
 	output, err := fg.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "fast_gelu_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "fast_gelu_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1396,13 +1271,13 @@ func TestParity_FastGelu(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_SimplifiedLayerNorm(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "norm_simplified_layer_norm")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "norm_simplified_layer_norm")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	gain := makeTensor(t, getFloat32s(g, "gain"), getInts(g, "gain_shape"))
-	eps := float32(getFloat(g, "epsilon"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	gain := testutil.MakeTensor(t, testutil.GetFloat32s(g, "gain"), testutil.GetInts(g, "gain_shape"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
 
 	sln, err := normalization.NewSimplifiedLayerNormalization[float32](engine, ops, gain, eps)
 	if err != nil {
@@ -1412,7 +1287,7 @@ func TestParity_SimplifiedLayerNorm(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "simplified_layer_norm_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "simplified_layer_norm_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1420,13 +1295,13 @@ func TestParity_SimplifiedLayerNorm(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_SkipSimplifiedLayerNorm(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "norm_skip_simplified_layer_norm")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "norm_skip_simplified_layer_norm")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	gain := makeTensor(t, getFloat32s(g, "gain"), getInts(g, "gain_shape"))
-	eps := float32(getFloat(g, "epsilon"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	gain := testutil.MakeTensor(t, testutil.GetFloat32s(g, "gain"), testutil.GetInts(g, "gain_shape"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
 
 	ssln, err := normalization.NewSkipSimplifiedLayerNormalization[float32](engine, ops, gain, eps)
 	if err != nil {
@@ -1436,7 +1311,7 @@ func TestParity_SkipSimplifiedLayerNorm(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "skip_simplified_layer_norm_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "skip_simplified_layer_norm_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1444,13 +1319,13 @@ func TestParity_SkipSimplifiedLayerNorm(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_LMHead(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "core_lm_head")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_lm_head")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	hiddenDim := int(getFloat(g, "hidden_dim"))
-	vocabSize := int(getFloat(g, "vocab_size"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	hiddenDim := int(testutil.GetFloat(g, "hidden_dim"))
+	vocabSize := int(testutil.GetFloat(g, "vocab_size"))
 
 	lmHead, err := core.NewLMHead[float32](engine, ops, hiddenDim, vocabSize)
 	if err != nil {
@@ -1462,13 +1337,13 @@ func TestParity_LMHead(t *testing.T) {
 	if len(params) < 1 {
 		t.Fatalf("expected at least 1 parameter, got %d", len(params))
 	}
-	copy(params[0].Value.Data(), getFloat32s(g, "weight"))
+	copy(params[0].Value.Data(), testutil.GetFloat32s(g, "weight"))
 
 	output, err := lmHead.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "lm_head_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "lm_head_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1476,13 +1351,13 @@ func TestParity_LMHead(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_PatchEmbed(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "timeseries_patch_embed")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "timeseries_patch_embed")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	patchSize := int(getFloat(g, "patch_size"))
-	embedDim := int(getFloat(g, "embed_dim"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	patchSize := int(testutil.GetFloat(g, "patch_size"))
+	embedDim := int(testutil.GetFloat(g, "embed_dim"))
 
 	pe, err := timeseries.NewPatchEmbed[float32]("test_patch_embed", engine, ops, patchSize, embedDim)
 	if err != nil {
@@ -1494,13 +1369,13 @@ func TestParity_PatchEmbed(t *testing.T) {
 	if len(params) < 1 {
 		t.Fatalf("expected at least 1 parameter, got %d", len(params))
 	}
-	copy(params[0].Value.Data(), getFloat32s(g, "proj"))
+	copy(params[0].Value.Data(), testutil.GetFloat32s(g, "proj"))
 
 	output, err := pe.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "patch_embed_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "patch_embed_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1508,13 +1383,13 @@ func TestParity_PatchEmbed(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_TSMixerBlock(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "timeseries_tsmixer_block")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "timeseries_tsmixer_block")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	numPatches := int(getFloat(g, "num_patches"))
-	dModel := int(getFloat(g, "d_model"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	numPatches := int(testutil.GetFloat(g, "num_patches"))
+	dModel := int(testutil.GetFloat(g, "d_model"))
 
 	block, err := timeseries.NewTSMixerBlock[float32](engine, ops, numPatches, dModel, 1, false)
 	if err != nil {
@@ -1528,16 +1403,16 @@ func TestParity_TSMixerBlock(t *testing.T) {
 		t.Fatalf("expected at least 4 parameters, got %d", len(params))
 	}
 
-	copy(params[0].Value.Data(), getFloat32s(g, "time_mlp1_w"))
-	copy(params[1].Value.Data(), getFloat32s(g, "time_mlp2_w"))
-	copy(params[2].Value.Data(), getFloat32s(g, "time_ln_gamma"))
-	copy(params[3].Value.Data(), getFloat32s(g, "time_ln_beta"))
+	copy(params[0].Value.Data(), testutil.GetFloat32s(g, "time_mlp1_w"))
+	copy(params[1].Value.Data(), testutil.GetFloat32s(g, "time_mlp2_w"))
+	copy(params[2].Value.Data(), testutil.GetFloat32s(g, "time_ln_gamma"))
+	copy(params[3].Value.Data(), testutil.GetFloat32s(g, "time_ln_beta"))
 
 	output, err := block.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "tsmixer_block_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "tsmixer_block_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1545,14 +1420,14 @@ func TestParity_TSMixerBlock(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_SSMLayer(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "timeseries_ssm_layer")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "timeseries_ssm_layer")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	dState := int(getFloat(g, "d_state"))
-	dInput := int(getFloat(g, "d_input"))
-	dOutput := int(getFloat(g, "d_output"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	dState := int(testutil.GetFloat(g, "d_state"))
+	dInput := int(testutil.GetFloat(g, "d_input"))
+	dOutput := int(testutil.GetFloat(g, "d_output"))
 
 	ssmLayer, err := timeseries.NewSSMLayer[float32](engine, dState, dInput, dOutput)
 	if err != nil {
@@ -1565,17 +1440,17 @@ func TestParity_SSMLayer(t *testing.T) {
 	if len(params) < 5 {
 		t.Fatalf("expected at least 5 parameters, got %d", len(params))
 	}
-	copy(params[0].Value.Data(), getFloat32s(g, "A_log"))
-	copy(params[1].Value.Data(), getFloat32s(g, "B"))
-	copy(params[2].Value.Data(), getFloat32s(g, "C"))
-	copy(params[3].Value.Data(), getFloat32s(g, "D"))
-	copy(params[4].Value.Data(), getFloat32s(g, "log_dt"))
+	copy(params[0].Value.Data(), testutil.GetFloat32s(g, "A_log"))
+	copy(params[1].Value.Data(), testutil.GetFloat32s(g, "B"))
+	copy(params[2].Value.Data(), testutil.GetFloat32s(g, "C"))
+	copy(params[3].Value.Data(), testutil.GetFloat32s(g, "D"))
+	copy(params[4].Value.Data(), testutil.GetFloat32s(g, "log_dt"))
 
 	output, err := ssmLayer.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "ssm_layer_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "ssm_layer_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1583,112 +1458,112 @@ func TestParity_SSMLayer(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_Op_Add(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_add")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_add")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	a := makeTensor(t, getFloat32s(g, "input_a"), getInts(g, "input_shape"))
-	b := makeTensor(t, getFloat32s(g, "input_b"), getInts(g, "input_shape"))
+	a := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_a"), testutil.GetInts(g, "input_shape"))
+	b := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_b"), testutil.GetInts(g, "input_shape"))
 	output, err := engine.Add(context.Background(), a, b)
 	if err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	assertClose(t, "op_add", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_add", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Op_Sub(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_sub")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_sub")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	a := makeTensor(t, getFloat32s(g, "input_a"), getInts(g, "input_shape"))
-	b := makeTensor(t, getFloat32s(g, "input_b"), getInts(g, "input_shape"))
+	a := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_a"), testutil.GetInts(g, "input_shape"))
+	b := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_b"), testutil.GetInts(g, "input_shape"))
 	output, err := engine.Sub(context.Background(), a, b)
 	if err != nil {
 		t.Fatalf("Sub: %v", err)
 	}
-	assertClose(t, "op_sub", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_sub", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Op_Mul(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_mul")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_mul")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	a := makeTensor(t, getFloat32s(g, "input_a"), getInts(g, "input_shape"))
-	b := makeTensor(t, getFloat32s(g, "input_b"), getInts(g, "input_shape"))
+	a := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_a"), testutil.GetInts(g, "input_shape"))
+	b := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_b"), testutil.GetInts(g, "input_shape"))
 	output, err := engine.Mul(context.Background(), a, b)
 	if err != nil {
 		t.Fatalf("Mul: %v", err)
 	}
-	assertClose(t, "op_mul", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_mul", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Op_Div(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_div")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_div")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	a := makeTensor(t, getFloat32s(g, "input_a"), getInts(g, "input_shape"))
-	b := makeTensor(t, getFloat32s(g, "input_b"), getInts(g, "input_shape"))
+	a := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_a"), testutil.GetInts(g, "input_shape"))
+	b := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_b"), testutil.GetInts(g, "input_shape"))
 	output, err := engine.Div(context.Background(), a, b)
 	if err != nil {
 		t.Fatalf("Div: %v", err)
 	}
-	assertClose(t, "op_div", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_div", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Op_Pow(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_pow")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_pow")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	a := makeTensor(t, getFloat32s(g, "input_a"), getInts(g, "input_shape"))
-	b := makeTensor(t, getFloat32s(g, "input_b"), getInts(g, "input_shape"))
+	a := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_a"), testutil.GetInts(g, "input_shape"))
+	b := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_b"), testutil.GetInts(g, "input_shape"))
 	output, err := engine.Pow(context.Background(), a, b)
 	if err != nil {
 		t.Fatalf("Pow: %v", err)
 	}
-	assertClose(t, "op_pow", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_pow", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Op_Sqrt(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_sqrt")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_sqrt")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	output, err := engine.Sqrt(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Sqrt: %v", err)
 	}
-	assertClose(t, "op_sqrt", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_sqrt", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Op_Sin(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_sin")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_sin")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	output, err := engine.Sin(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Sin: %v", err)
 	}
-	assertClose(t, "op_sin", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_sin", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Op_Cos(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_cos")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_cos")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	output, err := engine.Cos(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Cos: %v", err)
 	}
-	assertClose(t, "op_cos", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_cos", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1696,32 +1571,32 @@ func TestParity_Op_Cos(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_Op_Reshape(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_reshape")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_reshape")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	targetShape := getInts(g, "target_shape")
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	targetShape := testutil.GetInts(g, "target_shape")
 	output, err := engine.Reshape(context.Background(), input, targetShape)
 	if err != nil {
 		t.Fatalf("Reshape: %v", err)
 	}
-	assertClose(t, "op_reshape", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_reshape", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 func TestParity_Op_Concat(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "op_concat")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "op_concat")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	a := makeTensor(t, getFloat32s(g, "input_a"), getInts(g, "input_a_shape"))
-	b := makeTensor(t, getFloat32s(g, "input_b"), getInts(g, "input_b_shape"))
-	axis := int(getFloat(g, "axis"))
+	a := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_a"), testutil.GetInts(g, "input_a_shape"))
+	b := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_b"), testutil.GetInts(g, "input_b_shape"))
+	axis := int(testutil.GetFloat(g, "axis"))
 	output, err := engine.Concat(context.Background(), []*tensor.TensorNumeric[float32]{a, b}, axis)
 	if err != nil {
 		t.Fatalf("Concat: %v", err)
 	}
-	assertClose(t, "op_concat", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "op_concat", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1738,13 +1613,13 @@ func TestParity_AttnRes(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_BlockAttnRes(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "residual_block_attn_res")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "residual_block_attn_res")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	dim := int(getFloat(g, "dim"))
-	blockSize := int(getFloat(g, "block_size"))
-	eps := float32(getFloat(g, "epsilon"))
+	dim := int(testutil.GetFloat(g, "dim"))
+	blockSize := int(testutil.GetFloat(g, "block_size"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
 
 	bar, err := residual.NewBlockAttnRes[float32](engine, ops, blockSize, dim, eps)
 	if err != nil {
@@ -1754,10 +1629,10 @@ func TestParity_BlockAttnRes(t *testing.T) {
 	// RMSNorm gain is ones by default — matches Python golden data.
 	// No need to set weights since the constructor already initializes to ones.
 
-	query := makeTensor(t, getFloat32s(g, "query"), getInts(g, "query_shape"))
-	block0 := makeTensor(t, getFloat32s(g, "block0"), getInts(g, "block0_shape"))
-	block1 := makeTensor(t, getFloat32s(g, "block1"), getInts(g, "block1_shape"))
-	partialBlock := makeTensor(t, getFloat32s(g, "partial_block"), getInts(g, "partial_block_shape"))
+	query := testutil.MakeTensor(t, testutil.GetFloat32s(g, "query"), testutil.GetInts(g, "query_shape"))
+	block0 := testutil.MakeTensor(t, testutil.GetFloat32s(g, "block0"), testutil.GetInts(g, "block0_shape"))
+	block1 := testutil.MakeTensor(t, testutil.GetFloat32s(g, "block1"), testutil.GetInts(g, "block1_shape"))
+	partialBlock := testutil.MakeTensor(t, testutil.GetFloat32s(g, "partial_block"), testutil.GetInts(g, "partial_block_shape"))
 
 	blocks := []*tensor.TensorNumeric[float32]{block0, block1}
 
@@ -1766,7 +1641,7 @@ func TestParity_BlockAttnRes(t *testing.T) {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	expectedShape := getInts(g, "output_shape")
+	expectedShape := testutil.GetInts(g, "output_shape")
 	if s := output.Shape(); len(s) != len(expectedShape) {
 		t.Fatalf("output shape: got %v, want %v", s, expectedShape)
 	}
@@ -1776,14 +1651,14 @@ func TestParity_BlockAttnRes(t *testing.T) {
 		}
 	}
 
-	assertClose(t, "block_attn_res_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "block_attn_res_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 
 	// Also verify attention weights sum to 1.
 	alpha, err := bar.AttentionWeights(context.Background(), query, blocks, partialBlock)
 	if err != nil {
 		t.Fatalf("AttentionWeights: %v", err)
 	}
-	assertClose(t, "block_attn_res_alpha", alpha.Data(), getFloat32s(g, "alpha"), tol)
+	testutil.AssertClose(t, "block_attn_res_alpha", alpha.Data(), testutil.GetFloat32s(g, "alpha"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -1793,161 +1668,161 @@ func TestParity_BlockAttnRes(t *testing.T) {
 // T86.2.1: Activation backward tests
 
 func TestParity_ReLU_Backward(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_relu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_relu")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	relu := activations.NewReLU(engine, ops)
 	if _, err := relu.Forward(ctx, input); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := relu.Backward(ctx, types.FullBackprop, gradOutput, input)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "relu_grad_input", grads[0].Data(), getFloat32s(g, "expected_grad_input"), tol)
+	testutil.AssertClose(t, "relu_grad_input", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_input"), tol)
 }
 
 func TestParity_GELU_Backward(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_gelu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_gelu")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	gelu := activations.NewGelu(engine, ops)
 	if _, err := gelu.Forward(ctx, input); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := gelu.Backward(ctx, types.FullBackprop, gradOutput, input)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "gelu_grad_input", grads[0].Data(), getFloat32s(g, "expected_grad_input"), tol)
+	testutil.AssertClose(t, "gelu_grad_input", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_input"), tol)
 }
 
 func TestParity_Sigmoid_Backward(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_sigmoid")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_sigmoid")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	sigmoid := activations.NewSigmoid(engine, ops)
 	if _, err := sigmoid.Forward(ctx, input); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := sigmoid.Backward(ctx, types.FullBackprop, gradOutput, input)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "sigmoid_grad_input", grads[0].Data(), getFloat32s(g, "expected_grad_input"), tol)
+	testutil.AssertClose(t, "sigmoid_grad_input", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_input"), tol)
 }
 
 func TestParity_Tanh_Backward(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_tanh")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_tanh")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	tanh := activations.NewTanh(engine, ops)
 	if _, err := tanh.Forward(ctx, input); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := tanh.Backward(ctx, types.FullBackprop, gradOutput, input)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "tanh_grad_input", grads[0].Data(), getFloat32s(g, "expected_grad_input"), tol)
+	testutil.AssertClose(t, "tanh_grad_input", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_input"), tol)
 }
 
 func TestParity_LeakyReLU_Backward(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_leaky_relu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_leaky_relu")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	alpha := getFloat(g, "alpha")
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	alpha := testutil.GetFloat(g, "alpha")
 	lrelu := activations.NewLeakyReLU(engine, ops, activations.WithAlpha[float32](alpha))
 	if _, err := lrelu.Forward(ctx, input); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := lrelu.Backward(ctx, types.FullBackprop, gradOutput, input)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "leaky_relu_grad_input", grads[0].Data(), getFloat32s(g, "expected_grad_input"), tol)
+	testutil.AssertClose(t, "leaky_relu_grad_input", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_input"), tol)
 }
 
 func TestParity_SwiGLU_Backward(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "activation_swiglu")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "activation_swiglu")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 	swiglu := activations.NewSwiGLU[float32](engine, ops)
 	if _, err := swiglu.Forward(ctx, input); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := swiglu.Backward(ctx, types.FullBackprop, gradOutput, input)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "swiglu_grad_input", grads[0].Data(), getFloat32s(g, "expected_grad_input"), tol)
+	testutil.AssertClose(t, "swiglu_grad_input", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_input"), tol)
 }
 
 // T86.2.2: Normalization backward tests
 
 func TestParity_LayerNorm_Backward(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "norm_layer_norm")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "norm_layer_norm")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	eps := float32(getFloat(g, "epsilon"))
-	gammaParam := makeParam(t, "gamma", getFloat32s(g, "gamma"), getInts(g, "gamma_shape"))
-	betaParam := makeParam(t, "beta", getFloat32s(g, "beta"), getInts(g, "beta_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
+	gammaParam := testutil.MakeParam(t, "gamma", testutil.GetFloat32s(g, "gamma"), testutil.GetInts(g, "gamma_shape"))
+	betaParam := testutil.MakeParam(t, "beta", testutil.GetFloat32s(g, "beta"), testutil.GetInts(g, "beta_shape"))
 
 	ln := normalization.NewLayerNormalizationFromParams(engine, eps, gammaParam, betaParam)
 	if _, err := ln.Forward(ctx, input); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := ln.Backward(ctx, types.FullBackprop, gradOutput, input)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "layer_norm_grad_input", grads[0].Data(), getFloat32s(g, "expected_grad_input"), tol)
+	testutil.AssertClose(t, "layer_norm_grad_input", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_input"), tol)
 }
 
 func TestParity_RMSNorm_Backward(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "norm_rms_norm")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "norm_rms_norm")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	eps := float32(getFloat(g, "epsilon"))
-	gainParam := makeParam(t, "gain", getFloat32s(g, "gain"), getInts(g, "gain_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	eps := float32(testutil.GetFloat(g, "epsilon"))
+	gainParam := testutil.MakeParam(t, "gain", testutil.GetFloat32s(g, "gain"), testutil.GetInts(g, "gain_shape"))
 
 	rms, err := normalization.NewRMSNormFromParam(engine, ops, eps, gainParam)
 	if err != nil {
@@ -1957,75 +1832,75 @@ func TestParity_RMSNorm_Backward(t *testing.T) {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := rms.Backward(ctx, types.FullBackprop, gradOutput, input)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "rms_norm_grad_input", grads[0].Data(), getFloat32s(g, "expected_grad_input"), tol)
+	testutil.AssertClose(t, "rms_norm_grad_input", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_input"), tol)
 }
 
 // T86.2.3: Core backward tests
 
 func TestParity_Linear_Backward(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "core_linear")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_linear")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	weightParam := makeParam(t, "weight", getFloat32s(g, "weight"), getInts(g, "weight_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	weightParam := testutil.MakeParam(t, "weight", testutil.GetFloat32s(g, "weight"), testutil.GetInts(g, "weight_shape"))
 
 	linear := core.NewLinearFromParam(engine, weightParam)
 	if _, err := linear.Forward(ctx, input); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := linear.Backward(ctx, types.FullBackprop, gradOutput, input)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "linear_grad_input", grads[0].Data(), getFloat32s(g, "expected_grad_input"), tol)
+	testutil.AssertClose(t, "linear_grad_input", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_input"), tol)
 
 	// Check weight gradient was accumulated into the parameter
 	params := linear.Parameters()
-	assertClose(t, "linear_grad_weight", params[0].Gradient.Data(), getFloat32s(g, "expected_grad_weight"), tol)
+	testutil.AssertClose(t, "linear_grad_weight", params[0].Gradient.Data(), testutil.GetFloat32s(g, "expected_grad_weight"), tol)
 }
 
 func TestParity_MatMul_Backward(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "core_matmul")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_matmul")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	a := makeTensor(t, getFloat32s(g, "input_a"), getInts(g, "input_a_shape"))
-	b := makeTensor(t, getFloat32s(g, "input_b"), getInts(g, "input_b_shape"))
+	a := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_a"), testutil.GetInts(g, "input_a_shape"))
+	b := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input_b"), testutil.GetInts(g, "input_b_shape"))
 
 	mm := core.NewMatMul[float32](engine)
 	if _, err := mm.Forward(ctx, a, b); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	gradOutput := makeTensor(t, getFloat32s(g, "grad_output"), getInts(g, "output_shape"))
+	gradOutput := testutil.MakeTensor(t, testutil.GetFloat32s(g, "grad_output"), testutil.GetInts(g, "output_shape"))
 	grads, err := mm.Backward(ctx, types.FullBackprop, gradOutput, a, b)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "matmul_grad_a", grads[0].Data(), getFloat32s(g, "expected_grad_a"), tol)
-	assertClose(t, "matmul_grad_b", grads[1].Data(), getFloat32s(g, "expected_grad_b"), tol)
+	testutil.AssertClose(t, "matmul_grad_a", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad_a"), tol)
+	testutil.AssertClose(t, "matmul_grad_b", grads[1].Data(), testutil.GetFloat32s(g, "expected_grad_b"), tol)
 }
 
 // T86.2.4: Loss backward tests
 
 func TestParity_MSELoss_Backward(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "loss_mse")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "loss_mse")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	pred := makeTensor(t, getFloat32s(g, "predictions"), getInts(g, "predictions_shape"))
-	target := makeTensor(t, getFloat32s(g, "targets"), getInts(g, "targets_shape"))
+	pred := testutil.MakeTensor(t, testutil.GetFloat32s(g, "predictions"), testutil.GetInts(g, "predictions_shape"))
+	target := testutil.MakeTensor(t, testutil.GetFloat32s(g, "targets"), testutil.GetInts(g, "targets_shape"))
 
 	mse := loss.NewMSE(engine, ops)
 	if _, err := mse.Forward(ctx, pred, target); err != nil {
@@ -2033,68 +1908,68 @@ func TestParity_MSELoss_Backward(t *testing.T) {
 	}
 
 	// For loss backward, dOut is typically ones (scalar 1.0)
-	dOut := makeTensor(t, []float32{1.0}, []int{1})
+	dOut := testutil.MakeTensor(t, []float32{1.0}, []int{1})
 	grads, err := mse.Backward(ctx, types.FullBackprop, dOut, pred, target)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "mse_grad", grads[0].Data(), getFloat32s(g, "expected_grad"), tol)
+	testutil.AssertClose(t, "mse_grad", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad"), tol)
 }
 
 func TestParity_BCELoss_Backward(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "loss_bce")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "loss_bce")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	pred := makeTensor(t, getFloat32s(g, "predictions"), getInts(g, "predictions_shape"))
-	target := makeTensor(t, getFloat32s(g, "targets"), getInts(g, "targets_shape"))
+	pred := testutil.MakeTensor(t, testutil.GetFloat32s(g, "predictions"), testutil.GetInts(g, "predictions_shape"))
+	target := testutil.MakeTensor(t, testutil.GetFloat32s(g, "targets"), testutil.GetInts(g, "targets_shape"))
 
 	bce := loss.NewBCELoss(engine, ops)
 	if _, err := bce.Forward(ctx, pred, target); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	dOut := makeTensor(t, []float32{1.0}, []int{1})
+	dOut := testutil.MakeTensor(t, []float32{1.0}, []int{1})
 	grads, err := bce.Backward(ctx, types.FullBackprop, dOut, pred, target)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "bce_grad", grads[0].Data(), getFloat32s(g, "expected_grad"), tol)
+	testutil.AssertClose(t, "bce_grad", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad"), tol)
 }
 
 func TestParity_CrossEntropyLoss_Backward(t *testing.T) {
-	engine, _ := setup()
-	g := loadGolden(t, "loss_cross_entropy")
-	tol := getFloat(g, "tolerance")
+	engine, _ := testutil.Setup()
+	g := testutil.LoadGolden(t, "loss_cross_entropy")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	logits := makeTensor(t, getFloat32s(g, "logits"), getInts(g, "logits_shape"))
+	logits := testutil.MakeTensor(t, testutil.GetFloat32s(g, "logits"), testutil.GetInts(g, "logits_shape"))
 	targetsRaw := g["targets"].([]interface{})
 	targetData := make([]float32, len(targetsRaw))
 	for i, v := range targetsRaw {
 		targetData[i] = float32(v.(float64))
 	}
-	targets := makeTensor(t, targetData, []int{len(targetData)})
+	targets := testutil.MakeTensor(t, targetData, []int{len(targetData)})
 
 	cel := loss.NewCrossEntropyLoss[float32](engine)
 	if _, err := cel.Forward(ctx, logits, targets); err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	dOut := makeTensor(t, []float32{1.0}, []int{1})
+	dOut := testutil.MakeTensor(t, []float32{1.0}, []int{1})
 	grads, err := cel.Backward(ctx, types.FullBackprop, dOut)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	assertClose(t, "cross_entropy_grad", grads[0].Data(), getFloat32s(g, "expected_grad"), tol)
+	testutil.AssertClose(t, "cross_entropy_grad", grads[0].Data(), testutil.GetFloat32s(g, "expected_grad"), tol)
 }
 
 // T86.2.5: SSM backward test
 
 func TestParity_S4_Backward(t *testing.T) {
-	g := loadGolden(t, "ssm_s4")
-	if getFloat32s(g, "grad_output") == nil {
+	g := testutil.LoadGolden(t, "ssm_s4")
+	if testutil.GetFloat32s(g, "grad_output") == nil {
 		t.Skip("no backward golden data for S4")
 	}
 }
@@ -2102,8 +1977,8 @@ func TestParity_S4_Backward(t *testing.T) {
 // T86.2.6: Attention backward test
 
 func TestParity_SDPA_Backward(t *testing.T) {
-	g := loadGolden(t, "attention_sdpa_causal")
-	if getFloat32s(g, "grad_output") == nil {
+	g := testutil.LoadGolden(t, "attention_sdpa_causal")
+	if testutil.GetFloat32s(g, "grad_output") == nil {
 		t.Skip("no backward golden data for SDPA")
 	}
 }
@@ -2113,16 +1988,16 @@ func TestParity_SDPA_Backward(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_GQA(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "attention_gqa")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "attention_gqa")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	dModel := int(getFloat(g, "d_model"))
-	nQHeads := int(getFloat(g, "n_q_heads"))
-	nKVHeads := int(getFloat(g, "n_kv_heads"))
+	dModel := int(testutil.GetFloat(g, "d_model"))
+	nQHeads := int(testutil.GetFloat(g, "n_q_heads"))
+	nKVHeads := int(testutil.GetFloat(g, "n_kv_heads"))
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 
 	gqa, err := attention.NewGroupedQueryAttention(engine, ops, dModel, nQHeads, nKVHeads,
 		attention.WithNoRoPE[float32]())
@@ -2135,20 +2010,20 @@ func TestParity_GQA(t *testing.T) {
 	if len(params) < 8 {
 		t.Fatalf("expected 8 params, got %d", len(params))
 	}
-	copy(params[0].Value.Data(), getFloat32s(g, "wq_w"))
-	copy(params[1].Value.Data(), getFloat32s(g, "wq_b"))
-	copy(params[2].Value.Data(), getFloat32s(g, "wk_w"))
-	copy(params[3].Value.Data(), getFloat32s(g, "wk_b"))
-	copy(params[4].Value.Data(), getFloat32s(g, "wv_w"))
-	copy(params[5].Value.Data(), getFloat32s(g, "wv_b"))
-	copy(params[6].Value.Data(), getFloat32s(g, "wo_w"))
-	copy(params[7].Value.Data(), getFloat32s(g, "wo_b"))
+	copy(params[0].Value.Data(), testutil.GetFloat32s(g, "wq_w"))
+	copy(params[1].Value.Data(), testutil.GetFloat32s(g, "wq_b"))
+	copy(params[2].Value.Data(), testutil.GetFloat32s(g, "wk_w"))
+	copy(params[3].Value.Data(), testutil.GetFloat32s(g, "wk_b"))
+	copy(params[4].Value.Data(), testutil.GetFloat32s(g, "wv_w"))
+	copy(params[5].Value.Data(), testutil.GetFloat32s(g, "wv_b"))
+	copy(params[6].Value.Data(), testutil.GetFloat32s(g, "wo_w"))
+	copy(params[7].Value.Data(), testutil.GetFloat32s(g, "wo_b"))
 
 	output, err := gqa.Forward(ctx, input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "gqa_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "gqa_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -2156,19 +2031,19 @@ func TestParity_GQA(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_MoE(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "core_moe")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "core_moe")
+	tol := testutil.GetFloat(g, "tolerance")
 	ctx := context.Background()
 
-	nExperts := int(getFloat(g, "n_experts"))
-	topK := int(getFloat(g, "top_k"))
+	nExperts := int(testutil.GetFloat(g, "n_experts"))
+	topK := int(testutil.GetFloat(g, "top_k"))
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
-	gateWeight := makeTensor(t, getFloat32s(g, "gate_weight"), getInts(g, "gate_weight_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
+	gateWeight := testutil.MakeTensor(t, testutil.GetFloat32s(g, "gate_weight"), testutil.GetInts(g, "gate_weight_shape"))
 
 	expertWeightsRaw := g["expert_weights"].([]interface{})
-	expertShape := getInts(g, "expert_weight_shape")
+	expertShape := testutil.GetInts(g, "expert_weight_shape")
 	experts := make([]graph.Node[float32], nExperts)
 	for i := 0; i < nExperts; i++ {
 		ewArr := expertWeightsRaw[i].([]interface{})
@@ -2176,7 +2051,7 @@ func TestParity_MoE(t *testing.T) {
 		for j, v := range ewArr {
 			ewData[j] = float32(v.(float64))
 		}
-		p := makeParam(t, fmt.Sprintf("expert_%d", i), ewData, expertShape)
+		p := testutil.MakeParam(t, fmt.Sprintf("expert_%d", i), ewData, expertShape)
 		experts[i] = core.NewLinearFromParam(engine, p)
 	}
 
@@ -2187,7 +2062,7 @@ func TestParity_MoE(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "moe_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "moe_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -2195,7 +2070,7 @@ func TestParity_MoE(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_TabNet_Structural(t *testing.T) {
-	engine, _ := setup()
+	engine, _ := testutil.Setup()
 	ops := numeric.Float32Ops{}
 	cfg := tabular.TabNetConfig{
 		InputDim: 8, OutputDim: 3, NSteps: 3,
@@ -2209,7 +2084,7 @@ func TestParity_TabNet_Structural(t *testing.T) {
 	for i := range inputData {
 		inputData[i] = float32(i+1) * 0.1
 	}
-	output, err := model.Forward(context.Background(), makeTensor(t, inputData, []int{4, cfg.InputDim}))
+	output, err := model.Forward(context.Background(), testutil.MakeTensor(t, inputData, []int{4, cfg.InputDim}))
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
@@ -2328,7 +2203,7 @@ func TestParity_MarketVAE_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_AttentionHead_Structural(t *testing.T) {
-	engine, _ := setup()
+	engine, _ := testutil.Setup()
 	inputDim := 8
 	headDim := 4
 	batchSize := 2
@@ -2343,7 +2218,7 @@ func TestParity_AttentionHead_Structural(t *testing.T) {
 	for i := range inputData {
 		inputData[i] = float32(i+1) * 0.01
 	}
-	input := makeTensor(t, inputData, []int{batchSize, seqLen, inputDim})
+	input := testutil.MakeTensor(t, inputData, []int{batchSize, seqLen, inputDim})
 
 	output, err := head.Forward(context.Background(), input)
 	if err != nil {
@@ -2386,7 +2261,7 @@ func TestParity_GQA_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_MIMOMambaBlock_Structural(t *testing.T) {
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 	dModel := 8
 	dInner := 8 // must be divisible by numHeads
 	dState := 4
@@ -2408,7 +2283,7 @@ func TestParity_MIMOMambaBlock_Structural(t *testing.T) {
 	for i := range inputData {
 		inputData[i] = float32(i+1) * 0.01
 	}
-	input := makeTensor(t, inputData, []int{batchSize, seqLen, dModel})
+	input := testutil.MakeTensor(t, inputData, []int{batchSize, seqLen, dModel})
 
 	output, err := block.Forward(context.Background(), input)
 	if err != nil {
@@ -2446,7 +2321,7 @@ func TestParity_MIMOMambaBlock_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_AttnRes_Structural(t *testing.T) {
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 	modelDim := 8
 	numLayers := 3
 
@@ -2462,7 +2337,7 @@ func TestParity_AttnRes_Structural(t *testing.T) {
 		for j := range data {
 			data[j] = float32(i*modelDim+j+1) * 0.1
 		}
-		inputs[i] = makeTensor(t, data, []int{1, modelDim})
+		inputs[i] = testutil.MakeTensor(t, data, []int{1, modelDim})
 	}
 
 	output, err := ar.Forward(context.Background(), inputs...)
@@ -2486,7 +2361,7 @@ func TestParity_AttnRes_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_HModule_Structural(t *testing.T) {
-	engine, _ := setup()
+	engine, _ := testutil.Setup()
 	ops := &numeric.Float32Ops{}
 	modelDim := 8
 	ffnDim := 16
@@ -2509,7 +2384,7 @@ func TestParity_HModule_Structural(t *testing.T) {
 	for i := range inputData {
 		inputData[i] = float32(i+1) * 0.01
 	}
-	input := makeTensor(t, inputData, []int{batchSize, seqLen, modelDim})
+	input := testutil.MakeTensor(t, inputData, []int{batchSize, seqLen, modelDim})
 
 	output, err := hmod.Forward(context.Background(), input)
 	if err != nil {
@@ -2547,7 +2422,7 @@ func TestParity_HModule_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_MLSTM_Structural(t *testing.T) {
-	engine, _ := setup()
+	engine, _ := testutil.Setup()
 	inputDim := 4
 	hiddenDim := 3
 	batch := 2
@@ -2562,11 +2437,11 @@ func TestParity_MLSTM_Structural(t *testing.T) {
 	for i := range xData {
 		xData[i] = float32(i+1) * 0.1
 	}
-	x := makeTensor(t, xData, []int{batch, inputDim})
+	x := testutil.MakeTensor(t, xData, []int{batch, inputDim})
 
-	hPrev := makeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
-	cPrev := makeTensor(t, make([]float32, batch*hiddenDim*hiddenDim), []int{batch, hiddenDim, hiddenDim})
-	nPrev := makeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
+	hPrev := testutil.MakeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
+	cPrev := testutil.MakeTensor(t, make([]float32, batch*hiddenDim*hiddenDim), []int{batch, hiddenDim, hiddenDim})
+	nPrev := testutil.MakeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
 
 	h, c, n, m, err := mlstm.Forward(context.Background(), x, hPrev, cPrev, nPrev, nil)
 	if err != nil {
@@ -2602,7 +2477,7 @@ func TestParity_MLSTM_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_SLSTM_Structural(t *testing.T) {
-	engine, _ := setup()
+	engine, _ := testutil.Setup()
 	inputDim := 4
 	hiddenDim := 3
 	batch := 2
@@ -2617,11 +2492,11 @@ func TestParity_SLSTM_Structural(t *testing.T) {
 	for i := range xData {
 		xData[i] = float32(i+1) * 0.1
 	}
-	x := makeTensor(t, xData, []int{batch, inputDim})
+	x := testutil.MakeTensor(t, xData, []int{batch, inputDim})
 
-	hPrev := makeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
-	cPrev := makeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
-	nPrev := makeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
+	hPrev := testutil.MakeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
+	cPrev := testutil.MakeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
+	nPrev := testutil.MakeTensor(t, make([]float32, batch*hiddenDim), []int{batch, hiddenDim})
 
 	h, c, n, m, err := slstm.Forward(context.Background(), x, hPrev, cPrev, nPrev, nil)
 	if err != nil {
@@ -2650,7 +2525,7 @@ func TestParity_SLSTM_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_CLIPEncoder_Structural(t *testing.T) {
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 	cfg := vision.CLIPEncoderConfig{
 		ImageSize:   16,
 		PatchSize:   4,
@@ -2672,7 +2547,7 @@ func TestParity_CLIPEncoder_Structural(t *testing.T) {
 	for i := range inputData {
 		inputData[i] = float32(i%256) / 255.0
 	}
-	input := makeTensor(t, inputData, []int{batch, cfg.NumChannels, cfg.ImageSize, cfg.ImageSize})
+	input := testutil.MakeTensor(t, inputData, []int{batch, cfg.NumChannels, cfg.ImageSize, cfg.ImageSize})
 
 	output, err := enc.Forward(context.Background(), input)
 	if err != nil {
@@ -2737,7 +2612,7 @@ func TestParity_MelExtractor_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_WhisperEncoder_Structural(t *testing.T) {
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 	cfg := audio.WhisperEncoderConfig{
 		NumMels:    8,
 		HiddenDim:  16,
@@ -2758,7 +2633,7 @@ func TestParity_WhisperEncoder_Structural(t *testing.T) {
 	for i := range inputData {
 		inputData[i] = float32(i+1) * 0.01
 	}
-	input := makeTensor(t, inputData, []int{batch, cfg.NumMels, frames})
+	input := testutil.MakeTensor(t, inputData, []int{batch, cfg.NumMels, frames})
 
 	output, err := enc.Forward(context.Background(), input)
 	if err != nil {
@@ -2794,7 +2669,7 @@ func TestParity_ComparisonOps(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_TransformerBlock_Structural(t *testing.T) {
-	engine, _ := setup()
+	engine, _ := testutil.Setup()
 	ops := &numeric.Float32Ops{}
 	modelDim := 8
 	ffnDim := 16
@@ -2817,7 +2692,7 @@ func TestParity_TransformerBlock_Structural(t *testing.T) {
 	for i := range inputData {
 		inputData[i] = float32(i+1) * 0.01
 	}
-	input := makeTensor(t, inputData, []int{batchSize, seqLen, modelDim})
+	input := testutil.MakeTensor(t, inputData, []int{batchSize, seqLen, modelDim})
 
 	output, err := block.Forward(context.Background(), input)
 	if err != nil {
@@ -2840,15 +2715,15 @@ func TestParity_TransformerBlock_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_GRN(t *testing.T) {
-	engine, ops := setup()
-	g := loadGolden(t, "layer_grn")
-	tol := getFloat(g, "tolerance")
+	engine, ops := testutil.Setup()
+	g := testutil.LoadGolden(t, "layer_grn")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	inputDim := int(getFloat(g, "input_dim"))
-	hiddenDim := int(getFloat(g, "hidden_dim"))
-	outputDim := int(getFloat(g, "output_dim"))
+	inputDim := int(testutil.GetFloat(g, "input_dim"))
+	hiddenDim := int(testutil.GetFloat(g, "hidden_dim"))
+	outputDim := int(testutil.GetFloat(g, "output_dim"))
 
-	input := makeTensor(t, getFloat32s(g, "input"), getInts(g, "input_shape"))
+	input := testutil.MakeTensor(t, testutil.GetFloat32s(g, "input"), testutil.GetInts(g, "input_shape"))
 
 	grn, err := timeseries.NewGRN[float32]("test_grn", engine, ops, inputDim, hiddenDim, outputDim)
 	if err != nil {
@@ -2862,18 +2737,18 @@ func TestParity_GRN(t *testing.T) {
 		t.Fatalf("expected at least 7 parameters (w1,b1,w2,b2,wOut,gamma,beta), got %d", len(params))
 	}
 
-	copy(params[0].Value.Data(), getFloat32s(g, "w1"))
-	copy(params[1].Value.Data(), getFloat32s(g, "b1"))
-	copy(params[2].Value.Data(), getFloat32s(g, "w2"))
-	copy(params[3].Value.Data(), getFloat32s(g, "b2"))
-	copy(params[4].Value.Data(), getFloat32s(g, "w_out"))
+	copy(params[0].Value.Data(), testutil.GetFloat32s(g, "w1"))
+	copy(params[1].Value.Data(), testutil.GetFloat32s(g, "b1"))
+	copy(params[2].Value.Data(), testutil.GetFloat32s(g, "w2"))
+	copy(params[3].Value.Data(), testutil.GetFloat32s(g, "b2"))
+	copy(params[4].Value.Data(), testutil.GetFloat32s(g, "w_out"))
 	// params[5] = ln gamma (already ones), params[6] = ln beta (already zeros) — no need to set
 
 	output, err := grn.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
-	assertClose(t, "grn_forward", output.Data(), getFloat32s(g, "expected_output"), tol)
+	testutil.AssertClose(t, "grn_forward", output.Data(), testutil.GetFloat32s(g, "expected_output"), tol)
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/parity/llama3_test.go
+++ b/tests/parity/llama3_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var llama3Config = modelParityConfig{
+var llama3Config = testutil.ModelParityConfig{
 	Name:           "Llama 3",
 	ZMFEnvVar:      "LLAMA3_ZMF_PATH",
 	ModelDirEnvVar: "LLAMA3_MODEL_DIR",
@@ -16,15 +18,15 @@ var llama3Config = modelParityConfig{
 
 func TestLlama3ForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, llama3Config)
+	testutil.RunModelForwardPass(t, llama3Config)
 }
 
 func TestLlama3GreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, llama3Config)
+	testutil.RunModelGreedyDecode(t, llama3Config)
 }
 
 func TestLlama3Generation(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, llama3Config)
+	testutil.RunModelGeneration(t, llama3Config)
 }

--- a/tests/parity/llama4_test.go
+++ b/tests/parity/llama4_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var llama4Config = modelParityConfig{
+var llama4Config = testutil.ModelParityConfig{
 	Name:           "Llama 4",
 	ZMFEnvVar:      "LLAMA4_ZMF_PATH",
 	ModelDirEnvVar: "LLAMA4_MODEL_DIR",
@@ -16,15 +18,15 @@ var llama4Config = modelParityConfig{
 
 func TestLlama4ForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, llama4Config)
+	testutil.RunModelForwardPass(t, llama4Config)
 }
 
 func TestLlama4GreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, llama4Config)
+	testutil.RunModelGreedyDecode(t, llama4Config)
 }
 
 func TestLlama4Generation(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, llama4Config)
+	testutil.RunModelGeneration(t, llama4Config)
 }

--- a/tests/parity/mistral_test.go
+++ b/tests/parity/mistral_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var mistralConfig = modelParityConfig{
+var mistralConfig = testutil.ModelParityConfig{
 	Name:           "Mistral",
 	ZMFEnvVar:      "MISTRAL_ZMF_PATH",
 	ModelDirEnvVar: "MISTRAL_MODEL_DIR",
@@ -16,15 +18,15 @@ var mistralConfig = modelParityConfig{
 
 func TestMistralForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, mistralConfig)
+	testutil.RunModelForwardPass(t, mistralConfig)
 }
 
 func TestMistralGreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, mistralConfig)
+	testutil.RunModelGreedyDecode(t, mistralConfig)
 }
 
 func TestMistralGeneration(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, mistralConfig)
+	testutil.RunModelGeneration(t, mistralConfig)
 }

--- a/tests/parity/mixtral_test.go
+++ b/tests/parity/mixtral_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var mixtralConfig = modelParityConfig{
+var mixtralConfig = testutil.ModelParityConfig{
 	Name:           "Mixtral",
 	ZMFEnvVar:      "MIXTRAL_ZMF_PATH",
 	ModelDirEnvVar: "MIXTRAL_MODEL_DIR",
@@ -16,15 +18,15 @@ var mixtralConfig = modelParityConfig{
 
 func TestMixtralForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, mixtralConfig)
+	testutil.RunModelForwardPass(t, mixtralConfig)
 }
 
 func TestMixtralGreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, mixtralConfig)
+	testutil.RunModelGreedyDecode(t, mixtralConfig)
 }
 
 func TestMixtralGeneration(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, mixtralConfig)
+	testutil.RunModelGeneration(t, mixtralConfig)
 }

--- a/tests/parity/model_parity_test.go
+++ b/tests/parity/model_parity_test.go
@@ -10,59 +10,22 @@ import (
 
 	"github.com/zerfoo/zerfoo/tabular"
 	tsmodels "github.com/zerfoo/zerfoo/timeseries"
+
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
 )
-
-// getFloat64s extracts a float64 slice from a JSON array.
-func getFloat64s(m map[string]interface{}, key string) []float64 {
-	arr, ok := m[key].([]interface{})
-	if !ok {
-		return nil
-	}
-	out := make([]float64, len(arr))
-	for i, v := range arr {
-		out[i] = v.(float64)
-	}
-	return out
-}
-
-// getFloat64s2D extracts a 2D float64 slice from a JSON nested array.
-func getFloat64s2D(m map[string]interface{}, key string) [][]float64 {
-	arr, ok := m[key].([]interface{})
-	if !ok {
-		return nil
-	}
-	out := make([][]float64, len(arr))
-	for i, row := range arr {
-		rowArr := row.([]interface{})
-		out[i] = make([]float64, len(rowArr))
-		for j, v := range rowArr {
-			out[i][j] = v.(float64)
-		}
-	}
-	return out
-}
-
-// reshapeFloat64 reshapes a flat float64 slice into a 2D slice [rows][cols].
-func reshapeFloat64(flat []float64, rows, cols int) [][]float64 {
-	result := make([][]float64, rows)
-	for r := 0; r < rows; r++ {
-		result[r] = flat[r*cols : (r+1)*cols]
-	}
-	return result
-}
 
 // ---------------------------------------------------------------------------
 // T86.4.3: DLinear golden-file forward parity (PyTorch reference)
 // ---------------------------------------------------------------------------
 
 func TestParity_DLinear(t *testing.T) {
-	g := loadGolden(t, "timeseries_dlinear")
-	tol := getFloat(g, "tolerance")
+	g := testutil.LoadGolden(t, "timeseries_dlinear")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	inputLen := int(getFloat(g, "input_len"))
-	outputLen := int(getFloat(g, "output_len"))
-	channels := int(getFloat(g, "channels"))
-	kernelSize := int(getFloat(g, "kernel_size"))
+	inputLen := int(testutil.GetFloat(g, "input_len"))
+	outputLen := int(testutil.GetFloat(g, "output_len"))
+	channels := int(testutil.GetFloat(g, "channels"))
+	kernelSize := int(testutil.GetFloat(g, "kernel_size"))
 
 	m, err := tsmodels.NewDLinear(inputLen, outputLen, channels, kernelSize)
 	if err != nil {
@@ -70,10 +33,10 @@ func TestParity_DLinear(t *testing.T) {
 	}
 
 	// Load golden weights into the model via SaveWeights/loadWeights round-trip.
-	trendW := getFloat64s(g, "trend_w")
-	trendB := getFloat64s(g, "trend_b")
-	seasonalW := getFloat64s(g, "seasonal_w")
-	seasonalB := getFloat64s(g, "seasonal_b")
+	trendW := testutil.GetFloat64s(g, "trend_w")
+	trendB := testutil.GetFloat64s(g, "trend_b")
+	seasonalW := testutil.GetFloat64s(g, "seasonal_w")
+	seasonalB := testutil.GetFloat64s(g, "seasonal_b")
 
 	// Write golden weights to a temp file in DLinear's JSON format.
 	dir := t.TempDir()
@@ -85,10 +48,10 @@ func TestParity_DLinear(t *testing.T) {
 			"Channels":   channels,
 			"KernelSize": kernelSize,
 		},
-		"trend_w":    reshapeFloat64(trendW, channels, outputLen*inputLen),
-		"trend_b":    reshapeFloat64(trendB, channels, outputLen),
-		"seasonal_w": reshapeFloat64(seasonalW, channels, outputLen*inputLen),
-		"seasonal_b": reshapeFloat64(seasonalB, channels, outputLen),
+		"trend_w":    testutil.ReshapeFloat64(trendW, channels, outputLen*inputLen),
+		"trend_b":    testutil.ReshapeFloat64(trendB, channels, outputLen),
+		"seasonal_w": testutil.ReshapeFloat64(seasonalW, channels, outputLen*inputLen),
+		"seasonal_b": testutil.ReshapeFloat64(seasonalB, channels, outputLen),
 	}
 	wData, err := json.Marshal(weightsJSON)
 	if err != nil {
@@ -99,7 +62,7 @@ func TestParity_DLinear(t *testing.T) {
 	}
 
 	// Build input from golden data.
-	inputFlat := getFloat64s(g, "input")
+	inputFlat := testutil.GetFloat64s(g, "input")
 	input := make([][]float64, channels)
 	for c := 0; c < channels; c++ {
 		input[c] = inputFlat[c*inputLen : (c+1)*inputLen]
@@ -112,7 +75,7 @@ func TestParity_DLinear(t *testing.T) {
 	}
 
 	// Compare against golden expected output.
-	expectedOutput := getFloat64s(g, "expected_output")
+	expectedOutput := testutil.GetFloat64s(g, "expected_output")
 	if len(preds) != len(expectedOutput) {
 		t.Fatalf("output length: got %d, want %d", len(preds), len(expectedOutput))
 	}
@@ -129,18 +92,18 @@ func TestParity_DLinear(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_PatchTST(t *testing.T) {
-	g := loadGolden(t, "model_patchtst")
-	tol := getFloat(g, "tolerance")
+	g := testutil.LoadGolden(t, "model_patchtst")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	inputLen := int(getFloat(g, "input_len"))
-	patchLen := int(getFloat(g, "patch_len"))
-	stride := int(getFloat(g, "stride"))
-	dModel := int(getFloat(g, "d_model"))
-	nHeads := int(getFloat(g, "n_heads"))
-	nLayers := int(getFloat(g, "n_layers"))
-	outputDim := int(getFloat(g, "output_dim"))
-	batch := int(getFloat(g, "batch"))
-	goldenParamCount := int(getFloat(g, "param_count"))
+	inputLen := int(testutil.GetFloat(g, "input_len"))
+	patchLen := int(testutil.GetFloat(g, "patch_len"))
+	stride := int(testutil.GetFloat(g, "stride"))
+	dModel := int(testutil.GetFloat(g, "d_model"))
+	nHeads := int(testutil.GetFloat(g, "n_heads"))
+	nLayers := int(testutil.GetFloat(g, "n_layers"))
+	outputDim := int(testutil.GetFloat(g, "output_dim"))
+	batch := int(testutil.GetFloat(g, "batch"))
+	goldenParamCount := int(testutil.GetFloat(g, "param_count"))
 
 	config := tsmodels.PatchTSTConfig{
 		InputLength: inputLen,
@@ -152,7 +115,7 @@ func TestParity_PatchTST(t *testing.T) {
 		OutputDim:   outputDim,
 	}
 
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 	m, err := tsmodels.NewPatchTST(config, engine, ops)
 	if err != nil {
 		t.Fatalf("NewPatchTST: %v", err)
@@ -164,14 +127,14 @@ func TestParity_PatchTST(t *testing.T) {
 	}
 
 	// Extract golden flat params and weights from golden data.
-	flatParams := getFloat64s(g, "flat_params")
+	flatParams := testutil.GetFloat64s(g, "flat_params")
 
 	// Build the patchTSTWeights JSON using golden flat_params.
 	// Flat param order: patchEmbW, patchEmbB, posEmb,
 	//   per-layer: qW, qB, kW, kB, vW, vB, oW, oB,
 	//              ffn1W, ffn1B, ffn2W, ffn2B, norm1, bias1, norm2, bias2,
 	//   headW, headB.
-	numPatches := (inputLen - patchLen) / stride + 1
+	numPatches := (inputLen-patchLen)/stride + 1
 	ffnDim := dModel * 4
 	off := 0
 
@@ -263,7 +226,7 @@ func TestParity_PatchTST(t *testing.T) {
 	}
 
 	// Build input windows: [batch][1 channel][inputLen].
-	inputFlat := getFloat64s(g, "input")
+	inputFlat := testutil.GetFloat64s(g, "input")
 	windows := make([][][]float64, batch)
 	for b := 0; b < batch; b++ {
 		windows[b] = [][]float64{inputFlat[b*inputLen : (b+1)*inputLen]}
@@ -276,7 +239,7 @@ func TestParity_PatchTST(t *testing.T) {
 	}
 
 	// Compare against golden expected output.
-	expectedOutput := getFloat64s(g, "expected_output")
+	expectedOutput := testutil.GetFloat64s(g, "expected_output")
 	if len(preds) != len(expectedOutput) {
 		t.Fatalf("output length: got %d, want %d", len(preds), len(expectedOutput))
 	}
@@ -294,7 +257,7 @@ func TestParity_PatchTST(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_PatchTST_Structural(t *testing.T) {
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 
 	config := tsmodels.PatchTSTConfig{
 		InputLength:        16,
@@ -317,7 +280,7 @@ func TestParity_PatchTST_Structural(t *testing.T) {
 	for i := range inputData {
 		inputData[i] = float32(i+1) * 0.01
 	}
-	input := makeTensor(t, inputData, []int{batch, config.InputLength})
+	input := testutil.MakeTensor(t, inputData, []int{batch, config.InputLength})
 
 	output, err := m.Forward(context.Background(), input)
 	if err != nil {
@@ -343,7 +306,7 @@ func TestParity_PatchTST_Structural(t *testing.T) {
 	for i := range inputData2 {
 		inputData2[i] = float32(i+1) * 0.5
 	}
-	input2 := makeTensor(t, inputData2, []int{batch, config.InputLength})
+	input2 := testutil.MakeTensor(t, inputData2, []int{batch, config.InputLength})
 	output2, err := m.Forward(context.Background(), input2)
 	if err != nil {
 		t.Fatalf("Forward (input2): %v", err)
@@ -366,7 +329,7 @@ func TestParity_PatchTST_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_NBEATS_Structural(t *testing.T) {
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 
 	config := tsmodels.NBEATSConfig{
 		InputLength:     12,
@@ -387,7 +350,7 @@ func TestParity_NBEATS_Structural(t *testing.T) {
 	for i := range inputData {
 		inputData[i] = float32(i+1) * 0.1
 	}
-	input := makeTensor(t, inputData, []int{batch, config.InputLength})
+	input := testutil.MakeTensor(t, inputData, []int{batch, config.InputLength})
 
 	result, err := m.Forward(context.Background(), input)
 	if err != nil {
@@ -413,7 +376,7 @@ func TestParity_NBEATS_Structural(t *testing.T) {
 	for i := range inputData2 {
 		inputData2[i] = float32(i+1) * 0.5
 	}
-	input2 := makeTensor(t, inputData2, []int{batch, config.InputLength})
+	input2 := testutil.MakeTensor(t, inputData2, []int{batch, config.InputLength})
 	result2, err := m.Forward(context.Background(), input2)
 	if err != nil {
 		t.Fatalf("Forward (input2): %v", err)
@@ -508,16 +471,16 @@ func TestParity_ITransformer_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_NBEATS(t *testing.T) {
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 
-	g := loadGolden(t, "model_nbeats")
-	tol := getFloat(g, "tolerance")
+	g := testutil.LoadGolden(t, "model_nbeats")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	inputLen := int(getFloat(g, "input_length"))
-	outputLen := int(getFloat(g, "output_length"))
-	hiddenDim := int(getFloat(g, "hidden_dim"))
-	nHarmonics := int(getFloat(g, "n_harmonics"))
-	batch := int(getFloat(g, "batch"))
+	inputLen := int(testutil.GetFloat(g, "input_length"))
+	outputLen := int(testutil.GetFloat(g, "output_length"))
+	hiddenDim := int(testutil.GetFloat(g, "hidden_dim"))
+	nHarmonics := int(testutil.GetFloat(g, "n_harmonics"))
+	batch := int(testutil.GetFloat(g, "batch"))
 
 	config := tsmodels.NBEATSConfig{
 		InputLength:     inputLen,
@@ -534,7 +497,7 @@ func TestParity_NBEATS(t *testing.T) {
 	}
 
 	// Load golden params into model.
-	goldenParams := getFloat64s(g, "params")
+	goldenParams := testutil.GetFloat64s(g, "params")
 	flatPtrs := m.FlatParams()
 	if len(goldenParams) != len(flatPtrs) {
 		t.Fatalf("param count mismatch: golden=%d, model=%d", len(goldenParams), len(flatPtrs))
@@ -544,21 +507,21 @@ func TestParity_NBEATS(t *testing.T) {
 	}
 
 	// Build input tensor.
-	inputFlat := getFloat32s(g, "input")
-	input := makeTensor(t, inputFlat, []int{batch, inputLen})
+	inputFlat := testutil.GetFloat32s(g, "input")
+	input := testutil.MakeTensor(t, inputFlat, []int{batch, inputLen})
 
 	result, err := m.Forward(context.Background(), input)
 	if err != nil {
 		t.Fatalf("Forward: %v", err)
 	}
 
-	expectedOutput := getFloat32s(g, "expected_output")
+	expectedOutput := testutil.GetFloat32s(g, "expected_output")
 	got := result.Forecast.Data()
 
 	if len(got) != len(expectedOutput) {
 		t.Fatalf("output length: got %d, want %d", len(got), len(expectedOutput))
 	}
-	assertClose(t, "nbeats_forecast", got, expectedOutput, tol)
+	testutil.AssertClose(t, "nbeats_forecast", got, expectedOutput, tol)
 }
 
 // ---------------------------------------------------------------------------
@@ -566,16 +529,16 @@ func TestParity_NBEATS(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_ITransformer(t *testing.T) {
-	g := loadGolden(t, "model_itransformer")
-	tol := getFloat(g, "tolerance")
+	g := testutil.LoadGolden(t, "model_itransformer")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	channels := int(getFloat(g, "channels"))
-	inputLen := int(getFloat(g, "input_len"))
-	outputLen := int(getFloat(g, "output_len"))
-	dModel := int(getFloat(g, "d_model"))
-	dFF := int(getFloat(g, "d_ff"))
-	nHeads := int(getFloat(g, "n_heads"))
-	nLayers := int(getFloat(g, "n_layers"))
+	channels := int(testutil.GetFloat(g, "channels"))
+	inputLen := int(testutil.GetFloat(g, "input_len"))
+	outputLen := int(testutil.GetFloat(g, "output_len"))
+	dModel := int(testutil.GetFloat(g, "d_model"))
+	dFF := int(testutil.GetFloat(g, "d_ff"))
+	nHeads := int(testutil.GetFloat(g, "n_heads"))
+	nLayers := int(testutil.GetFloat(g, "n_layers"))
 
 	config := tsmodels.ITransformerConfig{
 		Channels:  channels,
@@ -593,7 +556,7 @@ func TestParity_ITransformer(t *testing.T) {
 	}
 
 	// Load golden params via flatParams pointers.
-	goldenParams := getFloat64s(g, "params")
+	goldenParams := testutil.GetFloat64s(g, "params")
 	flatPtrs := m.FlatParams()
 	if len(goldenParams) != len(flatPtrs) {
 		t.Fatalf("param count mismatch: golden=%d, model=%d", len(goldenParams), len(flatPtrs))
@@ -642,7 +605,7 @@ func TestParity_ITransformer(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_TFT_Structural(t *testing.T) {
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 
 	config := tsmodels.TFTConfig{
 		NumStaticFeatures: 3,
@@ -718,15 +681,15 @@ func TestParity_TFT_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_CfC(t *testing.T) {
-	g := loadGolden(t, "model_cfc")
-	tol := getFloat(g, "tolerance")
+	g := testutil.LoadGolden(t, "model_cfc")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	inputSize := int(getFloat(g, "input_size"))
-	hiddenSize := int(getFloat(g, "hidden_size"))
-	outputSize := int(getFloat(g, "output_size"))
-	numLayers := int(getFloat(g, "num_layers"))
-	outputLen := int(getFloat(g, "output_len"))
-	seqLen := int(getFloat(g, "seq_len"))
+	inputSize := int(testutil.GetFloat(g, "input_size"))
+	hiddenSize := int(testutil.GetFloat(g, "hidden_size"))
+	outputSize := int(testutil.GetFloat(g, "output_size"))
+	numLayers := int(testutil.GetFloat(g, "num_layers"))
+	outputLen := int(testutil.GetFloat(g, "output_len"))
+	seqLen := int(testutil.GetFloat(g, "seq_len"))
 
 	config := tsmodels.CfCConfig{
 		InputSize:  inputSize,
@@ -742,13 +705,13 @@ func TestParity_CfC(t *testing.T) {
 	}
 
 	// Extract golden weights from JSON.
-	whFlat := getFloat64s2D(g, "wh")
-	wxFlat := getFloat64s2D(g, "wx")
-	bhFlat := getFloat64s(g, "bh")
-	wtauFlat := getFloat64s2D(g, "wtau")
-	btauFlat := getFloat64s(g, "btau")
-	outWFlat := getFloat64s2D(g, "out_w")
-	outBFlat := getFloat64s(g, "out_b")
+	whFlat := testutil.GetFloat64s2D(g, "wh")
+	wxFlat := testutil.GetFloat64s2D(g, "wx")
+	bhFlat := testutil.GetFloat64s(g, "bh")
+	wtauFlat := testutil.GetFloat64s2D(g, "wtau")
+	btauFlat := testutil.GetFloat64s(g, "btau")
+	outWFlat := testutil.GetFloat64s2D(g, "out_w")
+	outBFlat := testutil.GetFloat64s(g, "out_b")
 
 	// Write golden weights to a temp file in CfC's JSON format.
 	dir := t.TempDir()
@@ -782,7 +745,7 @@ func TestParity_CfC(t *testing.T) {
 	}
 
 	// Build input: [channels][seqLen] from golden flat data.
-	inputFlat := getFloat64s(g, "input")
+	inputFlat := testutil.GetFloat64s(g, "input")
 	channels := inputSize
 	input := make([][]float64, channels)
 	for c := 0; c < channels; c++ {
@@ -796,7 +759,7 @@ func TestParity_CfC(t *testing.T) {
 	}
 
 	// Compare against golden expected output.
-	expectedOutput := getFloat64s(g, "expected_output")
+	expectedOutput := testutil.GetFloat64s(g, "expected_output")
 	if len(preds) != len(expectedOutput) {
 		t.Fatalf("output length: got %d, want %d", len(preds), len(expectedOutput))
 	}
@@ -887,7 +850,7 @@ func TestParity_CfC_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_FTTransformer_Structural(t *testing.T) {
-	engine, ops := setup()
+	engine, ops := testutil.Setup()
 
 	config := tabular.FTTransformerConfig{
 		NumFeatures: 4,
@@ -940,14 +903,14 @@ func TestParity_FTTransformer_Structural(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_FreTS(t *testing.T) {
-	g := loadGolden(t, "model_frets")
-	tol := getFloat(g, "tolerance")
+	g := testutil.LoadGolden(t, "model_frets")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	channels := int(getFloat(g, "channels"))
-	inputLen := int(getFloat(g, "input_len"))
-	outputLen := int(getFloat(g, "output_len"))
-	topK := int(getFloat(g, "top_k"))
-	hiddenSize := int(getFloat(g, "hidden_size"))
+	channels := int(testutil.GetFloat(g, "channels"))
+	inputLen := int(testutil.GetFloat(g, "input_len"))
+	outputLen := int(testutil.GetFloat(g, "output_len"))
+	topK := int(testutil.GetFloat(g, "top_k"))
+	hiddenSize := int(testutil.GetFloat(g, "hidden_size"))
 
 	config := tsmodels.FreTSConfig{
 		Channels:   channels,
@@ -964,16 +927,16 @@ func TestParity_FreTS(t *testing.T) {
 
 	// Load golden weights via FlatParams pointers.
 	// FlatParams order: chanW1, chanB1, chanW2, chanB2, tempW1, tempB1, tempW2, tempB2, outW, outB
-	chanW1 := getFloat64s(g, "chan_w1")
-	chanB1 := getFloat64s(g, "chan_b1")
-	chanW2 := getFloat64s(g, "chan_w2")
-	chanB2 := getFloat64s(g, "chan_b2")
-	tempW1 := getFloat64s(g, "temp_w1")
-	tempB1 := getFloat64s(g, "temp_b1")
-	tempW2 := getFloat64s(g, "temp_w2")
-	tempB2 := getFloat64s(g, "temp_b2")
-	outW := getFloat64s(g, "out_w")
-	outB := getFloat64s(g, "out_b")
+	chanW1 := testutil.GetFloat64s(g, "chan_w1")
+	chanB1 := testutil.GetFloat64s(g, "chan_b1")
+	chanW2 := testutil.GetFloat64s(g, "chan_w2")
+	chanB2 := testutil.GetFloat64s(g, "chan_b2")
+	tempW1 := testutil.GetFloat64s(g, "temp_w1")
+	tempB1 := testutil.GetFloat64s(g, "temp_b1")
+	tempW2 := testutil.GetFloat64s(g, "temp_w2")
+	tempB2 := testutil.GetFloat64s(g, "temp_b2")
+	outW := testutil.GetFloat64s(g, "out_w")
+	outB := testutil.GetFloat64s(g, "out_b")
 
 	allWeights := make([]float64, 0)
 	allWeights = append(allWeights, chanW1...)
@@ -996,7 +959,7 @@ func TestParity_FreTS(t *testing.T) {
 	}
 
 	// Build input: [channels][inputLen] from golden flat data.
-	inputFlat := getFloat64s(g, "input")
+	inputFlat := testutil.GetFloat64s(g, "input")
 	input := make([][]float64, channels)
 	for c := 0; c < channels; c++ {
 		input[c] = inputFlat[c*inputLen : (c+1)*inputLen]
@@ -1009,7 +972,7 @@ func TestParity_FreTS(t *testing.T) {
 	}
 
 	// Compare against expected output.
-	expectedOutput := getFloat64s(g, "expected_output")
+	expectedOutput := testutil.GetFloat64s(g, "expected_output")
 	if len(output) != len(expectedOutput) {
 		t.Fatalf("output length: got %d, want %d", len(output), len(expectedOutput))
 	}
@@ -1026,15 +989,15 @@ func TestParity_FreTS(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestParity_TimeMixer(t *testing.T) {
-	g := loadGolden(t, "model_timemixer")
-	tol := getFloat(g, "tolerance")
+	g := testutil.LoadGolden(t, "model_timemixer")
+	tol := testutil.GetFloat(g, "tolerance")
 
-	inputLen := int(getFloat(g, "input_len"))
-	outputLen := int(getFloat(g, "output_len"))
-	numFeatures := int(getFloat(g, "num_features"))
-	numScales := int(getFloat(g, "num_scales"))
-	hiddenSize := int(getFloat(g, "hidden_size"))
-	numLayers := int(getFloat(g, "num_layers"))
+	inputLen := int(testutil.GetFloat(g, "input_len"))
+	outputLen := int(testutil.GetFloat(g, "output_len"))
+	numFeatures := int(testutil.GetFloat(g, "num_features"))
+	numScales := int(testutil.GetFloat(g, "num_scales"))
+	hiddenSize := int(testutil.GetFloat(g, "hidden_size"))
+	numLayers := int(testutil.GetFloat(g, "num_layers"))
 
 	cfg := tsmodels.TimeMixerConfig{
 		InputLen:    inputLen,
@@ -1048,7 +1011,7 @@ func TestParity_TimeMixer(t *testing.T) {
 	m := tsmodels.NewTimeMixer(cfg)
 
 	// Inject golden flat params (MA weights + MLP weights) via FlatParams pointers.
-	flatParams := getFloat64s(g, "flat_params")
+	flatParams := testutil.GetFloat64s(g, "flat_params")
 	ptrs := m.FlatParams()
 	if len(ptrs) != len(flatParams) {
 		t.Fatalf("flat_params length mismatch: got %d pointers, want %d values", len(ptrs), len(flatParams))
@@ -1064,8 +1027,8 @@ func TestParity_TimeMixer(t *testing.T) {
 	}
 	trendHeads := make([][][]float64, numScales)
 	for s := 0; s < numScales; s++ {
-		flat := toFloat64Slice(trendHeadsRaw[s])
-		trendHeads[s] = reshapeFloat64(flat, inputLen, outputLen)
+		flat := testutil.ToFloat64Slice(trendHeadsRaw[s])
+		trendHeads[s] = testutil.ReshapeFloat64(flat, inputLen, outputLen)
 	}
 	m.SetTrendHeads(trendHeads)
 
@@ -1075,16 +1038,16 @@ func TestParity_TimeMixer(t *testing.T) {
 	}
 	seasonalHeads := make([][][]float64, numScales)
 	for s := 0; s < numScales; s++ {
-		flat := toFloat64Slice(seasonalHeadsRaw[s])
-		seasonalHeads[s] = reshapeFloat64(flat, inputLen, outputLen)
+		flat := testutil.ToFloat64Slice(seasonalHeadsRaw[s])
+		seasonalHeads[s] = testutil.ReshapeFloat64(flat, inputLen, outputLen)
 	}
 	m.SetSeasonalHeads(seasonalHeads)
 
-	mixWeights := getFloat64s(g, "mix_weights")
+	mixWeights := testutil.GetFloat64s(g, "mix_weights")
 	m.SetMixWeights(mixWeights)
 
 	// Build input [numFeatures][inputLen].
-	inputFlat := getFloat64s(g, "input")
+	inputFlat := testutil.GetFloat64s(g, "input")
 	input := make([][]float64, numFeatures)
 	for f := 0; f < numFeatures; f++ {
 		input[f] = inputFlat[f*inputLen : (f+1)*inputLen]
@@ -1097,7 +1060,7 @@ func TestParity_TimeMixer(t *testing.T) {
 	}
 
 	// Compare against golden expected output.
-	expectedOutput := getFloat64s(g, "expected_output")
+	expectedOutput := testutil.GetFloat64s(g, "expected_output")
 	got := make([]float64, 0, numFeatures*outputLen)
 	for f := 0; f < numFeatures; f++ {
 		got = append(got, out.Forecast[f]...)
@@ -1111,14 +1074,4 @@ func TestParity_TimeMixer(t *testing.T) {
 			t.Errorf("output[%d]: got %g, want %g (diff=%g, tol=%g)", i, got[i], expectedOutput[i], diff, tol)
 		}
 	}
-}
-
-// toFloat64Slice converts a JSON array ([]interface{}) to []float64.
-func toFloat64Slice(v interface{}) []float64 {
-	arr := v.([]interface{})
-	out := make([]float64, len(arr))
-	for i, x := range arr {
-		out[i] = x.(float64)
-	}
-	return out
 }

--- a/tests/parity/multigpu_test.go
+++ b/tests/parity/multigpu_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/zerfoo/zerfoo/inference"
 	"github.com/zerfoo/zerfoo/internal/cuda"
 	"github.com/zerfoo/zerfoo/registry"
+
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
 )
 
 // TestMultiGPU_DualDeviceInference loads the same model on two GPUs and verifies
@@ -24,8 +26,8 @@ func TestMultiGPU_DualDeviceInference(t *testing.T) {
 	modelID := "gemma-3-1b-it"
 	modelPath := findModelDir(t, modelID)
 
-	reg := &dirRegistry{
-		models: map[string]*registry.ModelInfo{
+	reg := &testutil.DirRegistry{
+		Models: map[string]*registry.ModelInfo{
 			modelID: {ID: modelID, Path: modelPath},
 		},
 	}

--- a/tests/parity/new_arch_parity_test.go
+++ b/tests/parity/new_arch_parity_test.go
@@ -3,6 +3,8 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
@@ -23,7 +25,7 @@ import (
 func TestNewArchParity(t *testing.T) {
 	layerreg.RegisterAll()
 
-	archs := []modelParityConfig{
+	archs := []testutil.ModelParityConfig{
 		llama4Config,
 		gemma3nConfig,
 		commandRConfig,
@@ -34,13 +36,13 @@ func TestNewArchParity(t *testing.T) {
 
 	for _, arch := range archs {
 		t.Run(arch.Name+"/forward_pass", func(t *testing.T) {
-			runModelForwardPass(t, arch)
+			testutil.RunModelForwardPass(t, arch)
 		})
 		t.Run(arch.Name+"/greedy_decode", func(t *testing.T) {
-			runModelGreedyDecode(t, arch)
+			testutil.RunModelGreedyDecode(t, arch)
 		})
 		t.Run(arch.Name+"/generation", func(t *testing.T) {
-			runModelGeneration(t, arch)
+			testutil.RunModelGeneration(t, arch)
 		})
 	}
 }

--- a/tests/parity/phi4_test.go
+++ b/tests/parity/phi4_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var phi4Config = modelParityConfig{
+var phi4Config = testutil.ModelParityConfig{
 	Name:           "Phi-3",
 	ZMFEnvVar:      "PHI4_ZMF_PATH",
 	ModelDirEnvVar: "PHI4_MODEL_DIR",
@@ -16,15 +18,15 @@ var phi4Config = modelParityConfig{
 
 func TestPhi4ForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, phi4Config)
+	testutil.RunModelForwardPass(t, phi4Config)
 }
 
 func TestPhi4GreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, phi4Config)
+	testutil.RunModelGreedyDecode(t, phi4Config)
 }
 
 func TestPhi4Generation(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, phi4Config)
+	testutil.RunModelGeneration(t, phi4Config)
 }

--- a/tests/parity/qwen_test.go
+++ b/tests/parity/qwen_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var qwenConfig = modelParityConfig{
+var qwenConfig = testutil.ModelParityConfig{
 	Name:           "Qwen 2.5",
 	ZMFEnvVar:      "QWEN25_ZMF_PATH",
 	ModelDirEnvVar: "QWEN25_MODEL_DIR",
@@ -16,15 +18,15 @@ var qwenConfig = modelParityConfig{
 
 func TestQwen25ForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, qwenConfig)
+	testutil.RunModelForwardPass(t, qwenConfig)
 }
 
 func TestQwen25GreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, qwenConfig)
+	testutil.RunModelGreedyDecode(t, qwenConfig)
 }
 
 func TestQwen25Generation(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, qwenConfig)
+	testutil.RunModelGeneration(t, qwenConfig)
 }

--- a/tests/parity/rwkv_test.go
+++ b/tests/parity/rwkv_test.go
@@ -3,10 +3,12 @@ package parity_test
 import (
 	"testing"
 
+	"github.com/zerfoo/zerfoo/tests/parity/testutil"
+
 	layerreg "github.com/zerfoo/zerfoo/layers/registry"
 )
 
-var rwkvConfig = modelParityConfig{
+var rwkvConfig = testutil.ModelParityConfig{
 	Name:           "RWKV",
 	ZMFEnvVar:      "RWKV_ZMF_PATH",
 	ModelDirEnvVar: "RWKV_MODEL_DIR",
@@ -16,15 +18,15 @@ var rwkvConfig = modelParityConfig{
 
 func TestRWKVForwardPass(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelForwardPass(t, rwkvConfig)
+	testutil.RunModelForwardPass(t, rwkvConfig)
 }
 
 func TestRWKVGreedyDecode(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGreedyDecode(t, rwkvConfig)
+	testutil.RunModelGreedyDecode(t, rwkvConfig)
 }
 
 func TestRWKVGeneration(t *testing.T) {
 	layerreg.RegisterAll()
-	runModelGeneration(t, rwkvConfig)
+	testutil.RunModelGeneration(t, rwkvConfig)
 }

--- a/tests/parity/testutil/assertions.go
+++ b/tests/parity/testutil/assertions.go
@@ -1,0 +1,48 @@
+package testutil
+
+import (
+	"math"
+	"testing"
+)
+
+// CompareSlices compares two float32 slices with tolerance.
+// Returns the number of mismatches and the max absolute difference.
+func CompareSlices(got, want []float32, tol float64) (mismatches int, maxDiff float64) {
+	if len(got) != len(want) {
+		return len(got) + len(want), math.Inf(1)
+	}
+	for i := range got {
+		diff := math.Abs(float64(got[i] - want[i]))
+		if diff > maxDiff {
+			maxDiff = diff
+		}
+		if diff > tol {
+			mismatches++
+		}
+	}
+	return
+}
+
+// AssertClose compares output data against expected with tolerance.
+func AssertClose(t *testing.T, label string, got, want []float32, tol float64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: length mismatch: got %d, want %d", label, len(got), len(want))
+	}
+	mismatches, maxDiff := CompareSlices(got, want, tol)
+	if mismatches > 0 {
+		// Show first few mismatches.
+		shown := 0
+		for i := range got {
+			diff := math.Abs(float64(got[i] - want[i]))
+			if diff > tol {
+				t.Errorf("%s[%d]: got %g, want %g (diff=%g)", label, i, got[i], want[i], diff)
+				shown++
+				if shown >= 5 {
+					break
+				}
+			}
+		}
+		t.Errorf("%s: %d/%d values exceed tolerance %g (maxDiff=%g)", label, mismatches, len(got), tol, maxDiff)
+	}
+}

--- a/tests/parity/testutil/golden.go
+++ b/tests/parity/testutil/golden.go
@@ -1,0 +1,118 @@
+// Package testutil provides shared helpers for the parity test suite.
+//
+// These helpers were previously inlined as unexported functions in
+// tests/parity/*_test.go; they are extracted here so future parity tests
+// can import them cleanly. See T124.6.2.
+package testutil
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// GoldenDir returns the absolute path to tests/golden/layers/ relative to
+// this source file. The previous in-package helper resolved the path via
+// runtime.Caller(0) from tests/parity/, so we walk one extra level up
+// here to preserve the original target directory.
+func GoldenDir() string {
+	_, f, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(f), "..", "..", "golden", "layers")
+}
+
+// LoadGolden loads a golden JSON file from GoldenDir and returns the raw map.
+func LoadGolden(t *testing.T, name string) map[string]interface{} {
+	t.Helper()
+	path := filepath.Join(GoldenDir(), name+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("load golden %s: %v", name, err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse golden %s: %v", name, err)
+	}
+	return m
+}
+
+// GetFloat32s extracts a float32 slice from a JSON array.
+func GetFloat32s(m map[string]interface{}, key string) []float32 {
+	arr, ok := m[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]float32, len(arr))
+	for i, v := range arr {
+		out[i] = float32(v.(float64))
+	}
+	return out
+}
+
+// GetFloat64s extracts a float64 slice from a JSON array.
+func GetFloat64s(m map[string]interface{}, key string) []float64 {
+	arr, ok := m[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]float64, len(arr))
+	for i, v := range arr {
+		out[i] = v.(float64)
+	}
+	return out
+}
+
+// GetFloat64s2D extracts a 2D float64 slice from a JSON nested array.
+func GetFloat64s2D(m map[string]interface{}, key string) [][]float64 {
+	arr, ok := m[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([][]float64, len(arr))
+	for i, row := range arr {
+		rowArr := row.([]interface{})
+		out[i] = make([]float64, len(rowArr))
+		for j, v := range rowArr {
+			out[i][j] = v.(float64)
+		}
+	}
+	return out
+}
+
+// GetInts extracts an int slice from a JSON array.
+func GetInts(m map[string]interface{}, key string) []int {
+	arr, ok := m[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]int, len(arr))
+	for i, v := range arr {
+		out[i] = int(v.(float64))
+	}
+	return out
+}
+
+// GetFloat extracts a float64 from a JSON value.
+func GetFloat(m map[string]interface{}, key string) float64 {
+	return m[key].(float64)
+}
+
+// ToFloat64Slice coerces an interface holding a JSON array to []float64.
+func ToFloat64Slice(v interface{}) []float64 {
+	arr := v.([]interface{})
+	out := make([]float64, len(arr))
+	for i, x := range arr {
+		out[i] = x.(float64)
+	}
+	return out
+}
+
+// ReshapeFloat64 reshapes a flat float64 slice into a 2D slice [rows][cols].
+func ReshapeFloat64(flat []float64, rows, cols int) [][]float64 {
+	result := make([][]float64, rows)
+	for r := 0; r < rows; r++ {
+		result[r] = flat[r*cols : (r+1)*cols]
+	}
+	return result
+}

--- a/tests/parity/testutil/model.go
+++ b/tests/parity/testutil/model.go
@@ -1,4 +1,4 @@
-package parity_test
+package testutil
 
 import (
 	"context"
@@ -9,46 +9,51 @@ import (
 	"testing"
 
 	"github.com/zerfoo/zerfoo/generate"
-	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/zerfoo/inference"
 	"github.com/zerfoo/zerfoo/registry"
+	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
 )
 
-// dirRegistry is a mock ModelRegistry that maps model IDs to local directories.
-type dirRegistry struct {
-	models map[string]*registry.ModelInfo
+// DirRegistry is a mock ModelRegistry that maps model IDs to local directories.
+type DirRegistry struct {
+	Models map[string]*registry.ModelInfo
 }
 
-func (r *dirRegistry) Get(modelID string) (*registry.ModelInfo, bool) {
-	info, ok := r.models[modelID]
+// Get returns the model info for the given ID, if any.
+func (r *DirRegistry) Get(modelID string) (*registry.ModelInfo, bool) {
+	info, ok := r.Models[modelID]
 	return info, ok
 }
 
-func (r *dirRegistry) Pull(_ context.Context, _ string) (*registry.ModelInfo, error) {
+// Pull is a no-op for the directory-backed test registry.
+func (r *DirRegistry) Pull(_ context.Context, _ string) (*registry.ModelInfo, error) {
 	return nil, nil
 }
 
-func (r *dirRegistry) List() []registry.ModelInfo { return nil }
-func (r *dirRegistry) Delete(_ string) error      { return nil }
+// List returns nil; tests don't enumerate the registry.
+func (r *DirRegistry) List() []registry.ModelInfo { return nil }
 
-// loadZMFGraph loads a ZMF model and returns the computation graph.
+// Delete is a no-op for the directory-backed test registry.
+func (r *DirRegistry) Delete(_ string) error { return nil }
+
+// LoadZMFGraph loads a ZMF model and returns the computation graph.
 // ZMF loading was removed; this always skips the test.
-func loadZMFGraph(t *testing.T, _ string) *graph.Graph[float32] {
+func LoadZMFGraph(t *testing.T, _ string) *graph.Graph[float32] {
 	t.Helper()
 	t.Skip("ZMF loading is no longer supported")
 	return nil
 }
 
-// forwardPassConfig holds parameters for a forward pass test.
-type forwardPassConfig struct {
+// ForwardPassConfig holds parameters for a forward pass test.
+type ForwardPassConfig struct {
 	Name         string
 	SeqLen       int
 	MinVocabSize int
 }
 
-// runForwardPassTest runs a single forward pass and validates the output.
-func runForwardPassTest(t *testing.T, g *graph.Graph[float32], cfg forwardPassConfig) {
+// RunForwardPassTest runs a single forward pass and validates the output.
+func RunForwardPassTest(t *testing.T, g *graph.Graph[float32], cfg ForwardPassConfig) {
 	t.Helper()
 
 	inputData := make([]float32, cfg.SeqLen)
@@ -100,8 +105,8 @@ func runForwardPassTest(t *testing.T, g *graph.Graph[float32], cfg forwardPassCo
 	}
 }
 
-// runGreedyDecodeTest runs N greedy decode steps from an initial token sequence.
-func runGreedyDecodeTest(t *testing.T, g *graph.Graph[float32], initTokens []float32, steps int) {
+// RunGreedyDecodeTest runs N greedy decode steps from an initial token sequence.
+func RunGreedyDecodeTest(t *testing.T, g *graph.Graph[float32], initTokens []float32, steps int) {
 	t.Helper()
 
 	tokens := append([]float32{}, initTokens...)
@@ -163,8 +168,8 @@ func runGreedyDecodeTest(t *testing.T, g *graph.Graph[float32], initTokens []flo
 	}
 }
 
-// modelParityConfig describes a complete parity test suite for a model family.
-type modelParityConfig struct {
+// ModelParityConfig describes a complete parity test suite for a model family.
+type ModelParityConfig struct {
 	// Name is a human-readable label (e.g. "Llama 3").
 	Name string
 	// ZMFEnvVar is the environment variable for the .zmf file path.
@@ -177,38 +182,38 @@ type modelParityConfig struct {
 	MinVocabSize int
 }
 
-// runModelForwardPass runs the forward pass test for a model family.
-func runModelForwardPass(t *testing.T, cfg modelParityConfig) {
+// RunModelForwardPass runs the forward pass test for a model family.
+func RunModelForwardPass(t *testing.T, cfg ModelParityConfig) {
 	t.Helper()
-	zmfPath := envOrSkip(t, cfg.ZMFEnvVar)
-	g := loadZMFGraph(t, zmfPath)
-	runForwardPassTest(t, g, forwardPassConfig{
+	zmfPath := EnvOrSkip(t, cfg.ZMFEnvVar)
+	g := LoadZMFGraph(t, zmfPath)
+	RunForwardPassTest(t, g, ForwardPassConfig{
 		Name:         cfg.Name,
 		SeqLen:       8,
 		MinVocabSize: cfg.MinVocabSize,
 	})
 }
 
-// runModelGreedyDecode runs the greedy decode test for a model family.
-func runModelGreedyDecode(t *testing.T, cfg modelParityConfig) {
+// RunModelGreedyDecode runs the greedy decode test for a model family.
+func RunModelGreedyDecode(t *testing.T, cfg ModelParityConfig) {
 	t.Helper()
-	zmfPath := envOrSkip(t, cfg.ZMFEnvVar)
-	g := loadZMFGraph(t, zmfPath)
-	runGreedyDecodeTest(t, g, []float32{1, 2, 3}, 5)
+	zmfPath := EnvOrSkip(t, cfg.ZMFEnvVar)
+	g := LoadZMFGraph(t, zmfPath)
+	RunGreedyDecodeTest(t, g, []float32{1, 2, 3}, 5)
 }
 
-// runModelGeneration runs the generation test suite for a model family.
-func runModelGeneration(t *testing.T, cfg modelParityConfig) {
+// RunModelGeneration runs the generation test suite for a model family.
+func RunModelGeneration(t *testing.T, cfg ModelParityConfig) {
 	t.Helper()
-	modelDir := modelDirOrSkip(t, cfg.ModelDirEnvVar, cfg.ZMFEnvVar)
-	runGenerationTests(t, generationTestConfig{
+	modelDir := ModelDirOrSkip(t, cfg.ModelDirEnvVar, cfg.ZMFEnvVar)
+	RunGenerationTests(t, GenerationTestConfig{
 		ModelID:  cfg.ModelID,
 		ModelDir: modelDir,
 	})
 }
 
-// envOrSkip returns the value of the named env var, or skips the test.
-func envOrSkip(t *testing.T, key string) string {
+// EnvOrSkip returns the value of the named env var, or skips the test.
+func EnvOrSkip(t *testing.T, key string) string {
 	t.Helper()
 	v := os.Getenv(key)
 	if v == "" {
@@ -217,8 +222,8 @@ func envOrSkip(t *testing.T, key string) string {
 	return v
 }
 
-// modelDirOrSkip resolves a model directory from env vars, or skips the test.
-func modelDirOrSkip(t *testing.T, dirEnvVar, zmfEnvVar string) string {
+// ModelDirOrSkip resolves a model directory from env vars, or skips the test.
+func ModelDirOrSkip(t *testing.T, dirEnvVar, zmfEnvVar string) string {
 	t.Helper()
 	if d := os.Getenv(dirEnvVar); d != "" {
 		return d
@@ -230,18 +235,18 @@ func modelDirOrSkip(t *testing.T, dirEnvVar, zmfEnvVar string) string {
 	return filepath.Dir(zmfPath)
 }
 
-// generationTestConfig holds parameters for generation tests via inference API.
-type generationTestConfig struct {
+// GenerationTestConfig holds parameters for generation tests via inference API.
+type GenerationTestConfig struct {
 	ModelID  string
 	ModelDir string
 }
 
-// runGenerationTests runs greedy, stream, and chat tests on an inference.Model.
-func runGenerationTests(t *testing.T, cfg generationTestConfig) {
+// RunGenerationTests runs greedy, stream, and chat tests on an inference.Model.
+func RunGenerationTests(t *testing.T, cfg GenerationTestConfig) {
 	t.Helper()
 
-	reg := &dirRegistry{
-		models: map[string]*registry.ModelInfo{
+	reg := &DirRegistry{
+		Models: map[string]*registry.ModelInfo{
 			cfg.ModelID: {ID: cfg.ModelID, Path: cfg.ModelDir},
 		},
 	}

--- a/tests/parity/testutil/tensors.go
+++ b/tests/parity/testutil/tensors.go
@@ -1,0 +1,38 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// MakeTensor creates a tensor from golden data.
+func MakeTensor(t *testing.T, data []float32, shape []int) *tensor.TensorNumeric[float32] {
+	t.Helper()
+	tn, err := tensor.New[float32](shape, data)
+	if err != nil {
+		t.Fatalf("create tensor shape=%v: %v", shape, err)
+	}
+	return tn
+}
+
+// MakeParam creates a graph.Parameter from golden data.
+func MakeParam(t *testing.T, name string, data []float32, shape []int) *graph.Parameter[float32] {
+	t.Helper()
+	tn := MakeTensor(t, data, shape)
+	p, err := graph.NewParameter[float32](name, tn, tensor.New[float32])
+	if err != nil {
+		t.Fatalf("create param %s: %v", name, err)
+	}
+	return p
+}
+
+// Setup creates a CPU compute engine and Float32Ops for parity tests.
+func Setup() (compute.Engine[float32], *numeric.Float32Ops) {
+	ops := &numeric.Float32Ops{}
+	engine := compute.NewCPUEngine[float32](ops)
+	return engine, ops
+}


### PR DESCRIPTION
## Summary
- Extract shared parity test helpers from `helpers_test.go`, `layer_parity_test.go`, and `model_parity_test.go` into a new `tests/parity/testutil/` subpackage so future parity suites can import them cleanly (T124.6.2).
- Behavior preserved -- helpers are renamed/exported, not rewritten. Adjusted `GoldenDir()` to walk one extra `..` so it still resolves to `tests/golden/layers`.
- All callers (model parity files, GPU parity files, layer/model parity files) updated to use `testutil.X`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./tests/parity/...`
- [ ] CI green