### PR TITLE
docs(attention): document FusedSDPA graph.Node (T3.1a follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,35 @@ trainer.Fit(ctx, trainX, trainY)
 predictions, _ := model.Predict(ctx, testX)
 ```
 
+### Fused SDPA graph node
+
+`layers/attention.FusedSDPA[T]` wraps the existing `ScaledDotProductAttention`
+as a `graph.Node[T]` so callers can compose fused scale + softmax + matmul
+attention inside autograd graphs without re-implementing the math:
+
+```go
+import (
+    "github.com/zerfoo/zerfoo/layers/attention"
+)
+
+// Causal (decoder) SDPA, head_dim=64.
+sdpa := attention.NewFusedSDPA[float32](engine, 64)
+
+// Bidirectional (encoder) SDPA with explicit Q/KV head counts.
+enc := attention.NewFusedSDPA[float32](engine, 64,
+    attention.WithFusedSDPABidirectional[float32](),
+    attention.WithFusedSDPAHeadCounts[float32](8, 8),
+)
+
+// Forward accepts (Q, K, V) or (Q, K, V, mask); Backward returns gradients
+// for [Q, K, V] (and a nil slot for mask when one was supplied).
+out, err := sdpa.Forward(ctx, q, k, v)
+```
+
+The node is numerically equivalent to the unfused
+`Q @ Kᵀ → scale → softmax → dropout → V` chain (fp32 ≤ 1e-5 fwd / 1e-5 bwd,
+fp64 ≤ 1e-12 fwd / 1e-10 bwd; see `layers/attention/fused_sdpa_node_test.go`).
+
 ## CLI
 
 ```bash


### PR DESCRIPTION
## Summary

Follow-up to PR #838 (T3.1a). The implementation and tests for the fused-SDPA `graph.Node` landed there but the README was not updated. This PR adds a short section to the Training section of the README so callers can find `attention.FusedSDPA` and see how to construct it via the options API.

Tracks Wolf's `docs/plan-pytorch-speed-parity.md` task T3.1a (final acceptance criterion: "Document the new node in zerfoo README/docs so callers can find it").

## Test plan

- [x] Markdown only -- no code changes, no test changes.
- [x] CI green.