### PR TITLE
fix(activations): Softmax.Backward implements gradient (matches functional.SoftmaxBackward)

### DIFF
--- a/layers/activations/new_activations_test.go
+++ b/layers/activations/new_activations_test.go
@@ -85,12 +85,10 @@ func TestSoftmax_ForwardInputError(t *testing.T) {
 func TestSoftmax_Backward(t *testing.T) {
 	eng := makeEngine()
 	sm := NewSoftmax[float32](eng, -1)
-	grads, err := sm.Backward(context.Background(), types.FullBackprop, nil)
-	if err != nil {
-		t.Fatalf("Softmax.Backward failed: %v", err)
-	}
-	if grads != nil {
-		t.Error("expected nil grads from Softmax.Backward")
+	// Backward before Forward must error: there is no cached softmax output
+	// to differentiate against.
+	if _, err := sm.Backward(context.Background(), types.FullBackprop, nil); err == nil {
+		t.Error("expected error when Backward is called before Forward")
 	}
 }
 

--- a/layers/activations/softmax.go
+++ b/layers/activations/softmax.go
@@ -12,14 +12,19 @@ import (
 )
 
 // Softmax applies the softmax function along a given axis.
-type Softmax[T tensor.Numeric] struct {
+//
+// Softmax is constrained to floating-point element types: the operation is
+// only defined on real-valued inputs, and the backward pass requires the
+// arithmetic implied by tensor.Float.
+type Softmax[T tensor.Float] struct {
 	engine      compute.Engine[T]
 	axis        int
 	outputShape []int
+	output      *tensor.TensorNumeric[T] // cached softmax output for backward
 }
 
 // NewSoftmax creates a new Softmax activation layer.
-func NewSoftmax[T tensor.Numeric](engine compute.Engine[T], axis int) *Softmax[T] {
+func NewSoftmax[T tensor.Float](engine compute.Engine[T], axis int) *Softmax[T] {
 	return &Softmax[T]{engine: engine, axis: axis}
 }
 
@@ -28,13 +33,68 @@ func (s *Softmax[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeri
 	if len(inputs) != 1 {
 		return nil, fmt.Errorf("Softmax expects 1 input, got %d", len(inputs))
 	}
-	s.outputShape = inputs[0].Shape()
-	return s.engine.Softmax(ctx, inputs[0], s.axis)
+	out, err := s.engine.Softmax(ctx, inputs[0], s.axis)
+	if err != nil {
+		return nil, err
+	}
+	s.outputShape = out.Shape()
+	s.output = out
+	return out, nil
 }
 
-// Backward returns nil gradients (not required for inference).
-func (s *Softmax[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
-	return nil, nil
+// Backward computes the gradient of the softmax function.
+//
+// For each row along the configured axis:
+//
+//	dInput = softmaxOutput * (dOutput - sum(dOutput * softmaxOutput, axis, keepdims))
+//
+// The cached softmax output from the forward pass is reused so the gradient
+// works on both CPU and GPU without requiring a custom kernel. This is the
+// same math implemented by functional.SoftmaxBackward; the implementation is
+// inlined here rather than delegated because layers/functional already
+// imports layers/activations (the gelu/sigmoid wrappers), so a delegation
+// would introduce an import cycle. A unit test in this package asserts
+// numerical equivalence with functional.SoftmaxBackward to keep the two
+// implementations honest.
+func (s *Softmax[T]) Backward(ctx context.Context, _ types.BackwardMode, dOut *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	if s.output == nil {
+		return nil, fmt.Errorf("Softmax.Backward called before Forward")
+	}
+	if dOut == nil {
+		return nil, fmt.Errorf("Softmax.Backward: dOut tensor is nil")
+	}
+
+	y := s.output
+	shape := y.Shape()
+	axis := s.axis
+	if axis < 0 {
+		axis += len(shape)
+	}
+	if axis < 0 || axis >= len(shape) {
+		return nil, fmt.Errorf("Softmax.Backward: axis %d out of range for shape %v", s.axis, shape)
+	}
+
+	// prod = dOut * y (elementwise)
+	prod, err := s.engine.Mul(ctx, dOut, y)
+	if err != nil {
+		return nil, fmt.Errorf("Softmax.Backward: mul dOut*y: %w", err)
+	}
+	// dot = sum(prod, axis, keepDims=true)
+	dot, err := s.engine.ReduceSum(ctx, prod, axis, true)
+	if err != nil {
+		return nil, fmt.Errorf("Softmax.Backward: reduce sum: %w", err)
+	}
+	// diff = dOut - dot (broadcast over axis)
+	diff, err := s.engine.Sub(ctx, dOut, dot)
+	if err != nil {
+		return nil, fmt.Errorf("Softmax.Backward: sub dot: %w", err)
+	}
+	// dInput = y * diff
+	dInput, err := s.engine.Mul(ctx, y, diff)
+	if err != nil {
+		return nil, fmt.Errorf("Softmax.Backward: mul y*(dOut-dot): %w", err)
+	}
+	return []*tensor.TensorNumeric[T]{dInput}, nil
 }
 
 // OpType returns "Softmax".
@@ -53,7 +113,7 @@ func (s *Softmax[T]) Parameters() []*graph.Parameter[T] { return nil }
 
 // BuildSoftmax constructs a Softmax layer for the registry.
 // The optional "axis" attribute (int or int64) selects the softmax axis; defaults to -1.
-func BuildSoftmax[T tensor.Numeric](
+func BuildSoftmax[T tensor.Float](
 	engine compute.Engine[T],
 	_ numeric.Arithmetic[T],
 	_ string,

--- a/layers/activations/softmax_functional_equiv_test.go
+++ b/layers/activations/softmax_functional_equiv_test.go
@@ -1,0 +1,98 @@
+package activations_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/zerfoo/zerfoo/layers/activations"
+	"github.com/zerfoo/zerfoo/layers/functional"
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// TestSoftmaxBackward_MatchesFunctional asserts that the Softmax layer's
+// Backward produces the same gradient as functional.SoftmaxBackward when
+// fed the same softmax output and upstream gradient. The two
+// implementations live in separate packages (to avoid an import cycle),
+// so this test pins them to the same numerical contract.
+func TestSoftmaxBackward_MatchesFunctional(t *testing.T) {
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	ops := numeric.Float32Ops{}
+	ctx := context.Background()
+
+	cases := []struct {
+		name  string
+		shape []int
+		in    []float32
+		dOut  []float32
+	}{
+		{
+			name:  "1x3_simple",
+			shape: []int{1, 3},
+			in:    []float32{1, 2, 3},
+			dOut:  []float32{0.5, -0.25, 0.75},
+		},
+		{
+			name:  "2x4_mixed",
+			shape: []int{2, 4},
+			in:    []float32{-1, 0, 1, 2, 3, -2, 0.5, 1.5},
+			dOut:  []float32{1, 0, 0, 0, 0.1, 0.2, 0.3, 0.4},
+		},
+		{
+			name:  "3x2_negatives",
+			shape: []int{3, 2},
+			in:    []float32{-3, -1, 0, 0, 5, 10},
+			dOut:  []float32{0.1, -0.1, 0.2, -0.2, 0.3, -0.3},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input, err := tensor.New[float32](tc.shape, append([]float32(nil), tc.in...))
+			if err != nil {
+				t.Fatalf("input tensor: %v", err)
+			}
+			dOut, err := tensor.New[float32](tc.shape, append([]float32(nil), tc.dOut...))
+			if err != nil {
+				t.Fatalf("dOut tensor: %v", err)
+			}
+
+			// Layer path.
+			sm := activations.NewSoftmax[float32](engine, -1)
+			y, err := sm.Forward(ctx, input)
+			if err != nil {
+				t.Fatalf("Softmax.Forward: %v", err)
+			}
+			grads, err := sm.Backward(ctx, types.FullBackprop, dOut)
+			if err != nil {
+				t.Fatalf("Softmax.Backward: %v", err)
+			}
+			if len(grads) != 1 {
+				t.Fatalf("expected 1 gradient from layer, got %d", len(grads))
+			}
+			gotLayer := grads[0].Data()
+
+			// Functional path, fed the same softmax output.
+			ref, err := functional.SoftmaxBackward[float32](ctx, engine, ops, dOut, y)
+			if err != nil {
+				t.Fatalf("functional.SoftmaxBackward: %v", err)
+			}
+			gotFn := ref.Data()
+
+			if len(gotLayer) != len(gotFn) {
+				t.Fatalf("length mismatch: layer=%d functional=%d", len(gotLayer), len(gotFn))
+			}
+			const tol = 1e-6
+			for i := range gotLayer {
+				if math.Abs(float64(gotLayer[i]-gotFn[i])) > tol {
+					t.Errorf("dInput[%d]: layer=%v functional=%v (|delta|=%v > tol=%v)",
+						i, gotLayer[i], gotFn[i],
+						math.Abs(float64(gotLayer[i]-gotFn[i])), tol)
+				}
+			}
+		})
+	}
+}

--- a/layers/activations/softmax_test.go
+++ b/layers/activations/softmax_test.go
@@ -194,18 +194,75 @@ func TestSoftmaxForwardInputCountError(t *testing.T) {
 	}
 }
 
-func TestSoftmaxBackward(t *testing.T) {
+func TestSoftmaxBackwardErrors(t *testing.T) {
 	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
 	ctx := context.Background()
-	softmax := NewSoftmax(engine, -1)
 
-	// Backward returns nil (not implemented for inference-only layer)
-	grads, err := softmax.Backward(ctx, types.FullBackprop, nil)
+	// Backward before Forward must error.
+	softmax := NewSoftmax(engine, -1)
+	dOut := makeTensor(t, []int{1, 3}, []float32{0.1, 0.2, 0.3})
+	if _, err := softmax.Backward(ctx, types.FullBackprop, dOut); err == nil {
+		t.Errorf("expected error when Backward is called before Forward")
+	}
+
+	// nil dOut must error.
+	softmax2 := NewSoftmax(engine, -1)
+	in := makeTensor(t, []int{1, 3}, []float32{1, 2, 3})
+	if _, err := softmax2.Forward(ctx, in); err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if _, err := softmax2.Backward(ctx, types.FullBackprop, nil); err == nil {
+		t.Errorf("expected error for nil dOut")
+	}
+}
+
+// TestSoftmaxBackwardKnownValues verifies the analytical gradient for a
+// hand-computable case. For input x = [1, 2, 3] with softmax output
+// y = exp(x)/sum(exp(x)), and upstream gradient dOut = [1, 0, 0]:
+//
+//	dot     = sum(dOut * y) = y[0]
+//	dInput  = y * (dOut - dot)
+//	        = [y[0]*(1-y[0]), -y[0]*y[1], -y[0]*y[2]]
+//
+// which is the first row of the softmax Jacobian.
+func TestSoftmaxBackwardKnownValues(t *testing.T) {
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	ctx := context.Background()
+
+	softmax := NewSoftmax(engine, -1)
+	in := makeTensor(t, []int{1, 3}, []float32{1, 2, 3})
+	yT, err := softmax.Forward(ctx, in)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	y := yT.Data()
+
+	dOut := makeTensor(t, []int{1, 3}, []float32{1, 0, 0})
+	grads, err := softmax.Backward(ctx, types.FullBackprop, dOut)
 	if err != nil {
 		t.Fatalf("Backward: %v", err)
 	}
-	if grads != nil {
-		t.Errorf("expected nil gradients, got %v", grads)
+	if len(grads) != 1 {
+		t.Fatalf("expected 1 gradient, got %d", len(grads))
+	}
+
+	got := grads[0].Data()
+	want := []float32{y[0] * (1 - y[0]), -y[0] * y[1], -y[0] * y[2]}
+	for i := range want {
+		if math.Abs(float64(got[i]-want[i])) > 1e-6 {
+			t.Errorf("dInput[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+
+	// Sum of dInput along the softmax axis must be ~0 because
+	// sum_j d softmax_i / d x_j = 0 for each i, hence
+	// sum_j (sum_i dOut_i * J_ij) = sum_i dOut_i * sum_j J_ij = 0.
+	var s float32
+	for _, v := range got {
+		s += v
+	}
+	if math.Abs(float64(s)) > 1e-6 {
+		t.Errorf("sum(dInput) = %v, want ~0", s)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `activations.Softmax.Backward` previously returned `(nil, nil)`, causing `Graph.Backward` to panic for any consumer that needed a gradient (attention blocks, classifier heads).
- Tighten `Softmax[T]` to `tensor.Float` and implement Backward as `dInput = y * (dOut - sum(dOut * y, axis, keepdims))` — the same math as `functional.SoftmaxBackward`.
- The math is inlined rather than delegated because `layers/functional` already imports `layers/activations` (gelu/sigmoid wrappers); a direct delegation would create an import cycle.
- New external test `softmax_functional_equiv_test.go` asserts numerical equivalence with `functional.SoftmaxBackward` across three shape/sign cases.
- Replaced the old `TestSoftmaxBackward` (which only asserted nil) with `TestSoftmaxBackwardErrors` and `TestSoftmaxBackwardKnownValues` (hand-computed Jacobian row).

This unblocks Wolf removing its `softmaxNode` workaround in `internal/crossasset/module.go` (Wolf T9.12).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./layers/activations/... ./layers/functional/... -race`
- [x] `go test ./... -race -timeout 300s` (one pre-existing timing-sensitive benchmark in `timeseries` flakes under load; unrelated to this change — passes in isolation)