### PR TITLE
fix(layernorm): run f32 backward in float64 on GPU too (gradient overflow)

### DIFF
--- a/layers/normalization/layer_normalization.go
+++ b/layers/normalization/layer_normalization.go
@@ -132,10 +132,14 @@ func NewLayerNormalizationFromParams[T tensor.Numeric](
 // when T is float32 or below AND the engine is a CPU engine. GPU engines
 // keep the current all-T path so their CUDA-native kernels remain in
 // charge of precision.
-func shouldUseMixedPrecisionBackward[T tensor.Numeric](engine compute.Engine[T]) bool {
-	if _, ok := engine.(*compute.CPUEngine[T]); !ok {
-		return false
-	}
+func shouldUseMixedPrecisionBackward[T tensor.Numeric](_ compute.Engine[T]) bool {
+	// Enabled for the low-precision float types on ALL engines (CPU and GPU).
+	// LayerNorm.Backward divides by the per-row stddev; in float32 an early-
+	// training gradient spike overflows (the GPU "CrossAsset cliff": gamma/beta
+	// grads -> ~1e12, cascading to ~1e34/NaN, while CPU's float64 backward
+	// absorbed it). Running the per-element backward in float64 fixes both.
+	// Previously gated to *compute.CPUEngine only, which left GPU float32
+	// LayerNorm backward overflowing to NaN.
 	var zero T
 	switch any(zero).(type) {
 	case float64:


### PR DESCRIPTION
## Problem
`LayerNorm.Backward` divides by the per-row stddev; in float32 an early-training gradient spike overflows. `shouldUseMixedPrecisionBackward` gated the float64 per-element backward to `*compute.CPUEngine` **only**, so on the **GPU** engine float32 LayerNorm backward ran in f32 and overflowed: gamma/beta grads reach ~1e12, cascading to ~1e34 / NaN in the FFN and attention weight grads — NaN at training step ~2. CPU float32 trained clean because its LayerNorm backward already ran in float64.

This is one cause of the GB10 f32 'CrossAsset cliff' (a Wolf/zerfoo model that NaNs on GPU but not CPU).

## Fix
Enable the float64 mixed-precision backward for the low-precision float types (float32/float16/bfloat16/float8) on **all** engines, not just CPU.

## Verified (GB10, f32)
With the fix, the LayerNorm/FFN/attention gradient magnitudes collapse from **1e12–1e34/NaN to O(0.4–20)** — the explosion is gone. CPU behavior is unchanged (it already used the f64 path); `layers/normalization` tests green.

## Note
This is necessary but, for that specific Wolf model, not the *only* GPU-f32 instability — a smaller residual NaN remains from a separate forward op (under investigation). Landing this regardless: it makes GPU float32 LayerNorm backward match the proven-stable CPU path and removes the dominant overflow.