### PR TITLE
chore(training): verify consolidated subtree (T124.4.7)

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3715,7 +3715,7 @@ left behind.
 - [x] T124.4.6 Move `federated/` -> `training/federated/`  Owner: TBD  Est: 1h  verifies: [infrastructure]  DONE 2026-04-27
   FedAvg coordinator.
 
-- [ ] T124.4.7 Tests + lint after training/ consolidation  Owner: TBD  Est: 0.5h  verifies: [infrastructure]
+- [x] T124.4.7 Tests + lint after training/ consolidation  Owner: TBD  Est: 0.5h  verifies: [infrastructure]  DONE 2026-04-28 verification clean across training/ subtree
   Deps: T124.4.1, T124.4.2, T124.4.3, T124.4.4, T124.4.5, T124.4.6
 
 #### E124.5: layers/ + inference/ consolidation (this sprint)

--- a/training/adapter.go
+++ b/training/adapter.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/zerfoo/zerfoo/training/optimizer"
 	ztensorgguf "github.com/zerfoo/ztensor/gguf"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
-	"github.com/zerfoo/zerfoo/training/optimizer"
 )
 
 // TrainerWorkflowAdapter adapts the existing Trainer interface to the new TrainingWorkflow interface.

--- a/training/adapter_test.go
+++ b/training/adapter_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/zerfoo/zerfoo/training/optimizer"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
-	"github.com/zerfoo/zerfoo/training/optimizer"
 )
 
 // mockTrainer implements Trainer for testing

--- a/training/automl/search.go
+++ b/training/automl/search.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/zerfoo/zerfoo/tabular"
+	"github.com/zerfoo/zerfoo/timeseries"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
-	"github.com/zerfoo/zerfoo/tabular"
-	"github.com/zerfoo/zerfoo/timeseries"
 )
 
 // ArchKind identifies an architecture in the tabular/time-series search space.
@@ -17,11 +17,11 @@ type ArchKind string
 
 const (
 	// Tabular architectures.
-	ArchMLP        ArchKind = "MLP"
+	ArchMLP           ArchKind = "MLP"
 	ArchFTTransformer ArchKind = "FTTransformer"
-	ArchTabNet     ArchKind = "TabNet"
-	ArchSAINT      ArchKind = "SAINT"
-	ArchTabResNet  ArchKind = "TabResNet"
+	ArchTabNet        ArchKind = "TabNet"
+	ArchSAINT         ArchKind = "SAINT"
+	ArchTabResNet     ArchKind = "TabResNet"
 
 	// Time-series architectures.
 	ArchTFT      ArchKind = "TFT"
@@ -69,10 +69,10 @@ type ArchResult struct {
 
 // SearchReport contains all evaluated trials and the best result.
 type SearchReport struct {
-	Trials      []ArchResult
-	BestArch    ArchKind
-	BestParams  map[string]float64
-	BestScore   float64
+	Trials     []ArchResult
+	BestArch   ArchKind
+	BestParams map[string]float64
+	BestScore  float64
 }
 
 // BestModel wraps the winning model with its configuration.
@@ -378,7 +378,7 @@ func evalFTTransformer(
 		NHeads:      nHeads,
 		NLayers:     nLayers,
 		DFFN:        dToken * 4,
-		DropoutRate:  dropout,
+		DropoutRate: dropout,
 	}
 
 	ft, err := tabular.NewFTTransformer(cfg, engine, ops)
@@ -654,7 +654,6 @@ func validateTabular(
 	return float64(correct) / float64(valSize), nil
 }
 
-
 // retrainBest creates the best architecture with the winning hyperparameters
 // and returns a BestModel. For architectures with training support (MLP),
 // the model is trained on all data. For others, the model is instantiated
@@ -743,7 +742,7 @@ func retrainBest(
 
 		rn, err := tabular.NewTabResNet(tabular.TabResNetConfig{
 			InputDim: inputDim, OutputDim: 3,
-			HiddenDims: makeHiddenDims(hiddenDim, numBlocks),
+			HiddenDims:  makeHiddenDims(hiddenDim, numBlocks),
 			DropoutRate: params["dropout"], Activation: tabular.ActivationReLU,
 			Norm: tabular.NormLayer,
 		}, engine, ops)
@@ -936,4 +935,3 @@ func argmax(probs []float32) (tabular.Direction, float64) {
 	}
 	return tabular.Direction(best), float64(probs[best])
 }
-

--- a/training/default_trainer.go
+++ b/training/default_trainer.go
@@ -4,9 +4,9 @@ package training
 import (
 	"context"
 
+	opt "github.com/zerfoo/zerfoo/training/optimizer"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
-	opt "github.com/zerfoo/zerfoo/training/optimizer"
 )
 
 // DefaultTrainer encapsulates stable training components and delegates

--- a/training/early_stop_test.go
+++ b/training/early_stop_test.go
@@ -114,10 +114,10 @@ func TestSmoothedEarlyStopping_MinDelta(t *testing.T) {
 		metric float64
 		want   bool
 	}{
-		{1.0, false},   // init: best=1.0
-		{0.95, false},  // delta=0.05 < 0.1 → no improve (count=1)
-		{0.92, false},  // delta=0.08 < 0.1 → no improve (count=2)
-		{0.905, true},  // delta=0.095 < 0.1 → no improve (count=3 >= patience)
+		{1.0, false},  // init: best=1.0
+		{0.95, false}, // delta=0.05 < 0.1 → no improve (count=1)
+		{0.92, false}, // delta=0.08 < 0.1 → no improve (count=2)
+		{0.905, true}, // delta=0.095 < 0.1 → no improve (count=3 >= patience)
 	}
 
 	for i, s := range steps {

--- a/training/lora/inject_test.go
+++ b/training/lora/inject_test.go
@@ -74,8 +74,8 @@ func newNamedStubLinear[T tensor.Numeric](name string, engine compute.Engine[T],
 	}, nil
 }
 
-func (n *namedStubLinear[T]) Name() string    { return n.layerName }
-func (n *namedStubLinear[T]) OpType() string   { return "Linear" }
+func (n *namedStubLinear[T]) Name() string   { return n.layerName }
+func (n *namedStubLinear[T]) OpType() string { return "Linear" }
 func (n *namedStubLinear[T]) SetName(name string) {
 	n.layerName = name
 	n.weights.Name = name + "_weights"

--- a/training/lora/linear.go
+++ b/training/lora/linear.go
@@ -26,8 +26,8 @@ type LoraLinear[T tensor.Numeric] struct {
 	engine compute.Engine[T]
 
 	// cached for backward
-	lastInput  *tensor.TensorNumeric[T]
-	lastAx     *tensor.TensorNumeric[T]
+	lastInput   *tensor.TensorNumeric[T]
+	lastAx      *tensor.TensorNumeric[T]
 	lastBaseOut *tensor.TensorNumeric[T]
 }
 

--- a/training/lora/linear_test.go
+++ b/training/lora/linear_test.go
@@ -26,10 +26,10 @@ func newStubLinear[T tensor.Numeric](engine compute.Engine[T], w *tensor.TensorN
 	return &stubLinear[T]{weights: param, engine: engine}, nil
 }
 
-func (s *stubLinear[T]) OpType() string                      { return "StubLinear" }
-func (s *stubLinear[T]) Attributes() map[string]interface{}  { return nil }
-func (s *stubLinear[T]) OutputShape() []int                  { return []int{-1, s.weights.Value.Shape()[1]} }
-func (s *stubLinear[T]) Parameters() []*graph.Parameter[T]   { return []*graph.Parameter[T]{s.weights} }
+func (s *stubLinear[T]) OpType() string                     { return "StubLinear" }
+func (s *stubLinear[T]) Attributes() map[string]interface{} { return nil }
+func (s *stubLinear[T]) OutputShape() []int                 { return []int{-1, s.weights.Value.Shape()[1]} }
+func (s *stubLinear[T]) Parameters() []*graph.Parameter[T]  { return []*graph.Parameter[T]{s.weights} }
 
 func (s *stubLinear[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
 	return s.engine.MatMul(ctx, inputs[0], s.weights.Value)

--- a/training/lora/qlora.go
+++ b/training/lora/qlora.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/zerfoo/zerfoo/training/optimizer"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
 	"github.com/zerfoo/ztensor/types"
-	"github.com/zerfoo/zerfoo/training/optimizer"
 )
 
 // QLoRATrainer wraps a model whose base Linear weights are NF4-quantized.

--- a/training/lora/qlora_test.go
+++ b/training/lora/qlora_test.go
@@ -5,12 +5,12 @@ import (
 	"math"
 	"testing"
 
+	"github.com/zerfoo/zerfoo/training/optimizer"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
 	"github.com/zerfoo/ztensor/types"
-	"github.com/zerfoo/zerfoo/training/optimizer"
 )
 
 // nf4StubLinear is a float32-specific Linear layer whose weight tensor uses
@@ -48,11 +48,13 @@ func newNF4StubLinear(name string, engine compute.Engine[float32], dIn, dOut int
 	}, nil
 }
 
-func (n *nf4StubLinear) OpType() string                              { return "Linear" }
-func (n *nf4StubLinear) Attributes() map[string]interface{}          { return nil }
-func (n *nf4StubLinear) OutputShape() []int                          { return []int{-1, n.dOut} }
-func (n *nf4StubLinear) Parameters() []*graph.Parameter[float32]     { return []*graph.Parameter[float32]{n.weights} }
-func (n *nf4StubLinear) Name() string                                { return n.layerName }
+func (n *nf4StubLinear) OpType() string                     { return "Linear" }
+func (n *nf4StubLinear) Attributes() map[string]interface{} { return nil }
+func (n *nf4StubLinear) OutputShape() []int                 { return []int{-1, n.dOut} }
+func (n *nf4StubLinear) Parameters() []*graph.Parameter[float32] {
+	return []*graph.Parameter[float32]{n.weights}
+}
+func (n *nf4StubLinear) Name() string { return n.layerName }
 func (n *nf4StubLinear) SetName(name string) {
 	n.layerName = name
 	n.weights.Name = name + "_weights"

--- a/training/loss/cross_entropy_loss.go
+++ b/training/loss/cross_entropy_loss.go
@@ -141,7 +141,6 @@ func (cel *CrossEntropyLoss[T]) Forward(ctx context.Context, inputs ...*tensor.T
 	return result, nil
 }
 
-
 // Backward computes the gradients for CrossEntropyLoss.
 func (cel *CrossEntropyLoss[T]) Backward(ctx context.Context, _ types.BackwardMode, dOut *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
 	// The gradient of Cross-Entropy Loss with respect to logits (predictions)

--- a/training/loss/quantile_test.go
+++ b/training/loss/quantile_test.go
@@ -22,7 +22,7 @@ func TestQuantileLoss(t *testing.T) {
 	}{
 		{
 			name:      "median q=0.5 symmetric",
-			preds:     []float32{1.0, 2.0},       // 2 samples, 1 quantile each
+			preds:     []float32{1.0, 2.0}, // 2 samples, 1 quantile each
 			predShape: []int{2, 1},
 			targets:   []float32{2.0, 1.0},
 			targShape: []int{2},
@@ -61,7 +61,7 @@ func TestQuantileLoss(t *testing.T) {
 		},
 		{
 			name:      "multiple quantiles",
-			preds:     []float32{2.0, 2.0, 2.0},  // 1 sample, 3 quantiles
+			preds:     []float32{2.0, 2.0, 2.0}, // 1 sample, 3 quantiles
 			predShape: []int{1, 3},
 			targets:   []float32{3.0},
 			targShape: []int{1},

--- a/training/nas/darts_layer.go
+++ b/training/nas/darts_layer.go
@@ -22,9 +22,9 @@ type DARTSLayer[T tensor.Numeric] struct {
 	alpha      *graph.Parameter[T]
 
 	// Cached forward pass state for backward.
-	weights    []T // softmax(alpha)
-	lastInput  *tensor.TensorNumeric[T]
-	opOutputs  []*tensor.TensorNumeric[T]
+	weights   []T // softmax(alpha)
+	lastInput *tensor.TensorNumeric[T]
+	opOutputs []*tensor.TensorNumeric[T]
 }
 
 // NewDARTSLayer creates a new DARTS mixed-operation layer with the given candidate

--- a/training/nas/darts_layer_test.go
+++ b/training/nas/darts_layer_test.go
@@ -19,10 +19,10 @@ type identityOp[T tensor.Numeric] struct {
 	shape  []int
 }
 
-func (op *identityOp[T]) OpType() string                      { return "identity" }
-func (op *identityOp[T]) Attributes() map[string]interface{}  { return nil }
-func (op *identityOp[T]) Parameters() []*graph.Parameter[T]   { return nil }
-func (op *identityOp[T]) OutputShape() []int                  { return op.shape }
+func (op *identityOp[T]) OpType() string                     { return "identity" }
+func (op *identityOp[T]) Attributes() map[string]interface{} { return nil }
+func (op *identityOp[T]) Parameters() []*graph.Parameter[T]  { return nil }
+func (op *identityOp[T]) OutputShape() []int                 { return op.shape }
 
 func (op *identityOp[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
 	return op.engine.MulScalar(ctx, inputs[0], op.scale)

--- a/training/nas/darts_optimizer_test.go
+++ b/training/nas/darts_optimizer_test.go
@@ -33,10 +33,10 @@ func newLinearOp[T tensor.Numeric](engine compute.Engine[T], ops numeric.Arithme
 	return &linearOp[T]{engine: engine, ops: ops, weight: wParam, shape: shape}, nil
 }
 
-func (op *linearOp[T]) OpType() string                      { return "linear" }
-func (op *linearOp[T]) Attributes() map[string]interface{}  { return nil }
-func (op *linearOp[T]) Parameters() []*graph.Parameter[T]   { return []*graph.Parameter[T]{op.weight} }
-func (op *linearOp[T]) OutputShape() []int                  { return op.shape }
+func (op *linearOp[T]) OpType() string                     { return "linear" }
+func (op *linearOp[T]) Attributes() map[string]interface{} { return nil }
+func (op *linearOp[T]) Parameters() []*graph.Parameter[T]  { return []*graph.Parameter[T]{op.weight} }
+func (op *linearOp[T]) OutputShape() []int                 { return op.shape }
 
 func (op *linearOp[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
 	w := op.weight.Value.Data()[0]

--- a/training/nas/discretize.go
+++ b/training/nas/discretize.go
@@ -19,14 +19,14 @@ type DiscretizedArch struct {
 func DefaultOpParams() map[OpType]int64 {
 	channels := int64(64)
 	return map[OpType]int64{
-		OpConv3x3:    9 * channels * channels,          // K^2 * C_in * C_out
-		OpConv5x5:    25 * channels * channels,         // K^2 * C_in * C_out
-		OpSepConv3x3: 9*channels + channels*channels,   // depthwise + pointwise
-		OpSepConv5x5: 25*channels + channels*channels,  // depthwise + pointwise
-		OpAvgPool3x3: 0,
-		OpMaxPool3x3: 0,
+		OpConv3x3:     9 * channels * channels,         // K^2 * C_in * C_out
+		OpConv5x5:     25 * channels * channels,        // K^2 * C_in * C_out
+		OpSepConv3x3:  9*channels + channels*channels,  // depthwise + pointwise
+		OpSepConv5x5:  25*channels + channels*channels, // depthwise + pointwise
+		OpAvgPool3x3:  0,
+		OpMaxPool3x3:  0,
 		OpSkipConnect: 0,
-		OpZero:       0,
+		OpZero:        0,
 	}
 }
 

--- a/training/nas/hw_estimator.go
+++ b/training/nas/hw_estimator.go
@@ -24,8 +24,8 @@ func DGXSpark() HWProfile {
 // OpCost defines the per-instance cost of an operation type in terms of
 // compute (FLOPs) and memory transfers (bytes read + written).
 type OpCost struct {
-	FLOPs     float64 // floating-point operations per instance
-	MemBytes  float64 // bytes of memory traffic per instance
+	FLOPs    float64 // floating-point operations per instance
+	MemBytes float64 // bytes of memory traffic per instance
 }
 
 // DefaultOpCosts returns cost estimates for each operation type. The values
@@ -36,7 +36,7 @@ func DefaultOpCosts() map[OpType]OpCost {
 
 	return map[OpType]OpCost{
 		OpConv3x3: {
-			FLOPs:    2 * 9 * channels * channels * spatial,  // 2*K^2*C_in*C_out*H*W
+			FLOPs:    2 * 9 * channels * channels * spatial, // 2*K^2*C_in*C_out*H*W
 			MemBytes: 4 * (channels*spatial + 9*channels*channels + channels*spatial),
 		},
 		OpConv5x5: {
@@ -74,8 +74,8 @@ func DefaultOpCosts() map[OpType]OpCost {
 // LatencyEstimator predicts inference latency for cell architectures using a
 // linear cost model calibrated against measured hardware benchmarks.
 type LatencyEstimator struct {
-	hw       HWProfile
-	opCosts  map[OpType]OpCost
+	hw      HWProfile
+	opCosts map[OpType]OpCost
 	// Fitted coefficients: latency = alpha * compute_time + beta * mem_time + bias
 	alpha float64
 	beta  float64

--- a/training/nas/search_space.go
+++ b/training/nas/search_space.go
@@ -12,14 +12,14 @@ import "math/rand/v2"
 type OpType string
 
 const (
-	OpConv3x3    OpType = "conv_3x3"
-	OpConv5x5    OpType = "conv_5x5"
-	OpSepConv3x3 OpType = "sep_conv_3x3"
-	OpSepConv5x5 OpType = "sep_conv_5x5"
-	OpAvgPool3x3 OpType = "avg_pool_3x3"
-	OpMaxPool3x3 OpType = "max_pool_3x3"
+	OpConv3x3     OpType = "conv_3x3"
+	OpConv5x5     OpType = "conv_5x5"
+	OpSepConv3x3  OpType = "sep_conv_3x3"
+	OpSepConv5x5  OpType = "sep_conv_5x5"
+	OpAvgPool3x3  OpType = "avg_pool_3x3"
+	OpMaxPool3x3  OpType = "max_pool_3x3"
 	OpSkipConnect OpType = "skip_connect"
-	OpZero       OpType = "zero"
+	OpZero        OpType = "zero"
 )
 
 // AllOps returns the default set of all 8 operation types.

--- a/training/nas/search_space_test.go
+++ b/training/nas/search_space_test.go
@@ -61,11 +61,11 @@ func TestNumCells(t *testing.T) {
 		numOps   int
 		want     int64
 	}{
-		{"2 nodes, 8 ops", 2, 8, 8},       // 1 edge, 8^1
-		{"3 nodes, 8 ops", 3, 8, 512},     // 3 edges, 8^3
-		{"4 nodes, 8 ops", 4, 8, 262144},  // 6 edges, 8^6
-		{"3 nodes, 2 ops", 3, 2, 8},       // 3 edges, 2^3
-		{"2 nodes, 2 ops", 2, 2, 2},       // 1 edge, 2^1
+		{"2 nodes, 8 ops", 2, 8, 8},      // 1 edge, 8^1
+		{"3 nodes, 8 ops", 3, 8, 512},    // 3 edges, 8^3
+		{"4 nodes, 8 ops", 4, 8, 262144}, // 6 edges, 8^6
+		{"3 nodes, 2 ops", 3, 2, 8},      // 3 edges, 2^3
+		{"2 nodes, 2 ops", 2, 2, 2},      // 1 edge, 2^1
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/training/nas/signal_search.go
+++ b/training/nas/signal_search.go
@@ -330,10 +330,10 @@ type signalCandidate struct {
 	engine compute.Engine[float32]
 }
 
-func (c *signalCandidate) OpType() string                      { return string(c.opType) }
-func (c *signalCandidate) Attributes() map[string]interface{}  { return nil }
+func (c *signalCandidate) OpType() string                          { return string(c.opType) }
+func (c *signalCandidate) Attributes() map[string]interface{}      { return nil }
 func (c *signalCandidate) Parameters() []*graph.Parameter[float32] { return nil }
-func (c *signalCandidate) OutputShape() []int                  { return nil }
+func (c *signalCandidate) OutputShape() []int                      { return nil }
 
 func (c *signalCandidate) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error) {
 	return c.engine.MulScalar(ctx, inputs[0], c.scale)

--- a/training/online/nas_trigger_test.go
+++ b/training/online/nas_trigger_test.go
@@ -33,12 +33,12 @@ func (s *syntheticDataProvider) ValBatch() (input, target []float32, shape []int
 
 func TestAutoNASTrigger(t *testing.T) {
 	tests := []struct {
-		name             string
-		currentSharpe    float64
+		name              string
+		currentSharpe     float64
 		improvementThresh float64
-		validators       []Validator
-		wantAccepted     bool
-		wantHasProposal  bool
+		validators        []Validator
+		wantAccepted      bool
+		wantHasProposal   bool
 	}{
 		{
 			name:              "drift triggers NAS and discovers improvement",

--- a/training/trainer.go
+++ b/training/trainer.go
@@ -4,9 +4,9 @@ package training
 import (
 	"context"
 
+	"github.com/zerfoo/zerfoo/training/optimizer"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
-	"github.com/zerfoo/zerfoo/training/optimizer"
 )
 
 // Trainer is an interface for model-specific training orchestration.

--- a/training/trainer_test.go
+++ b/training/trainer_test.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/zerfoo/zerfoo/training"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
 	"github.com/zerfoo/ztensor/testing/testutils"
-	"github.com/zerfoo/zerfoo/training"
 	"github.com/zerfoo/ztensor/types"
 )
 


### PR DESCRIPTION
## Summary

Closes T124.4.7 (verification task for E124.4 training/ consolidation).

Ran the full verification matrix across `training/` (rl, meta, gp, mlops/{monitor,recover}, provenance, federated, plus pre-existing trainer code):

- `go build ./training/...` -- OK
- `go vet ./training/...` -- OK (no findings)
- `go test ./training/...` -- OK (all 16 packages pass)
- Stale-import grep for old top-level paths (`rl|meta|gp|monitor|recover|provenance|federated`) -- zero hits
- `gofmt -l ./training/` -- 23 files had import-ordering drift from earlier moves; applied `gofmt -w` as minimal fix-forward

`golangci-lint run ./training/...` reports 54 pre-existing issues (staticcheck, errcheck, gosec, gocritic, misspell, unused, etc.) that predate E124.4. Out of scope for this verification task -- flagging here for a follow-up cleanup.

## Test plan

- [x] go build ./training/...
- [x] go vet ./training/...
- [x] go test ./training/...
- [x] gofmt clean
- [x] No stale top-level import paths