### PR TITLE
fix(adamw): zero gradient in-place, not via engine.Fill (arena-realloc corruption)

### DIFF
--- a/training/optimizer/adamw.go
+++ b/training/optimizer/adamw.go
@@ -348,13 +348,22 @@ func (a *AdamW[T]) stepMixedV(ctx context.Context, params []*graph.Parameter[T])
 		// mMixed/v64 and need no write-back.
 		param.Value.GetStorage().Set(paramData)
 
-		// Zero the gradient on-device rather than via an H2D write of a zero
-		// buffer. On CPU this is a cheap loop; on GPU it is a single Fill
-		// kernel and avoids one host->device transfer per parameter per step.
+		// Zero the gradient IN PLACE, preserving its storage buffer. Do NOT use
+		// engine.Fill here: on the GPU engine Fill reallocates the tensor's
+		// storage from the arena pool (gpuFill -> pool.Alloc + SetStorage), which
+		// moves param.Gradient INTO the arena. Callers that accumulate gradients
+		// across a batch and reset the arena per sample (e.g. Wolf crossasset)
+		// rely on the gradient living in a persistent, NON-arena buffer; an arena
+		// reset would then reclaim that buffer mid-accumulation and corrupt the
+		// next step's gradient -- a GPU-only, timing-sensitive NaN. Writing zeros
+		// back through the existing storage keeps the same buffer (a same-size
+		// Set is an in-place memcpy / H2D, not a realloc). gradData is the host
+		// copy already read above, so this reuses it.
 		var zero T
-		if err := a.engine.Fill(ctx, grad, zero); err != nil {
-			param.ClearGradient()
+		for i := range gradData {
+			gradData[i] = zero
 		}
+		grad.GetStorage().Set(gradData)
 	}
 
 	return nil


### PR DESCRIPTION
Follow-up to #844. `engine.Fill` on the GPU reallocates the tensor's storage from the arena pool (`gpuFill` -> `pool.Alloc` + `SetStorage`), moving `param.Gradient` INTO the arena. Wolf crossasset accumulates gradients across a batch and calls `ResetPool()` per sample on the documented invariant that gradients live in a persistent, NON-arena buffer (crossasset.go:633); the Fill-introduced arena buffer was then reclaimed mid-accumulation, corrupting the next step's gradient -> a GPU-only, timing-sensitive NaN.

Fix: zero the gradient in place through its existing storage (same-size `Set` = in-place copy, no realloc), preserving the buffer identity. Keeps the ADR-070 param-resident win; only re-adds a small zero write-back.

Note: this is a necessary correctness fix but is NOT sufficient to fully clean the GB10 f32 CrossAsset fold on its own -- a residual finite-forward / NaN-gradient instability in the input projections remains under investigation (tracked in docs/plan-pytorch-speed-parity.md T14.3). Optimizer tests green: `go test ./training/optimizer/`.

Separately, `gpuFill` reallocating from the arena pool instead of filling in place is a footgun worth a ztensor follow-up.