### PR TITLE
fix(adamw): keep f64 second moment on GPU f32 (CrossAsset cliff dominant cause)

### DIFF
--- a/training/optimizer/adamw.go
+++ b/training/optimizer/adamw.go
@@ -64,13 +64,21 @@ func NewAdamW[T tensor.Numeric](engine compute.Engine[T], learningRate, beta1, b
 }
 
 // shouldUseMixedPrecisionV returns true when AdamW should keep the
-// second-moment accumulator in float64 instead of T. True only when T is
-// float32 or below (float64 T doesn't need promotion) AND the engine is
-// a CPU engine. GPU engines preserve the current all-T path so their
-// CUDA-native kernels keep working; upgrading them to mixed precision
-// is a follow-up once a native GPU kernel exists for the division.
+// second-moment accumulator in float64 instead of T. True when T is float32
+// or below (float64 T doesn't need promotion) on a CPU or CUDA GPU engine.
+//
+// An all-T (f32) second moment is numerically unstable for GPU f32 training:
+// sqrt(v)+eps in the denominator loses precision when gradients span a wide
+// dynamic range, so m/sqrt(v) drifts the weights until they overflow to NaN a
+// few optimizer steps in -- the "CrossAsset cliff" GPU-only blow-up. The CPU
+// path has always used an f64 v and trains the same model cleanly, so GPU must
+// match. stepMixedV does the f64 update on host then writes param/m/grad back
+// to device storage (a no-op for host storage), so it is correct on the GB10
+// unified-memory engine and on discrete CUDA GPUs alike.
 func shouldUseMixedPrecisionV[T tensor.Numeric](engine compute.Engine[T]) bool {
-	if _, ok := engine.(*compute.CPUEngine[T]); !ok {
+	switch engine.(type) {
+	case *compute.CPUEngine[T], *compute.GPUEngine[T]:
+	default:
 		return false
 	}
 	var zero T
@@ -310,6 +318,15 @@ func (a *AdamW[T]) stepMixedV(_ context.Context, params []*graph.Parameter[T]) e
 
 			gradData[i] = zero
 		}
+
+		// Persist the host-side updates back to the parameter's storage. For
+		// CPU storage Data() returns the backing slice and this is a no-op
+		// reassignment; for GPU storage Data() returned a host copy, so the
+		// updated weights, first moment, and zeroed gradient must be copied
+		// back to the device (H2D) or the step would be silently discarded.
+		param.Value.GetStorage().Set(paramData)
+		m.GetStorage().Set(mData)
+		grad.GetStorage().Set(gradData)
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

GPU f32 AdamW training of the Wolf CrossAsset model blew up to NaN a few
optimizer steps in (the GPU-only \"CrossAsset cliff\"), while the **identical
model + data + seed trains cleanly on CPU** (acc 0.5260, even with gradient
clipping disabled).

Deep diagnosis (per-op forward + backward magnitude diffs, GPU vs CPU, seed=42):

- **Forward is bit-identical** GPU vs CPU at the first sample (ratio 1.000 for all 90 graph nodes).
- **Per-op backward amplification is identical** GPU vs CPU (e.g. attention Q@K^T node 6.30 vs 6.36; attn@V node 12.39 vs 12.01).
- So the divergence is **neither forward nor backward** — it emerges over **optimizer steps**.

Root cause: `shouldUseMixedPrecisionV` gated the mixed-precision **f64 second
moment** to CPU engines only. GPU f32 training therefore kept `v` (the AdamW
second moment) in **f32**. With a wide gradient dynamic range, the
`sqrt(v)+eps` denominator loses precision, so `m/sqrt(v)` drifts the weights
until they overflow to NaN. The CPU path has always used an f64 `v` and is
stable on the same model.

## Fix

Enable the f64-`v` path (`stepMixedV`) for CUDA GPU engines too. `stepMixedV`
does the f64 update on host; since `GPUStorage.Data()` returns a host **copy**
(not a coherent view), the updated `param`/`m`/`grad` are now written back to
storage via `Set()` — a no-op for CPU storage, the required H2D for GPU storage.

## Verification (live GB10, seed=42, folds=2 epochs=1, f32)

| run | result |
|---|---|
| before fix (f32 v) | NaN at **epoch 0, batch 2** |
| after fix (f64 v) | runs a **full epoch** (crash deferred from sample ~512 to ~9177) |

The fix removes the **dominant** instability (an ~18x deferral). A **residual**
GPU f32 numerical sensitivity remains, driven by a pathological non-stationary
input feature (cumulative OBV, post-normalization magnitude ~103) in the Wolf
dataset — tracked on the Wolf side, not a zerfoo optimizer issue.

Optimizer unit tests pass (`go test ./training/optimizer/`).