### PR TITLE
refactor(activations): thin-wrap layers/functional over canonical Nodes (T124.2.2)

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -3654,7 +3654,7 @@ left behind.
   inline copies].
   Acceptance: audit table written to `docs/audits/T124.2.1-activations.md`.
 
-- [ ] T124.2.2 Make `layers/functional/activations.go` thin wrappers  Owner: TBD  Est: 3h  verifies: [infrastructure]
+- [x] DONE 2026-04-28 T124.2.2 Make `layers/functional/activations.go` thin wrappers  Owner: TBD  Est: 3h  verifies: [infrastructure]
   Deps: T124.2.1
   Convert each function in `layers/functional/activations.go` to construct
   the corresponding Node from `layers/activations/registry.go` and

--- a/layers/functional/activations.go
+++ b/layers/functional/activations.go
@@ -2,8 +2,8 @@ package functional
 
 import (
 	"context"
-	"math"
 
+	"github.com/zerfoo/zerfoo/layers/activations"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
@@ -11,52 +11,11 @@ import (
 
 // GELU applies the Gaussian Error Linear Unit activation using the tanh
 // approximation: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715*x^3))).
-// All arithmetic is routed through Engine[T] primitives.
+// Thin wrapper that delegates to the canonical activations.Gelu Node so
+// there is a single source of truth for the math (T124.2.2).
 func GELU[T tensor.Float](ctx context.Context, engine compute.Engine[T], ops numeric.Arithmetic[T],
 	x *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
-
-	// x^2
-	x2, err := engine.Mul(ctx, x, x)
-	if err != nil {
-		return nil, err
-	}
-	// x^3
-	x3, err := engine.Mul(ctx, x2, x)
-	if err != nil {
-		return nil, err
-	}
-	// 0.044715 * x^3
-	coeff, err := engine.MulScalar(ctx, x3, ops.FromFloat64(0.044715))
-	if err != nil {
-		return nil, err
-	}
-	// x + 0.044715 * x^3
-	inner, err := engine.Add(ctx, x, coeff)
-	if err != nil {
-		return nil, err
-	}
-	// sqrt(2/pi) * (x + 0.044715 * x^3)
-	scaled, err := engine.MulScalar(ctx, inner, ops.FromFloat64(math.Sqrt(2/math.Pi)))
-	if err != nil {
-		return nil, err
-	}
-	// tanh(...)
-	th, err := engine.Tanh(ctx, scaled)
-	if err != nil {
-		return nil, err
-	}
-	// 1 + tanh(...)
-	onePlus, err := engine.AddScalar(ctx, th, ops.One())
-	if err != nil {
-		return nil, err
-	}
-	// x * (1 + tanh(...))
-	prod, err := engine.Mul(ctx, x, onePlus)
-	if err != nil {
-		return nil, err
-	}
-	// 0.5 * x * (1 + tanh(...))
-	return engine.MulScalar(ctx, prod, ops.FromFloat64(0.5))
+	return activations.NewGelu(engine, ops).Forward(ctx, x)
 }
 
 // Softmax applies the softmax function along the given axis.
@@ -72,19 +31,11 @@ func ReLU[T tensor.Numeric](ctx context.Context, engine compute.Engine[T], ops n
 }
 
 // Sigmoid applies the sigmoid activation: exp(x) / (1 + exp(x)).
-// All arithmetic is routed through Engine[T] primitives.
+// Thin wrapper that delegates to the canonical activations.Sigmoid Node
+// (T124.2.2).
 func Sigmoid[T tensor.Numeric](ctx context.Context, engine compute.Engine[T], ops numeric.Arithmetic[T],
 	x *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
-
-	expX, err := engine.Exp(ctx, x)
-	if err != nil {
-		return nil, err
-	}
-	denom, err := engine.AddScalar(ctx, expX, ops.One())
-	if err != nil {
-		return nil, err
-	}
-	return engine.Div(ctx, expX, denom)
+	return activations.NewSigmoid(engine, ops).Forward(ctx, x)
 }
 
 // SiLU applies the Sigmoid Linear Unit (SiLU / Swish) activation: x * sigmoid(x).

--- a/layers/functional/gelu_backward.go
+++ b/layers/functional/gelu_backward.go
@@ -2,11 +2,13 @@ package functional
 
 import (
 	"context"
-	"math"
+	"fmt"
 
+	"github.com/zerfoo/zerfoo/layers/activations"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
 )
 
 // GELUBackward computes the gradient of the GELU activation.
@@ -14,106 +16,22 @@ import (
 // input: original input to GELU
 // Returns: dInput (same shape as input)
 //
-// Using the tanh approximation GELU(x) = 0.5 * x * (1 + tanh(u))
-// where u = sqrt(2/pi) * (x + 0.044715*x^3), the derivative is:
-// GELU'(x) = 0.5*(1+tanh(u)) + 0.5*x*(1-tanh^2(u))*sqrt(2/pi)*(1+3*0.044715*x^2)
+// Thin wrapper that delegates to the canonical activations.Gelu Node's
+// Backward (T124.2.2). The node's Backward consumes the lastInput cached
+// during Forward, so we run Forward(input) first to seed it, then call
+// Backward(dOutput).
 func GELUBackward[T tensor.Float](ctx context.Context, engine compute.Engine[T], ops numeric.Arithmetic[T],
 	dOutput, input *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
-
-	// x^2
-	x2, err := engine.Mul(ctx, input, input)
+	node := activations.NewGelu(engine, ops)
+	if _, err := node.Forward(ctx, input); err != nil {
+		return nil, fmt.Errorf("GELUBackward: forward seed: %w", err)
+	}
+	grads, err := node.Backward(ctx, types.FullBackprop, dOutput)
 	if err != nil {
 		return nil, err
 	}
-
-	// x^3
-	x3, err := engine.Mul(ctx, x2, input)
-	if err != nil {
-		return nil, err
+	if len(grads) != 1 {
+		return nil, fmt.Errorf("GELUBackward: expected 1 gradient, got %d", len(grads))
 	}
-
-	// 0.044715 * x^3
-	bx3, err := engine.MulScalar(ctx, x3, ops.FromFloat64(0.044715))
-	if err != nil {
-		return nil, err
-	}
-
-	// x + 0.044715 * x^3
-	inner, err := engine.Add(ctx, input, bx3)
-	if err != nil {
-		return nil, err
-	}
-
-	// u = sqrt(2/pi) * (x + 0.044715 * x^3)
-	u, err := engine.MulScalar(ctx, inner, ops.FromFloat64(math.Sqrt(2/math.Pi)))
-	if err != nil {
-		return nil, err
-	}
-
-	// tanh(u)
-	tanhU, err := engine.Tanh(ctx, u)
-	if err != nil {
-		return nil, err
-	}
-
-	// sech^2(u) = 1 - tanh^2(u): negate tanh^2 then add 1
-	tanhU2, err := engine.Mul(ctx, tanhU, tanhU)
-	if err != nil {
-		return nil, err
-	}
-	negTanhU2, err := engine.MulScalar(ctx, tanhU2, ops.FromFloat64(-1))
-	if err != nil {
-		return nil, err
-	}
-	sechSq, err := engine.AddScalar(ctx, negTanhU2, ops.One())
-	if err != nil {
-		return nil, err
-	}
-
-	// du/dx = sqrt(2/pi) * (1 + 3*0.044715*x^2)
-	dterm, err := engine.MulScalar(ctx, x2, ops.FromFloat64(3*0.044715))
-	if err != nil {
-		return nil, err
-	}
-	dterm, err = engine.AddScalar(ctx, dterm, ops.One())
-	if err != nil {
-		return nil, err
-	}
-	dudx, err := engine.MulScalar(ctx, dterm, ops.FromFloat64(math.Sqrt(2/math.Pi)))
-	if err != nil {
-		return nil, err
-	}
-
-	// 0.5 * (1 + tanh(u))
-	onePlusTanh, err := engine.AddScalar(ctx, tanhU, ops.One())
-	if err != nil {
-		return nil, err
-	}
-	halfOnePlusTanh, err := engine.MulScalar(ctx, onePlusTanh, ops.FromFloat64(0.5))
-	if err != nil {
-		return nil, err
-	}
-
-	// 0.5 * x * sech^2(u) * du/dx
-	xSechSq, err := engine.Mul(ctx, input, sechSq)
-	if err != nil {
-		return nil, err
-	}
-	xSechSqDudx, err := engine.Mul(ctx, xSechSq, dudx)
-	if err != nil {
-		return nil, err
-	}
-	halfXSechSqDudx, err := engine.MulScalar(ctx, xSechSqDudx, ops.FromFloat64(0.5))
-	if err != nil {
-		return nil, err
-	}
-
-	// derivative = 0.5*(1+tanh(u)) + 0.5*x*sech^2(u)*du/dx
-	derivative, err := engine.Add(ctx, halfOnePlusTanh, halfXSechSqDudx)
-	if err != nil {
-		return nil, err
-	}
-
-	// dInput = dOutput * derivative
-	return engine.Mul(ctx, dOutput, derivative)
+	return grads[0], nil
 }


### PR DESCRIPTION
## Summary
- Replace inline GELU forward, Sigmoid forward, and GELU backward math in `layers/functional` with thin delegations to the canonical `layers/activations.Gelu` and `layers/activations.Sigmoid` Nodes (T124.2.2).
- Public function signatures preserved; no caller changes required.
- Net deletion: ~131 LOC of duplicated activation math.
- ReLU, Softmax, SiLU left as-is (already wrappers; SiLU now transitively benefits via Sigmoid). CLIP quickGELU and SSM SiLU intentionally untouched per T124.2.1 audit.

## Verification
- `go build ./...` clean
- `go vet ./...` clean
- `go test ./layers/functional/... ./layers/activations/...` pass
- `go test ./tests/parity/...` pass

## Test plan
- [ ] CI green on all jobs
- [ ] Reviewer confirms math identity between deleted inline impls and canonical Node sources (gelu.go, sigmoid.go)

Plan: docs/plan.md T124.2.2 marked DONE.
Audit: docs/audits/T124.2.1-activations.md.