### PR TITLE
fix(layers): dst-form in-place gradient accumulation -- no-dst Add double-counts under the persistent-accumulator hook (#850)

### DIFF
--- a/layers/core/conv1d.go
+++ b/layers/core/conv1d.go
@@ -232,7 +232,7 @@ func (c *Conv1D[T]) Backward(ctx context.Context, mode types.BackwardMode, outpu
 	if err != nil {
 		return nil, err
 	}
-	c.weight.Gradient, err = c.engine.Add(ctx, c.weight.Gradient, dwTensor)
+	c.weight.Gradient, err = c.engine.Add(ctx, c.weight.Gradient, dwTensor, c.weight.Gradient)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func (c *Conv1D[T]) Backward(ctx context.Context, mode types.BackwardMode, outpu
 		if err != nil {
 			return nil, err
 		}
-		c.bias.Gradient, err = c.engine.Add(ctx, c.bias.Gradient, dbTensor)
+		c.bias.Gradient, err = c.engine.Add(ctx, c.bias.Gradient, dbTensor, c.bias.Gradient)
 		if err != nil {
 			return nil, err
 		}

--- a/layers/core/linear.go
+++ b/layers/core/linear.go
@@ -133,7 +133,7 @@ func (l *Linear[T]) Backward(ctx context.Context, mode types.BackwardMode, outpu
 	if err != nil {
 		return nil, err
 	}
-	l.weights.Gradient, err = l.engine.Add(ctx, l.weights.Gradient, dw)
+	l.weights.Gradient, err = l.engine.Add(ctx, l.weights.Gradient, dw, l.weights.Gradient)
 	if err != nil {
 		return nil, err
 	}

--- a/layers/core/variable_selection.go
+++ b/layers/core/variable_selection.go
@@ -277,7 +277,7 @@ func (v *VariableSelection[T]) Backward(ctx context.Context, mode types.Backward
 	if err != nil {
 		return nil, err
 	}
-	v.w2.Gradient, err = v.engine.Add(ctx, v.w2.Gradient, dW2)
+	v.w2.Gradient, err = v.engine.Add(ctx, v.w2.Gradient, dW2, v.w2.Gradient)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func (v *VariableSelection[T]) Backward(ctx context.Context, mode types.Backward
 	if err != nil {
 		return nil, err
 	}
-	v.b2.Gradient, err = v.engine.Add(ctx, v.b2.Gradient, db2)
+	v.b2.Gradient, err = v.engine.Add(ctx, v.b2.Gradient, db2, v.b2.Gradient)
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +316,7 @@ func (v *VariableSelection[T]) Backward(ctx context.Context, mode types.Backward
 	if err != nil {
 		return nil, err
 	}
-	v.w1.Gradient, err = v.engine.Add(ctx, v.w1.Gradient, dW1)
+	v.w1.Gradient, err = v.engine.Add(ctx, v.w1.Gradient, dW1, v.w1.Gradient)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (v *VariableSelection[T]) Backward(ctx context.Context, mode types.Backward
 	if err != nil {
 		return nil, err
 	}
-	v.b1.Gradient, err = v.engine.Add(ctx, v.b1.Gradient, db1)
+	v.b1.Gradient, err = v.engine.Add(ctx, v.b1.Gradient, db1, v.b1.Gradient)
 	if err != nil {
 		return nil, err
 	}

--- a/layers/normalization/batch_norm.go
+++ b/layers/normalization/batch_norm.go
@@ -221,7 +221,7 @@ func (b *BatchNormalization[T]) Backward(ctx context.Context, _ types.BackwardMo
 		if b.scale.Gradient == nil {
 			b.scale.Gradient = dScale
 		} else {
-			b.scale.Gradient, err = b.engine.Add(ctx, b.scale.Gradient, dScale)
+			b.scale.Gradient, err = b.engine.Add(ctx, b.scale.Gradient, dScale, b.scale.Gradient)
 			if err != nil {
 				return nil, fmt.Errorf("BatchNormalization backward: accumulate scale gradient: %w", err)
 			}
@@ -249,7 +249,7 @@ func (b *BatchNormalization[T]) Backward(ctx context.Context, _ types.BackwardMo
 		if b.bias.Gradient == nil {
 			b.bias.Gradient = dBias
 		} else {
-			b.bias.Gradient, err = b.engine.Add(ctx, b.bias.Gradient, dBias)
+			b.bias.Gradient, err = b.engine.Add(ctx, b.bias.Gradient, dBias, b.bias.Gradient)
 			if err != nil {
 				return nil, fmt.Errorf("BatchNormalization backward: accumulate bias gradient: %w", err)
 			}

--- a/layers/ssm/complex_state.go
+++ b/layers/ssm/complex_state.go
@@ -736,7 +736,7 @@ func (c *ComplexSSMState[T]) Backward(ctx context.Context, mode types.BackwardMo
 
 	// 3. Backward through conv1d
 	dXPreConv, dConvW := c.conv1dBackward(batch, seqLen, dXConv)
-	c.convWeight.Gradient, err = c.engine.Add(ctx, c.convWeight.Gradient, dConvW)
+	c.convWeight.Gradient, err = c.engine.Add(ctx, c.convWeight.Gradient, dConvW, c.convWeight.Gradient)
 	if err != nil {
 		return nil, err
 	}

--- a/layers/ssm/mamba_block.go
+++ b/layers/ssm/mamba_block.go
@@ -675,7 +675,7 @@ func (m *MambaBlock[T]) Backward(ctx context.Context, mode types.BackwardMode, o
 	dXPreConv, dConvW := m.conv1dBackward(batch, seqLen, dXConv)
 
 	// Accumulate conv weight gradient
-	m.convWeight.Gradient, err = m.engine.Add(ctx, m.convWeight.Gradient, dConvW)
+	m.convWeight.Gradient, err = m.engine.Add(ctx, m.convWeight.Gradient, dConvW, m.convWeight.Gradient)
 	if err != nil {
 		return nil, err
 	}
@@ -697,7 +697,7 @@ func (m *MambaBlock[T]) Backward(ctx context.Context, mode types.BackwardMode, o
 	if m.convBias.Gradient == nil {
 		m.convBias.Gradient = dConvBias
 	} else {
-		m.convBias.Gradient, err = m.engine.Add(ctx, m.convBias.Gradient, dConvBias)
+		m.convBias.Gradient, err = m.engine.Add(ctx, m.convBias.Gradient, dConvBias, m.convBias.Gradient)
 		if err != nil {
 			return nil, err
 		}

--- a/layers/ssm/mimo_ssm.go
+++ b/layers/ssm/mimo_ssm.go
@@ -680,7 +680,7 @@ func (m *MIMOMambaBlock[T]) Backward(ctx context.Context, mode types.BackwardMod
 	// 3. Backward through conv1d
 	dXPreConv, dConvW := m.conv1dBackward(batch, seqLen, dXConv)
 	if m.convWeight.Gradient != nil {
-		m.convWeight.Gradient, err = m.engine.Add(ctx, m.convWeight.Gradient, dConvW)
+		m.convWeight.Gradient, err = m.engine.Add(ctx, m.convWeight.Gradient, dConvW, m.convWeight.Gradient)
 		if err != nil {
 			return nil, err
 		}

--- a/layers/timeseries/patch_embed.go
+++ b/layers/timeseries/patch_embed.go
@@ -185,7 +185,7 @@ func (pe *PatchEmbed[T]) Backward(ctx context.Context, mode types.BackwardMode, 
 	if err != nil {
 		return nil, err
 	}
-	pe.proj.Gradient, err = pe.engine.Add(ctx, pe.proj.Gradient, dw)
+	pe.proj.Gradient, err = pe.engine.Add(ctx, pe.proj.Gradient, dw, pe.proj.Gradient)
 	if err != nil {
 		return nil, err
 	}

--- a/layers/timeseries/vsn.go
+++ b/layers/timeseries/vsn.go
@@ -422,7 +422,7 @@ func (v *VSN[T]) Backward(ctx context.Context, mode types.BackwardMode, outputGr
 		if err != nil {
 			return nil, err
 		}
-		v.varProj[i].Gradient, err = v.engine.Add(ctx, v.varProj[i].Gradient, dw)
+		v.varProj[i].Gradient, err = v.engine.Add(ctx, v.varProj[i].Gradient, dw, v.varProj[i].Gradient)
 		if err != nil {
 			return nil, err
 		}

--- a/training/grad_accum_addstyle_test.go
+++ b/training/grad_accum_addstyle_test.go
@@ -1,0 +1,137 @@
+package training
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// arenaAddStyleNode mirrors layers/core/linear.go's gradient accumulation.
+//
+// FIXED (dst-form) semantics, as converted in this PR:
+//
+//	p.Gradient, err = engine.Add(ctx, p.Gradient, dw, p.Gradient)
+//
+// modeled engine behavior: the FIRST call sees the host-initialized gradient
+// as dst, and the GPU engine re-homes the result into the arena (fresh arena
+// tensor holding old+delta); once the capture hook has installed its
+// persistent accumulator, dst is stable non-arena storage and the add is in
+// place, preserving storage identity.
+//
+// LEGACY (no-dst) semantics, the pre-fix bug:
+//
+//	p.Gradient, err = engine.Add(ctx, p.Gradient, dw)
+//
+// every call allocates a fresh arena tensor holding old+delta. Combined with
+// the capture hook (which then re-adds that history into the accumulator)
+// this double-counts: accum becomes 2*accum + delta per sample and explodes
+// exponentially -- the Inf observed on the GB10 (zerfoo#850 follow-up).
+type arenaAddStyleNode struct {
+	param   *graph.Parameter[float32]
+	arena   *testArena
+	tb      testing.TB
+	dstForm bool // true = fixed in-place form; false = legacy no-dst form
+	calls   int
+}
+
+func (n *arenaAddStyleNode) OpType() string                     { return "ArenaAddStyle" }
+func (n *arenaAddStyleNode) Attributes() map[string]interface{} { return nil }
+func (n *arenaAddStyleNode) OutputShape() []int                 { return n.param.Value.Shape() }
+func (n *arenaAddStyleNode) Parameters() []*graph.Parameter[float32] {
+	return []*graph.Parameter[float32]{n.param}
+}
+
+func (n *arenaAddStyleNode) Forward(_ context.Context, inputs ...*tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error) {
+	return inputs[0], nil
+}
+
+func (n *arenaAddStyleNode) Backward(_ context.Context, _ types.BackwardMode, outputGradient *tensor.TensorNumeric[float32], _ ...*tensor.TensorNumeric[float32]) ([]*tensor.TensorNumeric[float32], error) {
+	n.calls++
+	delta := outputGradient.Data()
+	old := n.param.Gradient.Data() // host copy or backing slice; values only
+
+	if n.dstForm && n.calls > 1 {
+		// In-place add into the existing (hook-installed accumulator)
+		// storage: storage identity preserved, no arena allocation.
+		dst := n.param.Gradient.Data()
+		for i := range dst {
+			dst[i] = old[i] + delta[i]
+		}
+		return []*tensor.TensorNumeric[float32]{outputGradient}, nil
+	}
+
+	// Re-homed / legacy path: a fresh arena tensor holding old+delta.
+	span := n.arena.alloc(n.tb, len(delta))
+	st := &arenaStorage{a: n.arena, span: span}
+	g, err := tensor.NewWithStorage([]int{len(delta)}, tensor.Storage[float32](st))
+	if err != nil {
+		return nil, err
+	}
+	buf := st.Slice()
+	for i := range buf {
+		buf[i] = old[i] + delta[i]
+	}
+	n.param.Gradient = g
+	return []*tensor.TensorNumeric[float32]{outputGradient}, nil
+}
+
+func addStyleFixture(t *testing.T, arena *testArena, dstForm bool) (*graph.Graph[float32], graph.Node[float32], *arenaAddStyleNode) {
+	t.Helper()
+	value, err := tensor.New([]int{2}, []float32{0, 0})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	param, err := graph.NewParameter("linear_w", value, tensor.New[float32])
+	if err != nil {
+		t.Fatalf("NewParameter: %v", err)
+	}
+	node := &arenaAddStyleNode{param: param, arena: arena, tb: t, dstForm: dstForm}
+	b := graph.NewBuilder[float32](nil)
+	in := b.Input([]int{2})
+	b.AddNode(node, in)
+	g, err := b.Build(node)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return g, in, node
+}
+
+// TestGradAccum_AddStyleDstForm_NoDoubleCount proves the linear.go dst-form
+// conversion: an add-style layer under the Wolf hazard schedule (per-sample
+// arena Reset) accumulates to exactly the analytic per-sample sum -- no
+// double-count, no poison.
+func TestGradAccum_AddStyleDstForm_NoDoubleCount(t *testing.T) {
+	arena := newTestArena(64)
+	g, in, node := addStyleFixture(t, arena, true)
+	strategy := NewDefaultBackpropStrategy[float32]()
+	runWolfHazardSchedule(t, strategy, g, in, arena, 3)
+
+	got := node.param.Gradient.Data()
+	want := []float32{6, 60} // [1+2+3, 10+20+30]
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("accumulated gradient[%d] = %v, want %v (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestGradAccum_AddStyleLegacyNoDst_DoubleCounts documents WHY the dst-form
+// conversion is required: the legacy no-dst pattern hands the capture hook a
+// fresh arena tensor already containing the accumulated history, which the
+// hook re-adds -- the result diverges from the analytic sum (exponentially in
+// the sample count; Inf on real batch sizes).
+func TestGradAccum_AddStyleLegacyNoDst_DoubleCounts(t *testing.T) {
+	arena := newTestArena(64)
+	g, in, node := addStyleFixture(t, arena, false)
+	strategy := NewDefaultBackpropStrategy[float32]()
+	runWolfHazardSchedule(t, strategy, g, in, arena, 3)
+
+	got := node.param.Gradient.Data()
+	want := []float32{6, 60}
+	if got[0] == want[0] && got[1] == want[1] {
+		t.Fatalf("legacy no-dst pattern unexpectedly produced the analytic sum %v -- the double-count this test documents has been silently fixed elsewhere; update the test", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #851, found live on the GB10: with the persistent-accumulator hook installed, layers using the no-dst accumulation pattern `p.Gradient, err = engine.Add(ctx, p.Gradient, dw)` hand the hook a FRESH arena tensor already containing the accumulated history; the hook re-adds it, so `accum = 2*accum + dw` per sample -> exponential -> **Inf in ffnB1\_biases within batch 0** (verify2 run). Pre-#851 the same sites were the original stale-arena-read (the ninth bug's NaN).

Converts all 15 no-dst sites across layers/ (linear, conv1d, variable_selection, patch_embed, batch_norm, ssm family, vsn) to the dst-form in-place add `engine.Add(ctx, p.Gradient, dw, p.Gradient)`: first call re-homes into the arena (hook migrates to the persistent accumulator), subsequent calls write in place into the accumulator (storage identity preserved -> hook's idempotency skip applies). Exactly the migration #851's report prescribed for the ssm sites -- linear.go was the missed Wolf-critical one.

Regression tests: `TestGradAccum_AddStyleDstForm_NoDoubleCount` (analytic sum under the Wolf hazard schedule) and `TestGradAccum_AddStyleLegacyNoDst_DoubleCounts` (documents the failure mode). Refs #850, #847, zerfoo/ztensor#128.