### PR TITLE
fix(layernorm): recompute mean/variance from input in f64 backward (GPU arena cache corruption)

### DIFF
--- a/layers/normalization/layer_normalization.go
+++ b/layers/normalization/layer_normalization.go
@@ -418,9 +418,6 @@ func (ln *LayerNormalization[T]) backwardMixedCPU(dOut *tensor.TensorNumeric[T],
 
 	inputData := input.Data()
 	dOutData := dOut.Data()
-	meanData := ln.mean.Data()
-	varData := ln.variance.Data()
-	normedData := ln.normedInput.Data()
 	gammaData := ln.gamma.Value.Data()
 
 	dInputTensor, err := tensor.New[T](ln.inputShape, nil)
@@ -434,10 +431,30 @@ func (ln *LayerNormalization[T]) backwardMixedCPU(dOut *tensor.TensorNumeric[T],
 	nFeatF := float64(nFeat)
 
 	for p := 0; p < positions; p++ {
-		mu := lnNumericToFloat64(meanData[p])
-		sigma := math.Sqrt(lnNumericToFloat64(varData[p]) + epsilon)
-		sigma3 := sigma * sigma * sigma
 		base := p * nFeat
+
+		// Recompute mean and variance from the (reliable) forward input in
+		// float64 rather than trusting the cached ln.mean / ln.variance /
+		// ln.normedInput tensors. On the GPU arena those cached tensors can be
+		// overwritten by downstream forward ops before Backward runs -- the
+		// cached variance comes back negative, making sigma = sqrt(var+eps) NaN
+		// (the residual GPU f32 "CrossAsset cliff"; CPU's GC-kept tensors were
+		// immune, masking it). Recomputing here is self-contained and exact.
+		var mu float64
+		for i := 0; i < nFeat; i++ {
+			mu += lnNumericToFloat64(inputData[base+i])
+		}
+		mu /= nFeatF
+
+		var variance float64
+		for i := 0; i < nFeat; i++ {
+			d := lnNumericToFloat64(inputData[base+i]) - mu
+			variance += d * d
+		}
+		variance /= nFeatF
+
+		sigma := math.Sqrt(variance + epsilon)
+		sigma3 := sigma * sigma * sigma
 
 		var sumDNorm, sumDNormXMu float64
 		for i := 0; i < nFeat; i++ {
@@ -453,7 +470,7 @@ func (ln *LayerNormalization[T]) backwardMixedCPU(dOut *tensor.TensorNumeric[T],
 			gi := lnNumericToFloat64(gammaData[i])
 			dOutI := lnNumericToFloat64(dOutData[base+i])
 			xMinusMu := lnNumericToFloat64(inputData[base+i]) - mu
-			normed := lnNumericToFloat64(normedData[base+i])
+			normed := xMinusMu / sigma
 
 			dNorm := dOutI * gi
 			term1 := dNorm / sigma

--- a/layers/normalization/layer_normalization_recompute_backward_test.go
+++ b/layers/normalization/layer_normalization_recompute_backward_test.go
@@ -1,0 +1,102 @@
+package normalization
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// TestLayerNorm_MixedBackward_RecomputesStatsFromInput is the regression test
+// for the residual GPU f32 "CrossAsset cliff" (Wolf docs/plan-gpu-f32-residual,
+// S-GR.4.1). The mixed-precision (f64) backward must recompute mean/variance
+// from the forward input, NOT trust the cached ln.mean/ln.variance tensors:
+// on the GPU arena those caches get overwritten by downstream forward ops
+// before Backward runs, so the cached variance comes back negative and
+// sigma = sqrt(var+eps) becomes NaN.
+//
+// We simulate that corruption by clobbering the cached variance with garbage
+// (including a negative value) after Forward, then assert the backward still
+// produces finite gradients that match an uncorrupted reference.
+func TestLayerNorm_MixedBackward_RecomputesStatsFromInput(t *testing.T) {
+	engine := compute.NewCPUEngine[float32](&numeric.Float32Ops{})
+	ctx := context.Background()
+	const nFeat = 4
+
+	ln, err := NewLayerNormalization[float32](engine, nFeat)
+	if err != nil {
+		t.Fatalf("NewLayerNormalization: %v", err)
+	}
+	if !ln.useMixedBackward {
+		t.Fatal("expected useMixedBackward=true for float32 on CPU engine")
+	}
+
+	inputData := []float32{0.5, -1.2, 3.4, 40.0, 2.0, 2.0, 2.0, 2.1}
+	input, err := tensor.New[float32]([]int{2, nFeat}, inputData)
+	if err != nil {
+		t.Fatalf("tensor.New input: %v", err)
+	}
+	dOutData := []float32{0.1, -0.2, 0.3, -0.4, 0.05, 0.06, -0.07, 0.08}
+	dOut, err := tensor.New[float32]([]int{2, nFeat}, dOutData)
+	if err != nil {
+		t.Fatalf("tensor.New dOut: %v", err)
+	}
+
+	// Reference gradients from a clean forward+backward (uncorrupted cache).
+	if _, err := ln.Forward(ctx, input); err != nil {
+		t.Fatalf("Forward (reference): %v", err)
+	}
+	refGrads, err := ln.Backward(ctx, types.FullBackprop, dOut, input)
+	if err != nil {
+		t.Fatalf("Backward (reference): %v", err)
+	}
+	refData := append([]float32(nil), refGrads[0].Data()...)
+	for i, v := range refData {
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			t.Fatalf("reference gradient non-finite at %d: %v", i, v)
+		}
+	}
+
+	// Now corrupt the cached stats the way the GPU arena does: overwrite the
+	// cached variance with garbage that includes a negative value (which would
+	// make sigma = sqrt(var+eps) NaN if the backward trusted the cache).
+	if _, err := ln.Forward(ctx, input); err != nil {
+		t.Fatalf("Forward (corrupt case): %v", err)
+	}
+	varData := ln.variance.Data()
+	for i := range varData {
+		varData[i] = -7.5 // impossible for a real variance; sqrt(<0) = NaN
+	}
+	meanData := ln.mean.Data()
+	for i := range meanData {
+		meanData[i] = 999.0 // garbage mean
+	}
+	normedData := ln.normedInput.Data()
+	for i := range normedData {
+		normedData[i] = float32(math.NaN())
+	}
+
+	gotGrads, err := ln.Backward(ctx, types.FullBackprop, dOut, input)
+	if err != nil {
+		t.Fatalf("Backward (corrupt case): %v", err)
+	}
+	got := gotGrads[0].Data()
+
+	// The backward must ignore the corrupted cache and recompute from input:
+	// gradients stay finite and match the reference.
+	const tol = 1e-5
+	for i := range got {
+		if math.IsNaN(float64(got[i])) || math.IsInf(float64(got[i]), 0) {
+			t.Fatalf("gradient %d non-finite despite corrupted cache: %v "+
+				"(backward did not recompute stats from input)", i, got[i])
+		}
+		if d := math.Abs(float64(got[i] - refData[i])); d > tol {
+			t.Fatalf("gradient %d = %v, want %v (diff %g > tol): backward used "+
+				"the corrupted cache instead of recomputing", i, got[i], refData[i], d)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
On the GPU arena, the mixed-precision (f64) LayerNorm backward (`backwardMixedCPU`) read the **cached** forward stats (`ln.mean`/`ln.variance`/`ln.normedInput`). Those caches are not graph-refcounted, so the arena's free-list reuses their buffers for downstream forward ops before Backward runs. Traced on a GB10 CrossAsset f32 run: cached `variance = -0.42` (== mean; variance can't be negative) → `sigma = sqrt(var+eps) = NaN` → NaN gamma/beta/input gradients. This is the residual GPU f32 'CrossAsset cliff' (Wolf docs/plan-gpu-f32-residual). CPU's GC-kept tensors were immune, which masked it.

## Fix
Recompute mean and variance (and the normalized value) from the forward **input** — which is reliable in Backward — instead of trusting the volatile cache. Self-contained, numerically exact, no behavior change on CPU.

## Test
`TestLayerNorm_MixedBackward_RecomputesStatsFromInput` clobbers the cached variance (negative) + mean + normedInput after Forward and asserts the backward still returns finite gradients matching an uncorrupted reference. Fails on pre-fix code (sqrt(negative)=NaN); passes with the fix. Full `layers/normalization` suite green with -race.

## Status
One of two fixes for the GPU f32 cliff (the other is the fast-math `tanh` saturation fix in ztensor). Together they advance GB10 f32 training from a batch-0 NaN to batch-2; a third residual (gradient divergence) remains under investigation.