### PR TITLE
fix(training): persistent parameter-gradient accumulators -- arena tensors must not back Parameter.Gradient (#850)

### DIFF
--- a/training/grad_accum.go
+++ b/training/grad_accum.go
@@ -1,0 +1,281 @@
+// Package training: persistent parameter-gradient accumulators (issue #850).
+//
+// Layer Backward implementations assign engine-op results directly to the
+// persistent Parameter.Gradient field (e.g. layers/core/bias.go
+// `b.biases.Gradient = biasesGrad`). On the GPU engine those results are
+// ARENA-allocated tensors. Trainers that accumulate gradients across multiple
+// Backward calls while resetting the arena between samples (the Wolf
+// crossasset pattern: forward+backward per sample, ResetPool per sample,
+// optimizer step per batch) are then left with Parameter.Gradient pointing at
+// recycled arena memory: silent corruption normally, deterministic NaN under
+// ZTENSOR_ARENA_POISON=1. This is the fourth lifetime pattern of the
+// zerfoo#842 / zerfoo#845 / zerfoo/ztensor#128 bug class: a Backward-written
+// Parameter.Gradient read after arena reset.
+//
+// The fix is a single strategy-level hook, not N layer edits: after every
+// graph.Backward, each trainable parameter whose gradient is arena-backed has
+// that gradient accumulated into a parameter-owned PERSISTENT (non-arena)
+// buffer, and Parameter.Gradient is repointed at that buffer. Layers that
+// overwrite .Gradient next sample replace the pointer with a fresh arena
+// tensor; the hook then re-accumulates into the same persistent buffer.
+// Layers (and the optimizer, zerfoo#845) that write IN PLACE into the
+// existing .Gradient now correctly hit the persistent buffer and are skipped
+// by the hook via storage identity.
+//
+// Pinning via the ztensor Pin API (ADR 006) is deliberately NOT used here:
+// arena Reset has raise-the-floor semantics, so pinning the gradients would
+// retain every sample's activations below the pinned buffers, defeating the
+// per-sample reset and re-OOMing the arena (zerfoo/ztensor#118 history).
+package training
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// gradAccumulator maintains one persistent (non-arena) gradient buffer per
+// trainable parameter. It is embedded in the gradient strategies and lives as
+// long as the strategy, so the buffers persist across samples AND across
+// optimizer steps: the optimizer zeroes Parameter.Gradient in place after
+// Step (zerfoo#845 stepMixedV zeroes via storage Set), and the next batch
+// accumulates into the same, now-zeroed buffer.
+type gradAccumulator[T tensor.Numeric] struct {
+	// engine, when set (see DefaultBackpropStrategy.SetEngine), performs the
+	// accumulation as an in-place engine.Add with dst=accumulator -- on the
+	// GPU engine this is a device-side kernel writing into the accumulator's
+	// existing (non-pool) device pointer, with no host round-trip. When nil,
+	// a host read-modify-writeback fallback is used (Data() is a D2H copy on
+	// GPU storage and Set() an H2D copy), which is correct on both unified
+	// and discrete memory, just slower.
+	engine compute.Engine[T]
+
+	// accums maps each parameter to its persistent accumulator tensor.
+	accums map[*graph.Parameter[T]]*tensor.TensorNumeric[T]
+}
+
+// setEngine configures the optional engine used for in-place device-side
+// accumulation.
+func (a *gradAccumulator[T]) setEngine(e compute.Engine[T]) { a.engine = e }
+
+// capture is the post-Backward hook: for every trainable parameter of g
+// whose Gradient is arena-backed, accumulate the gradient into the
+// parameter's persistent buffer and repoint Parameter.Gradient at it.
+//
+// The hook is unconditional but cheap: parameters with nil gradients (not in
+// the active graph this step) and gradients whose storage is not arena-backed
+// (the entire CPU path) are skipped without any allocation, so CPU training
+// behavior is byte-identical to before.
+func (a *gradAccumulator[T]) capture(ctx context.Context, g *graph.Graph[T]) error {
+	for _, p := range g.Parameters() {
+		grad := p.Gradient
+		if grad == nil {
+			// First-batch / partial-graph path: the parameter received no
+			// gradient this step.
+			continue
+		}
+
+		accum := a.accums[p]
+		if accum != nil && storagesIdentical(accum, grad) {
+			// The layer (or optimizer) accumulated in place into the
+			// persistent buffer we installed earlier; nothing to migrate.
+			// This also makes the hook idempotent for parameters shared by
+			// multiple nodes (Graph.Parameters may yield duplicates).
+			continue
+		}
+
+		if !arenaBackedStorage(grad) {
+			// Non-arena storage (CPU engines, raw device allocations,
+			// bucketed pools) is never recycled behind a live reference;
+			// leave the gradient untouched.
+			continue
+		}
+
+		if accum == nil {
+			var err error
+			accum, err = newPersistentGradTensor[T](grad)
+			if err != nil {
+				return fmt.Errorf("training: allocating persistent gradient accumulator for %q: %w", p.Name, err)
+			}
+			if a.accums == nil {
+				a.accums = make(map[*graph.Parameter[T]]*tensor.TensorNumeric[T])
+			}
+			a.accums[p] = accum
+		}
+
+		if err := a.addInto(ctx, accum, grad, p.Name); err != nil {
+			return err
+		}
+
+		p.Gradient = accum
+	}
+
+	return nil
+}
+
+// storagesIdentical reports whether two tensors share the same storage
+// object (pointer identity through the Storage interface).
+func storagesIdentical[T tensor.Numeric](x, y *tensor.TensorNumeric[T]) bool {
+	return x.GetStorage() == y.GetStorage()
+}
+
+// arenaBackedStorage reports whether t's storage is backed by an arena pool
+// that can recycle the memory behind a live reference. It reuses the ADR 006
+// save-for-backward detection mechanism (zerfoo/ztensor#128): storage that
+// implements tensor.PinnableStorage AND whose backing pool actually takes a
+// pin is arena-backed. The probe pin is released immediately; it exists only
+// as a detection handshake, never as a retention mechanism (see the package
+// comment for why pinning gradients is rejected).
+func arenaBackedStorage[T tensor.Numeric](t *tensor.TensorNumeric[T]) bool {
+	p, ok := t.GetStorage().(tensor.PinnableStorage)
+	if !ok {
+		return false
+	}
+	if !p.PinForBackward() {
+		return false
+	}
+	p.UnpinForBackward()
+	return true
+}
+
+// newPersistentGradTensor allocates a zeroed accumulator with the same shape
+// as grad whose storage is guaranteed NOT to be arena-backed:
+//
+//   - For device gradients (*tensor.GPUStorage) it allocates a raw
+//     runtime.Malloc-backed GPUStorage (pool == nil) on the same device via
+//     tensor.NewGPUStorageFromSlice. A nil-pool GPUStorage is never touched
+//     by engine ResetPool, and a same-length storage Set/TrySet is an
+//     in-place copy (no realloc), so the device pointer is stable across the
+//     optimizer's in-place MulScalar / Set-zeroing (zerfoo#845).
+//   - For any other pinnable storage (host-backed arenas in tests) it
+//     allocates a plain GC-owned host tensor, which cannot be recycled
+//     behind a live reference.
+func newPersistentGradTensor[T tensor.Numeric](grad *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	shape := grad.Shape()
+	if gs, ok := grad.GetStorage().(*tensor.GPUStorage[T]); ok {
+		ps, err := tensor.NewGPUStorageFromSlice(make([]T, gs.Len()), gs.DeviceID())
+		if err != nil {
+			return nil, err
+		}
+		return tensor.NewWithStorage[T](shape, ps)
+	}
+	return tensor.New[T](shape, nil)
+}
+
+// addInto performs accum += grad without ever swapping accum's storage.
+func (a *gradAccumulator[T]) addInto(ctx context.Context, accum, grad *tensor.TensorNumeric[T], name string) error {
+	if accum.GetStorage().Len() != grad.GetStorage().Len() {
+		return fmt.Errorf("training: gradient accumulator for %q has %d elements but gradient has %d",
+			name, accum.GetStorage().Len(), grad.GetStorage().Len())
+	}
+
+	if a.engine != nil {
+		before := accum.GetStorage()
+		res, err := a.engine.Add(ctx, accum, grad, accum)
+		if err != nil {
+			return fmt.Errorf("training: accumulating gradient for %q: %w", name, err)
+		}
+		// The engine must write IN PLACE into the provided dst storage
+		// (ztensor#84 dst reuse). If it relocated the accumulator (e.g. a
+		// host dst handed to a GPU engine gets re-homed into the arena via
+		// SetStorage), the persistent buffer would silently become
+		// arena-backed -- the exact bug this hook exists to fix.
+		if res != accum || res.GetStorage() != before {
+			return fmt.Errorf("training: engine.Add relocated the persistent gradient accumulator for %q; the engine must write in place into dst", name)
+		}
+		return nil
+	}
+
+	// Host fallback: read-modify-writeback through the storage interface.
+	// Data() is the backing slice for host storage and a D2H copy for GPU
+	// storage; the writeback below makes the result land in the accumulator's
+	// existing buffer in both cases.
+	dst := accum.Data()
+	src := grad.Data()
+	if err := addSlice(dst, src); err != nil {
+		return fmt.Errorf("training: accumulating gradient for %q: %w", name, err)
+	}
+	if gs, ok := accum.GetStorage().(*tensor.GPUStorage[T]); ok {
+		if err := gs.TrySet(dst); err != nil {
+			return fmt.Errorf("training: writing back gradient accumulator for %q: %w", name, err)
+		}
+		return nil
+	}
+	accum.GetStorage().Set(dst)
+	return nil
+}
+
+// addSlice performs dst[i] += src[i] for the built-in numeric types.
+// Minifloat types (float16/bfloat16/float8) are not supported on this host
+// fallback path; configure an engine via SetEngine for those. In practice
+// they cannot reach here: arena-backed gradients only come from the GPU
+// engine, whose kernels are float32-gated.
+func addSlice[T tensor.Numeric](dst, src []T) error {
+	if len(dst) != len(src) {
+		return errors.New("length mismatch")
+	}
+	switch d := any(dst).(type) {
+	case []float32:
+		s := any(src).([]float32)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []float64:
+		s := any(src).([]float64)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []int:
+		s := any(src).([]int)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []int8:
+		s := any(src).([]int8)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []int16:
+		s := any(src).([]int16)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []int32:
+		s := any(src).([]int32)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []int64:
+		s := any(src).([]int64)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []uint:
+		s := any(src).([]uint)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []uint8:
+		s := any(src).([]uint8)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []uint32:
+		s := any(src).([]uint32)
+		for i := range d {
+			d[i] += s[i]
+		}
+	case []uint64:
+		s := any(src).([]uint64)
+		for i := range d {
+			d[i] += s[i]
+		}
+	default:
+		return errors.New("unsupported numeric type for host gradient accumulation; set an engine on the strategy")
+	}
+	return nil
+}

--- a/training/grad_accum_test.go
+++ b/training/grad_accum_test.go
@@ -1,0 +1,541 @@
+package training
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/device"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// ---------------------------------------------------------------------------
+// Issue #850 regression tests: Parameter.Gradient must not be backed by arena
+// memory across a per-sample arena reset (the Wolf crossasset schedule:
+// forward+backward per sample, ResetPool per sample, optimizer step per
+// batch). The harness below mirrors ztensor's host-backed cuda.ArenaPool
+// poison-test pattern (TestSaveForBackward_WolfHazard_*) without importing
+// ztensor internals: a bump allocator whose Reset fills unpinned spans with
+// NaN -- the ZTENSOR_ARENA_POISON=1 semantics that named this bug on the GB10.
+// ---------------------------------------------------------------------------
+
+// testArena is a host-backed bump allocator with poison-on-reset and
+// per-span pin refcounts.
+type testArena struct {
+	buf   []float32
+	off   int
+	spans []*arenaSpan
+}
+
+type arenaSpan struct {
+	start, n int
+	pins     int
+}
+
+func newTestArena(elems int) *testArena {
+	return &testArena{buf: make([]float32, elems)}
+}
+
+func (a *testArena) alloc(tb testing.TB, n int) *arenaSpan {
+	tb.Helper()
+	if a.off+n > len(a.buf) {
+		tb.Fatalf("testArena: out of memory (off=%d, n=%d, cap=%d)", a.off, n, len(a.buf))
+	}
+	s := &arenaSpan{start: a.off, n: n}
+	a.off += n
+	a.spans = append(a.spans, s)
+	return s
+}
+
+// Reset rewinds the arena and poisons every unpinned span with NaN
+// (ZTENSOR_ARENA_POISON semantics). Pinned spans raise the rewind floor,
+// matching the arena's raise-the-floor Reset.
+func (a *testArena) Reset() {
+	nan := float32(math.NaN())
+	floor := 0
+	kept := a.spans[:0]
+	for _, s := range a.spans {
+		if s.pins > 0 {
+			if end := s.start + s.n; end > floor {
+				floor = end
+			}
+			kept = append(kept, s)
+			continue
+		}
+		for i := s.start; i < s.start+s.n; i++ {
+			a.buf[i] = nan
+		}
+	}
+	a.spans = kept
+	a.off = floor
+}
+
+// arenaStorage backs a tensor with a testArena span, implementing
+// tensor.PinnableStorage exactly like ztensor's GPUStorage does for
+// arena-backed device memory -- this is what arenaBackedStorage detects.
+type arenaStorage struct {
+	a    *testArena
+	span *arenaSpan
+}
+
+func (s *arenaStorage) Len() int                { return s.span.n }
+func (s *arenaStorage) Slice() []float32        { return s.a.buf[s.span.start : s.span.start+s.span.n] }
+func (s *arenaStorage) Set(d []float32)         { copy(s.Slice(), d) }
+func (s *arenaStorage) DeviceType() device.Type { return device.CPU }
+func (s *arenaStorage) PinForBackward() bool    { s.span.pins++; return true }
+func (s *arenaStorage) UnpinForBackward() {
+	if s.span.pins > 0 {
+		s.span.pins--
+	}
+}
+
+var (
+	_ tensor.Storage[float32] = (*arenaStorage)(nil)
+	_ tensor.PinnableStorage  = (*arenaStorage)(nil)
+)
+
+// arenaBiasNode mirrors layers/core/bias.go's Backward: it OVERWRITES its
+// parameter's Gradient with a freshly engine-allocated tensor every call --
+// on the GPU engine that allocation comes from the arena, modeled here by
+// testArena. With useArena=false it allocates plain GC-owned host tensors
+// (the CPU engine behavior).
+type arenaBiasNode struct {
+	param        *graph.Parameter[float32]
+	extra        *graph.Parameter[float32] // a parameter that never receives a gradient
+	arena        *testArena
+	useArena     bool
+	tb           testing.TB
+	lastAssigned *tensor.TensorNumeric[float32]
+}
+
+func (n *arenaBiasNode) OpType() string                     { return "ArenaBias" }
+func (n *arenaBiasNode) Attributes() map[string]interface{} { return nil }
+func (n *arenaBiasNode) OutputShape() []int                 { return n.param.Value.Shape() }
+
+func (n *arenaBiasNode) Parameters() []*graph.Parameter[float32] {
+	ps := []*graph.Parameter[float32]{n.param}
+	if n.extra != nil {
+		ps = append(ps, n.extra)
+	}
+	return ps
+}
+
+func (n *arenaBiasNode) Forward(_ context.Context, inputs ...*tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error) {
+	return inputs[0], nil
+}
+
+func (n *arenaBiasNode) Backward(_ context.Context, _ types.BackwardMode, outputGradient *tensor.TensorNumeric[float32], _ ...*tensor.TensorNumeric[float32]) ([]*tensor.TensorNumeric[float32], error) {
+	gradVals := outputGradient.Data()
+
+	var g *tensor.TensorNumeric[float32]
+	if n.useArena {
+		span := n.arena.alloc(n.tb, len(gradVals))
+		st := &arenaStorage{a: n.arena, span: span}
+		var err error
+		g, err = tensor.NewWithStorage([]int{len(gradVals)}, tensor.Storage[float32](st))
+		if err != nil {
+			return nil, err
+		}
+		copy(st.Slice(), gradVals)
+	} else {
+		var err error
+		g, err = tensor.New([]int{len(gradVals)}, append([]float32(nil), gradVals...))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// The bug under test: layers assign the engine-op result (an arena
+	// tensor on GPU) directly to the persistent Parameter.Gradient field.
+	n.param.Gradient = g
+	n.lastAssigned = g
+
+	return []*tensor.TensorNumeric[float32]{outputGradient}, nil
+}
+
+// passthroughLoss returns a scalar loss and propagates the targets tensor as
+// the initial gradient, so tests control per-sample gradients exactly.
+type passthroughLoss struct{}
+
+func (l *passthroughLoss) OpType() string                          { return "PassthroughLoss" }
+func (l *passthroughLoss) Attributes() map[string]interface{}      { return nil }
+func (l *passthroughLoss) OutputShape() []int                      { return []int{1} }
+func (l *passthroughLoss) Parameters() []*graph.Parameter[float32] { return nil }
+
+func (l *passthroughLoss) Forward(_ context.Context, _ ...*tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error) {
+	return tensor.New([]int{1}, []float32{0})
+}
+
+func (l *passthroughLoss) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[float32], inputs ...*tensor.TensorNumeric[float32]) ([]*tensor.TensorNumeric[float32], error) {
+	// inputs are (modelOutput, targets); the targets tensor is the gradient.
+	return []*tensor.TensorNumeric[float32]{inputs[1]}, nil
+}
+
+// wolfHazardFixture builds a 1-node graph around an arenaBiasNode.
+func wolfHazardFixture(t *testing.T, useArena bool, arena *testArena) (*graph.Graph[float32], graph.Node[float32], *arenaBiasNode) {
+	t.Helper()
+
+	value, err := tensor.New([]int{2}, []float32{0, 0})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	param, err := graph.NewParameter("bias", value, tensor.New[float32])
+	if err != nil {
+		t.Fatalf("NewParameter: %v", err)
+	}
+
+	extraValue, err := tensor.New([]int{2}, []float32{0, 0})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	extra, err := graph.NewParameter("never_used", extraValue, tensor.New[float32])
+	if err != nil {
+		t.Fatalf("NewParameter: %v", err)
+	}
+	// A parameter the active graph never writes: the hook must tolerate a
+	// nil gradient.
+	extra.Gradient = nil
+
+	node := &arenaBiasNode{param: param, extra: extra, arena: arena, useArena: useArena, tb: t}
+
+	b := graph.NewBuilder[float32](nil)
+	in := b.Input([]int{2})
+	b.AddNode(node, in)
+	g, err := b.Build(node)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return g, in, node
+}
+
+// runWolfHazardSchedule runs the Wolf crossasset schedule: per sample, one
+// forward+backward through the strategy followed by an arena Reset; targets
+// for sample k are [k+1, 10*(k+1)].
+func runWolfHazardSchedule(t *testing.T, strategy GradientStrategy[float32], g *graph.Graph[float32], in graph.Node[float32], arena *testArena, samples int) {
+	t.Helper()
+	ctx := context.Background()
+	loss := &passthroughLoss{}
+
+	for k := 0; k < samples; k++ {
+		input, err := tensor.New([]int{2}, []float32{1, 1})
+		if err != nil {
+			t.Fatalf("tensor.New: %v", err)
+		}
+		targets, err := tensor.New([]int{2}, []float32{float32(k + 1), float32(10 * (k + 1))})
+		if err != nil {
+			t.Fatalf("tensor.New: %v", err)
+		}
+		batch := Batch[float32]{
+			Inputs:  map[graph.Node[float32]]*tensor.TensorNumeric[float32]{in: input},
+			Targets: targets,
+		}
+		if _, err := strategy.ComputeGradients(ctx, g, loss, batch); err != nil {
+			t.Fatalf("ComputeGradients (sample %d): %v", k, err)
+		}
+		// Wolf's per-sample ResetPool: recycle (and poison) the arena.
+		arena.Reset()
+	}
+}
+
+// analytic sum of per-sample grads for runWolfHazardSchedule with 3 samples:
+// [1+2+3, 10+20+30] = [6, 60].
+var wantSum3 = []float32{6, 60}
+
+// TestPersistentGradAccum_WolfHazard_Fixed: WITH the hook, the accumulated
+// gradient survives per-sample arena resets and equals the analytic sum of
+// per-sample gradients.
+func TestPersistentGradAccum_WolfHazard_Fixed(t *testing.T) {
+	arena := newTestArena(1024)
+	g, in, node := wolfHazardFixture(t, true, arena)
+	strategy := NewDefaultBackpropStrategy[float32]()
+
+	runWolfHazardSchedule(t, strategy, g, in, arena, 3)
+
+	got := node.param.Gradient.Data()
+	for i, v := range got {
+		if math.IsNaN(float64(v)) {
+			t.Fatalf("param.Gradient[%d] = NaN: accumulated gradient was poisoned by arena reset", i)
+		}
+		if v != wantSum3[i] {
+			t.Fatalf("param.Gradient[%d] = %v, want %v (analytic sum of per-sample grads)", i, v, wantSum3[i])
+		}
+	}
+
+	// The gradient now lives in the persistent accumulator, not the arena.
+	if node.param.Gradient == node.lastAssigned {
+		t.Fatal("param.Gradient still points at the layer-assigned arena tensor")
+	}
+	if arenaBackedStorage(node.param.Gradient) {
+		t.Fatal("param.Gradient is still arena-backed after the hook")
+	}
+	// The nil-gradient parameter was tolerated and left untouched.
+	if node.extra.Gradient != nil {
+		t.Fatalf("nil-gradient parameter was modified: %v", node.extra.Gradient)
+	}
+	// Exactly one accumulator was allocated.
+	if len(strategy.grads.accums) != 1 {
+		t.Fatalf("len(accums) = %d, want 1", len(strategy.grads.accums))
+	}
+}
+
+// TestPersistentGradAccum_WolfHazard_WithoutHookPoisoned asserts the OLD
+// behavior is detectable: without the hook, the same schedule leaves
+// Parameter.Gradient pointing at poisoned (NaN) arena memory. This is the
+// exact failure ZTENSOR_ARENA_POISON named on the GB10 (issue #850).
+func TestPersistentGradAccum_WolfHazard_WithoutHookPoisoned(t *testing.T) {
+	arena := newTestArena(1024)
+	g, in, node := wolfHazardFixture(t, true, arena)
+
+	// noHookStrategy reproduces pre-fix behavior: computeGradientsCommon
+	// with a nil accumulator.
+	ctx := context.Background()
+	loss := &passthroughLoss{}
+	for k := 0; k < 3; k++ {
+		input, _ := tensor.New([]int{2}, []float32{1, 1})
+		targets, _ := tensor.New([]int{2}, []float32{float32(k + 1), float32(10 * (k + 1))})
+		batch := Batch[float32]{
+			Inputs:  map[graph.Node[float32]]*tensor.TensorNumeric[float32]{in: input},
+			Targets: targets,
+		}
+		if _, err := computeGradientsCommon[float32](ctx, g, loss, batch, types.FullBackprop, nil); err != nil {
+			t.Fatalf("computeGradientsCommon (sample %d): %v", k, err)
+		}
+		arena.Reset()
+	}
+
+	got := node.param.Gradient.Data()
+	for i, v := range got {
+		if !math.IsNaN(float64(v)) {
+			t.Fatalf("param.Gradient[%d] = %v, want NaN: without the hook the gradient must read poisoned arena memory", i, v)
+		}
+	}
+}
+
+// TestPersistentGradAccum_WithEngine: the engine fast path (in-place
+// engine.Add with dst=accumulator) produces the same analytic sum and never
+// swaps the accumulator's storage.
+func TestPersistentGradAccum_WithEngine(t *testing.T) {
+	arena := newTestArena(1024)
+	g, in, node := wolfHazardFixture(t, true, arena)
+	strategy := NewDefaultBackpropStrategy[float32]()
+	strategy.SetEngine(compute.NewCPUEngine[float32](numeric.Float32Ops{}))
+
+	runWolfHazardSchedule(t, strategy, g, in, arena, 3)
+
+	got := node.param.Gradient.Data()
+	for i, v := range got {
+		if v != wantSum3[i] {
+			t.Fatalf("param.Gradient[%d] = %v, want %v", i, v, wantSum3[i])
+		}
+	}
+	accum := strategy.grads.accums[node.param]
+	if accum == nil {
+		t.Fatal("no accumulator allocated")
+	}
+	if node.param.Gradient != accum {
+		t.Fatal("param.Gradient does not point at the persistent accumulator")
+	}
+}
+
+// TestEngineAdd_PreservesAccumulatorStorageIdentity: engine.Add with
+// dst=accumulator must write IN PLACE into the provided dst storage and not
+// swap it -- the property the hook's fast path depends on.
+func TestEngineAdd_PreservesAccumulatorStorageIdentity(t *testing.T) {
+	ctx := context.Background()
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	accum, err := tensor.New([]int{3}, []float32{1, 2, 3})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	grad, err := tensor.New([]int{3}, []float32{10, 20, 30})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+
+	before := accum.GetStorage()
+	res, err := engine.Add(ctx, accum, grad, accum)
+	if err != nil {
+		t.Fatalf("engine.Add: %v", err)
+	}
+	if res != accum {
+		t.Fatal("engine.Add returned a different tensor than dst")
+	}
+	if res.GetStorage() != before {
+		t.Fatal("engine.Add swapped dst's storage; accumulation requires in-place writes")
+	}
+	want := []float32{11, 22, 33}
+	for i, v := range res.Data() {
+		if v != want[i] {
+			t.Fatalf("res[%d] = %v, want %v", i, v, want[i])
+		}
+	}
+
+	// Same property through the hook's addInto.
+	acc := &gradAccumulator[float32]{engine: engine}
+	if err := acc.addInto(ctx, accum, grad, "p"); err != nil {
+		t.Fatalf("addInto: %v", err)
+	}
+	if accum.GetStorage() != before {
+		t.Fatal("addInto swapped the accumulator's storage")
+	}
+	want = []float32{21, 42, 63}
+	for i, v := range accum.Data() {
+		if v != want[i] {
+			t.Fatalf("accum[%d] = %v, want %v", i, v, want[i])
+		}
+	}
+}
+
+// TestPersistentGradAccum_CPUNoOp: on a pure CPU path (no arena-backed
+// storage anywhere) the hook is a no-op -- no accumulator is allocated and
+// Parameter.Gradient is exactly the tensor the layer assigned, preserving
+// pre-fix CPU semantics byte for byte.
+func TestPersistentGradAccum_CPUNoOp(t *testing.T) {
+	g, in, node := wolfHazardFixture(t, false, nil)
+	strategy := NewDefaultBackpropStrategy[float32]()
+
+	ctx := context.Background()
+	loss := &passthroughLoss{}
+	for k := 0; k < 2; k++ {
+		input, _ := tensor.New([]int{2}, []float32{1, 1})
+		targets, _ := tensor.New([]int{2}, []float32{float32(k + 1), float32(10 * (k + 1))})
+		batch := Batch[float32]{
+			Inputs:  map[graph.Node[float32]]*tensor.TensorNumeric[float32]{in: input},
+			Targets: targets,
+		}
+		if _, err := strategy.ComputeGradients(ctx, g, loss, batch); err != nil {
+			t.Fatalf("ComputeGradients (sample %d): %v", k, err)
+		}
+	}
+
+	if len(strategy.grads.accums) != 0 {
+		t.Fatalf("len(accums) = %d, want 0: CPU gradients must not allocate accumulators", len(strategy.grads.accums))
+	}
+	if node.param.Gradient != node.lastAssigned {
+		t.Fatal("param.Gradient was repointed on the CPU path; hook must be a no-op")
+	}
+	// CPU overwrite semantics preserved: last sample's gradient, not a sum.
+	want := []float32{2, 20}
+	for i, v := range node.param.Gradient.Data() {
+		if v != want[i] {
+			t.Fatalf("param.Gradient[%d] = %v, want %v (unchanged CPU overwrite semantics)", i, v, want[i])
+		}
+	}
+}
+
+// TestPersistentGradAccum_OptimizerZeroReuse: the optimizer zeroes
+// Parameter.Gradient in place after Step (zerfoo#845 stepMixedV zeroes via
+// storage Set). The hook must reuse the SAME persistent buffer for the next
+// batch, and the next batch's accumulated value must not include the
+// previous batch.
+func TestPersistentGradAccum_OptimizerZeroReuse(t *testing.T) {
+	arena := newTestArena(4096)
+	g, in, node := wolfHazardFixture(t, true, arena)
+	strategy := NewDefaultBackpropStrategy[float32]()
+
+	// Batch 1: 3 samples.
+	runWolfHazardSchedule(t, strategy, g, in, arena, 3)
+
+	accum := node.param.Gradient
+	storageBefore := accum.GetStorage()
+
+	// Optimizer end-of-batch: zero the gradient IN PLACE via storage Set
+	// (the zerfoo#845 contract).
+	zeroed := accum.Data()
+	for i := range zeroed {
+		zeroed[i] = 0
+	}
+	accum.GetStorage().Set(zeroed)
+
+	// Batch 2: same 3-sample schedule.
+	runWolfHazardSchedule(t, strategy, g, in, arena, 3)
+
+	if node.param.Gradient != accum {
+		t.Fatal("hook allocated a new accumulator instead of reusing the zeroed persistent buffer")
+	}
+	if node.param.Gradient.GetStorage() != storageBefore {
+		t.Fatal("accumulator storage changed across batches")
+	}
+	for i, v := range node.param.Gradient.Data() {
+		if v != wantSum3[i] {
+			t.Fatalf("batch-2 param.Gradient[%d] = %v, want %v (zeroed accumulator must restart the sum)", i, v, wantSum3[i])
+		}
+	}
+}
+
+// TestPersistentGradAccum_InPlaceLayerSkipped: a layer (or optimizer) that
+// writes in place into the persistent buffer the hook installed must not be
+// double-counted: the hook skips when Parameter.Gradient already IS the
+// accumulator.
+func TestPersistentGradAccum_InPlaceLayerSkipped(t *testing.T) {
+	ctx := context.Background()
+	acc := &gradAccumulator[float32]{}
+
+	arena := newTestArena(64)
+	span := arena.alloc(t, 2)
+	st := &arenaStorage{a: arena, span: span}
+	gradT, err := tensor.NewWithStorage([]int{2}, tensor.Storage[float32](st))
+	if err != nil {
+		t.Fatalf("NewWithStorage: %v", err)
+	}
+	copy(st.Slice(), []float32{3, 4})
+
+	value, _ := tensor.New([]int{2}, []float32{0, 0})
+	p, err := graph.NewParameter("w", value, tensor.New[float32])
+	if err != nil {
+		t.Fatalf("NewParameter: %v", err)
+	}
+	p.Gradient = gradT
+
+	node := &arenaBiasNode{param: p}
+	b := graph.NewBuilder[float32](nil)
+	in := b.Input([]int{2})
+	b.AddNode(node, in)
+	g, err := b.Build(node)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// First capture: migrates the arena gradient into a fresh accumulator.
+	if err := acc.capture(ctx, g); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	accum := acc.accums[p]
+	if accum == nil || p.Gradient != accum {
+		t.Fatal("first capture did not install the accumulator")
+	}
+
+	// An in-place writer (AddGradient-style layer, optimizer clip with dst)
+	// mutates the accumulator directly; p.Gradient still IS the accumulator.
+	if err := p.AddGradient(mustNewTensor(t, []float32{1, 1})); err != nil {
+		t.Fatalf("AddGradient: %v", err)
+	}
+
+	// Second capture must not double-count or reallocate.
+	if err := acc.capture(ctx, g); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if p.Gradient != accum {
+		t.Fatal("second capture replaced the accumulator")
+	}
+	want := []float32{4, 5}
+	for i, v := range p.Gradient.Data() {
+		if v != want[i] {
+			t.Fatalf("p.Gradient[%d] = %v, want %v (in-place writes must not be re-accumulated)", i, v, want[i])
+		}
+	}
+}
+
+func mustNewTensor(t *testing.T, data []float32) *tensor.TensorNumeric[float32] {
+	t.Helper()
+	tt, err := tensor.New([]int{len(data)}, data)
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	return tt
+}

--- a/training/strategy_backprop.go
+++ b/training/strategy_backprop.go
@@ -4,6 +4,7 @@ package training
 import (
 	"context"
 
+	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
 	"github.com/zerfoo/ztensor/types"
@@ -11,11 +12,30 @@ import (
 
 // DefaultBackpropStrategy performs standard backpropagation through the loss
 // and model graph.
-type DefaultBackpropStrategy[T tensor.Numeric] struct{}
+//
+// The strategy maintains persistent (non-arena) gradient accumulators per
+// parameter (issue #850): after each Backward, any arena-backed
+// Parameter.Gradient is accumulated into a parameter-owned persistent buffer
+// and Parameter.Gradient is repointed at it, so per-sample engine ResetPool
+// calls (the Wolf crossasset pattern) cannot corrupt accumulated gradients.
+// The accumulators live as long as the strategy: reuse one strategy instance
+// across all samples and batches of a training run.
+type DefaultBackpropStrategy[T tensor.Numeric] struct {
+	grads gradAccumulator[T]
+}
 
 // NewDefaultBackpropStrategy constructs a DefaultBackpropStrategy.
 func NewDefaultBackpropStrategy[T tensor.Numeric]() *DefaultBackpropStrategy[T] {
 	return &DefaultBackpropStrategy[T]{}
+}
+
+// SetEngine configures an optional compute engine used to perform the
+// persistent gradient accumulation as an in-place engine.Add with
+// dst=accumulator (device-side, no host round-trip). Without an engine a
+// host read-modify-writeback fallback is used, which is correct but slower
+// for device gradients.
+func (s *DefaultBackpropStrategy[T]) SetEngine(e compute.Engine[T]) {
+	s.grads.setEngine(e)
 }
 
 // ComputeGradients runs forward pass, computes loss, runs backward passes,
@@ -26,7 +46,7 @@ func (s *DefaultBackpropStrategy[T]) ComputeGradients(
 	loss graph.Node[T],
 	batch Batch[T],
 ) (T, error) {
-	return computeGradientsCommon[T](ctx, g, loss, batch, types.FullBackprop)
+	return computeGradientsCommon[T](ctx, g, loss, batch, types.FullBackprop, &s.grads)
 }
 
 // Statically assert that the type implements the GradientStrategy interface.

--- a/training/strategy_common.go
+++ b/training/strategy_common.go
@@ -10,12 +10,19 @@ import (
 )
 
 // computeGradientsCommon consolidates the shared logic between training strategies.
+//
+// acc, when non-nil, is the persistent parameter-gradient accumulator hook
+// (issue #850): after Backward, arena-backed Parameter.Gradient tensors are
+// accumulated into persistent buffers so a subsequent engine ResetPool (the
+// Wolf per-sample reset pattern) cannot recycle the memory the optimizer and
+// cross-sample accumulation will read.
 func computeGradientsCommon[T tensor.Numeric](
 	ctx context.Context,
 	g *graph.Graph[T],
 	loss graph.Node[T],
 	batch Batch[T],
 	mode types.BackwardMode,
+	acc *gradAccumulator[T],
 ) (T, error) {
 	var zero T
 	// Materialize inputs in graph input order
@@ -45,6 +52,14 @@ func computeGradientsCommon[T tensor.Numeric](
 	// Model backward
 	if err := g.Backward(ctx, mode, lossGrads[0]); err != nil {
 		return zero, fmt.Errorf("model backward pass failed: %w", err)
+	}
+
+	// Migrate arena-backed parameter gradients to persistent buffers BEFORE
+	// any tensor release / arena reset can recycle them (issue #850).
+	if acc != nil {
+		if err := acc.capture(ctx, g); err != nil {
+			return zero, fmt.Errorf("persistent gradient accumulation failed: %w", err)
+		}
 	}
 
 	lossVal := lossTensor.Data()[0]

--- a/training/strategy_one_step.go
+++ b/training/strategy_one_step.go
@@ -4,6 +4,7 @@ package training
 import (
 	"context"
 
+	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
 	"github.com/zerfoo/ztensor/types"
@@ -11,11 +12,24 @@ import (
 
 // OneStepApproximationStrategy performs a one-step gradient approximation.
 // It is designed for training recurrent models without full BPTT.
-type OneStepApproximationStrategy[T tensor.Numeric] struct{}
+//
+// Like DefaultBackpropStrategy, it maintains persistent (non-arena) gradient
+// accumulators per parameter (issue #850); reuse one strategy instance across
+// all samples and batches of a training run.
+type OneStepApproximationStrategy[T tensor.Numeric] struct {
+	grads gradAccumulator[T]
+}
 
 // NewOneStepApproximationStrategy constructs a OneStepApproximationStrategy.
 func NewOneStepApproximationStrategy[T tensor.Numeric]() *OneStepApproximationStrategy[T] {
 	return &OneStepApproximationStrategy[T]{}
+}
+
+// SetEngine configures an optional compute engine used to perform the
+// persistent gradient accumulation as an in-place engine.Add with
+// dst=accumulator. See DefaultBackpropStrategy.SetEngine.
+func (s *OneStepApproximationStrategy[T]) SetEngine(e compute.Engine[T]) {
+	s.grads.setEngine(e)
 }
 
 // ComputeGradients performs a forward pass and a one-step backward pass.
@@ -25,7 +39,7 @@ func (s *OneStepApproximationStrategy[T]) ComputeGradients(
 	loss graph.Node[T],
 	batch Batch[T],
 ) (T, error) {
-	return computeGradientsCommon[T](ctx, g, loss, batch, types.OneStepApproximation)
+	return computeGradientsCommon[T](ctx, g, loss, batch, types.OneStepApproximation, &s.grads)
 }
 
 // Ensure OneStepApproximationStrategy implements the GradientStrategy interface.


### PR DESCRIPTION
Fixes #850. Refs #847, zerfoo/ztensor#128, ztensor ADR 006, `docs/plan-gpu-training-hardening.md` E2.

## The bug

`ZTENSOR_ARENA_POISON=1` on the GB10 named the ninth Wolf GPU-f32 bug: layer `Backward` implementations assign engine-op results -- which on the GPU engine are **arena-allocated** tensors -- directly to the persistent `Parameter.Gradient` field (e.g. `layers/core/bias.go:128` `b.biases.Gradient = biasesGrad`, an `engine.Sum` result; a dozen+ similar sites across `layers/`). Trainers that accumulate gradients across multiple `Backward` calls while resetting the arena between samples (the Wolf crossasset schedule: forward+backward per sample, `ResetPool` per sample, optimizer step per batch) are then left with `Parameter.Gradient` pointing at recycled arena memory: silent corruption normally, deterministic NaN at the op under poison. `ffnB1_biases` (a Bias param) is exactly the parameter that has been failing through nine investigations.

This is the fourth lifetime pattern of the #842 / #845 / ztensor#128 bug class: **Backward-written `Parameter.Gradient` read after arena reset** (by cross-sample accumulation and by the optimizer).

## The fix: one strategy-level hook, not N layer edits

**Hook location:** `training/grad_accum.go` (`gradAccumulator.capture`), invoked from `training/strategy_common.go` `computeGradientsCommon` immediately after `graph.Backward` succeeds and **before** `ClearMemo`. Both `DefaultBackpropStrategy` and `OneStepApproximationStrategy` (the path Wolf reaches via `strategy.ComputeGradients` / `ComputeGradientsFromBatch` / `DefaultTrainer.TrainStep`) embed one `gradAccumulator` that lives as long as the strategy.

After every Backward, for each trainable parameter of the graph:

1. **Skip** nil gradients (params not in the active graph), and skip when `Parameter.Gradient` already shares storage with the persistent accumulator (in-place writers: `AddGradient`-style layers, the optimizer's in-place clip).
2. **Detect arena-backed storage** by reusing the ADR 006 / ztensor#132 mechanism exactly: type-assert `tensor.PinnableStorage` and probe `PinForBackward()` (true iff the backing pool is an arena that supports backward pinning), releasing the probe pin immediately. Non-arena storage (the entire CPU path, raw device allocations, bucketed pools) makes the hook a strict no-op -- asserted by tests.
3. **Lazily allocate a parameter-owned persistent accumulator** of the same shape (zeroed).
4. **Accumulate** `accumulator += Parameter.Gradient`.
5. **Repoint** `Parameter.Gradient = accumulator`. Layers that overwrite `.Gradient` next sample replace the pointer with a fresh arena tensor; the hook then re-accumulates into the same persistent buffer.

## Persistent-allocation mechanism

For device gradients (`*tensor.GPUStorage[T]`) the accumulator is a **raw `runtime.Malloc`-backed `GPUStorage` (`pool == nil`)** allocated via `tensor.NewGPUStorageFromSlice(make([]T, n), deviceID)` -- never touched by engine `ResetPool`, and a same-length storage `Set`/`TrySet` is an in-place copy (no realloc), so the device pointer stays stable across the optimizer's in-place `MulScalar` clip and `Set`-zeroing (#845 `stepMixedV`). For any other pinnable storage (host-backed arenas in tests) it is a plain GC-owned host tensor. A host accumulator was deliberately **not** used for device gradients: GPU engine ops with a non-`GPUStorage` dst re-home the dst into the arena via `makeGPUResult`/`SetStorage`, which would silently make the "persistent" buffer arena-backed again.

**Accumulation mechanism:** when the strategy is given an engine (new `SetEngine` on both strategies), accumulation is an in-place `engine.Add(ctx, accum, grad, accum)` -- the ztensor#84 dst-reuse path writes the kernel output directly into the accumulator's existing device pointer; the hook verifies the returned tensor and storage are identical and errors otherwise. Without an engine (Wolf today), a host read-modify-writeback fallback is used (`Data()` D2H, add, `TrySet` H2D) -- correct on unified and discrete memory, just slower; this matches the transfer pattern `stepMixedV` already pays per step.

## Why pinning was rejected

The ztensor Pin API (ADR 006) has raise-the-floor `Reset` semantics: pinning the gradients across the per-sample reset would retain every sample's activations *below* the pinned buffers, defeating the per-sample reset and re-OOMing the arena -- the ztensor#118 history. The pin API is used here only as a transient *detection probe* (pin, then immediately unpin), never as a retention mechanism.

## Optimizer interaction (#845)

The optimizer zeroes `Parameter.Gradient` **in place** after `Step` (`stepMixedV` zeroes via storage `Set`; clip uses `MulScalar` with `dst=grad`). Since `Parameter.Gradient` now *is* the persistent accumulator, the zeroed buffer is reused verbatim next batch -- covered by `TestPersistentGradAccum_OptimizerZeroReuse`.

## Regression-test story (`training/grad_accum_test.go`)

The harness mirrors ztensor's host-backed `cuda.ArenaPool` poison tests (`TestSaveForBackward_WolfHazard_*`) without importing ztensor internals: a bump allocator whose `Reset` poisons unpinned spans with NaN (`ZTENSOR_ARENA_POISON` semantics) backing a `tensor.Storage[float32]` + `tensor.PinnableStorage` implementation, plus a Bias-like node that overwrites its param gradient with a fresh arena tensor each Backward (the `bias.go:128` shape).

- `TestPersistentGradAccum_WolfHazard_Fixed` -- 3 samples x (Backward, arena Reset): accumulated gradient equals the analytic sum of per-sample grads, no NaN, gradient no longer arena-backed; nil-gradient params tolerated.
- `TestPersistentGradAccum_WolfHazard_WithoutHookPoisoned` -- the same schedule with a nil hook reads **NaN**: the pre-fix failure mode is detectable and is what the hook fixes.
- `TestEngineAdd_PreservesAccumulatorStorageIdentity` -- `engine.Add(dst=accum)` returns the same tensor with the same storage pointer (the property the fast path depends on), directly and through the hook.
- `TestPersistentGradAccum_CPUNoOp` -- pure CPU path: zero accumulators allocated, `Parameter.Gradient` is pointer-identical to the layer-assigned tensor, values byte-identical to pre-fix semantics.
- `TestPersistentGradAccum_OptimizerZeroReuse` -- in-place zeroing between batches reuses the same buffer; batch 2 sums restart from zero.
- `TestPersistentGradAccum_InPlaceLayerSkipped` -- in-place writers into the installed accumulator are not double-counted.
- `TestPersistentGradAccum_WithEngine` -- the engine fast path produces the same analytic sum.

## Gates

`go build ./...`, `go vet ./...` clean; gofmt clean on changed files; `go test ./... -count=1` fully green; `go test ./training/... -race` green; `golangci-lint run ./training/...` reports no issues in changed files.

## Known limitation (reported, out of scope)

Paths that bypass the strategies are not covered: `model/adapters.go` (direct `Graph.Backward`), `training/nas` DARTS (layer-level backward), LoRA internals. Additionally, the `layers/ssm` family accumulates cross-sample via `p.Gradient, _ = engine.Add(ctx, p.Gradient, delta)` **without a dst** -- on an arena engine that produces a fresh arena tensor whose value already includes the accumulator, which the hook would double-count; those sites should migrate to the dst form (`engine.Add(ctx, p.Gradient, delta, p.Gradient)`) in a follow-up under #847. Wolf's crossasset path (Bias/Linear/FFN overwrite-style layers) is fully covered.

NOT verified on the GB10 in this PR per instructions -- lead to verify live with `ZTENSOR_ARENA_POISON=1` on the Wolf gr-12 schedule.
