### PR TITLE
docs(design): per-op verification gates + gradient accumulation policy; GB10 close-out devlog; plan T5.1/T5.3

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1063,6 +1063,38 @@ go test -count=1 -v \
 go test -run Parity -v ./compute/
 ```
 
+### 7.5 Per-Op Verification Gates (ADR-091)
+
+Every new op — a `graph.Node` implementation or a new engine method — must pass
+three complementary harnesses before merge. The harnesses live in ztensor
+`testing/` (gradcheck, oracle) and the parity runner; ADR-091 defines the
+policy. A new op is not done until all three gates are green.
+
+1. **gradcheck (math correctness).** Register the op in the OpInfo registry:
+   constructor, representative shapes, input domains, tolerances. The harness
+   checks the node's analytic `Backward` against float64 central differences on
+   the CPU engine. Runs in ordinary CI; catches wrong Jacobians as named tests.
+2. **Engine parity under arena stress (implementation correctness).** The same
+   op sequence runs CPU-f32 vs GPU-f32, forward AND backward, in interleaved
+   schedules (A.fwd, B.fwd, ..., A.bwd) with a small arena to force buffer
+   reuse. Catches kernel bugs and the cached-intermediate lifetime-corruption
+   class that single-op tests cannot see (pairs with ztensor's
+   `ZTENSOR_ARENA_POISON` mode and the ADR 006 save-for-backward contract).
+   GPU runs execute as Spark pods on the GPU host (CI has no GPU) and
+   serialize on the single device.
+3. **PyTorch oracle (convention correctness).** The op's forward+backward case
+   bundle is dumped through the registry and replayed in torch inside the
+   pinned NGC container; both directions are diffed within per-op tolerances
+   (`|ztensor − torch| ≤ atol + rtol·|torch|`; NaN always fails). Catches
+   numerics-convention divergence (fast-math, reduction ordering, eps
+   placement) that both Go engines could share.
+
+The OpInfo registry's `NewRegistryNode[T]` is the single source of truth for
+constructor arguments, so registering an op once enrolls it in gradcheck and
+the oracle with identical configurations. Each harness encodes at least one
+historically-fixed bug as a red-proof regression fixture proving it would have
+caught that bug class.
+
 ---
 
 ## 8. Build and CI
@@ -1640,6 +1672,28 @@ before forward and ReduceScatter after backward.
 - `cmd/train-distributed/` -- CLI: `zerfoo train-distributed --ranks 4 --model path --dataset jsonl`
 
 See [ADR-050](adr/050-distributed-training-fsdp.md).
+
+### 21.4 Gradient Accumulation Policy
+
+Gradient accumulation across samples/micro-batches stays on the device that
+produced the gradients, ordered on the graph's own stream. When no accumulation
+engine is configured explicitly (`SetEngine`), the accumulator derives the
+graph's compute engine via `Graph.Engine()` (ztensor) and performs in-place
+dst-form adds (`Add(ctx, acc, grad, acc)`), so device-resident f32 gradients
+accumulate as in-place kernels on the same stream as the graph's kernels --
+no per-sample device-to-host round-trip. Host-backed, non-f32, and engine-less
+graphs keep the host fallback.
+
+Two upstream ztensor contracts make both paths safe:
+
+- **dst-form storage identity**: an op given a `dst` writes into `dst`'s
+  existing storage and never re-homes it onto a pool allocation, so a
+  persistent accumulator is never silently converted into an arena tensor that
+  a per-step reset recycles behind the live reference.
+- **host-access synchronization**: any host read/write of device memory (the
+  fallback path's `Data()`/`TrySet`) is stream-ordered via per-device
+  registered sync hooks (`tensor.RegisterHostAccessSync`), so a host read can
+  never observe bytes from before a still-asynchronous kernel write.
 
 ---
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,42 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-06-11: GPU training hardening close-out -- device-resident gradient accumulation (#855) validated end-to-end on GB10 f32
+
+**Type:** finding
+**Tags:** gpu-training-hardening, t5.1, t5.3, gradient-accumulation, stream-sync, arena, gb10, #855, #857
+
+**Problem:** GB10 f32 training of the hardest consumer workload still produced
+a deterministic gradient NaN around batch 3-4 after every kernel-level fix in
+the hardening plan: forward clean, per-sample gradients finite, corruption
+entering between the last accumulation and the optimizer guard.
+
+**Root cause -- two stacked ztensor contract gaps, not numerics:**
+
+1. **Unordered host access** (ztensor#137): the gradAccumulator host fallback
+   round-tripped every device gradient through the host (`Data()` D2H, add,
+   `TrySet` H2D) per sample; on GB10 cache-coherent unified memory the host
+   read raced the still-async kernel writing the gradient. Fixed upstream via
+   per-device host-access sync hooks. zerfoo#855 (a69ea550) additionally takes
+   the round-trip off the hot path: with no engine configured, the accumulator
+   derives the graph's own engine (`Graph.Engine()`, new ztensor API) for
+   fully device-resident in-place f32 accumulation on the graph's stream.
+2. **Stale GC-finalizer frees after arena Reset** (ztensor#138): the training
+   loop's first big GC freed thousands of dead pre-Reset storages whose stale
+   FreeArena calls poisoned/double-issued free-list memory owned by live
+   tensors. Fixed upstream with arena reset-epochs (`FreeAtEpoch` drops
+   cross-epoch frees). zerfoo#857 (97af57df) bumps to the fixed ztensor.
+
+**Measured outcome (GB10, f32, both fixes):** two consecutive clean end-to-end
+training runs -- zero NaN, epoch loss 0.778373, accuracy within 0.05pp of the
+CPU baseline, ~390 samples/s. Plan T5.1 acceptance met (two clean runs inside
+the 1pp gate). T5.3 documentation shipped with this entry: design.md gains
+7.5 Per-Op Verification Gates (gradcheck / parity-under-arena-stress /
+PyTorch-oracle -- the gates every new op must pass, ADR-091) and 21.4 Gradient
+Accumulation Policy; ztensor design.md gains the host-access synchronization
+contract, reset-epoch free semantics, pinning, and the dst-form accumulation
+policy (ztensor#139).
+
 ## 2026-04-21: T99.2.2.8 -- H21 reference diff (HF vs zerfoo PLE; structural candidate identified: Q4_K -> Q4_0 re-quantization in gather tables)
 
 **Type:** investigation

--- a/docs/plan-gpu-training-hardening.md
+++ b/docs/plan-gpu-training-hardening.md
@@ -374,7 +374,7 @@ fp32 fixed-order, every kernel passes the oracle gate, perf delta recorded.
 
 Acceptance: the prize -- Wolf trains clean on GB10 f32 -- plus shipped tags.
 
-- [ ] T5.1 Wolf CrossAsset GB10 f32 clean fold on the hardened stack
+- [x] T5.1 Wolf CrossAsset GB10 f32 clean fold on the hardened stack  2026 06 11  (DONE verify9 + verify9b on image 0066d970: two consecutive clean runs, zero NaN, epoch loss 0.778373, fold-0 acc 0.6760 vs CPU 0.6765 -- inside the 1pp gate; Bug 11 fixes ztensor#137/#138 + zerfoo#855/#857; Wolf devlog + ADR 072 resolution in wolf#200. NOTE: the formal blocked-by T3.1/T3.2/T3.3 kernel audit was overtaken by events -- the residual was allocator lifetime (host-access ordering + stale cross-epoch frees), not kernel numerics; T3.1/T3.2/T3.3 remain open as hardening.)
        Owner: TBD  Est: 1d  verifies: [UC-GH-007]  kind: agent  blocked-by: [T2.3, T3.1, T3.2, T3.3]
   - Bump a Wolf branch to the hardened ztensor/zerfoo, rebuild the image, run
     folds=2 epochs=1 seed=42 -precision=f32 -gpu (QK-norm on) on the GB10 via
@@ -393,7 +393,7 @@ Acceptance: the prize -- Wolf trains clean on GB10 f32 -- plus shipped tags.
   - Acceptance: tags exist; Wolf main builds against them; speed-parity plan
     progress log updated.
 
-- [ ] T5.3 Documentation: design.md updates + devlog entries (both repos)
+- [x] T5.3 Documentation: design.md updates + devlog entries (both repos)  2026 06 11  (DONE ztensor#139: design.md host-access sync contract + reset-epoch frees + pinning + dst-form accumulation policy, devlog entry; zerfoo#859: design.md 7.5 per-op verification gates (gradcheck/parity/oracle, ADR-091) + 21.4 gradient accumulation policy (Graph.Engine()), devlog entry; wolf#200: ADR 072 resolution + Bug 11 devlog)
        Owner: TBD  Est: 3h  verifies: [infrastructure]  kind: agent  blocked-by: [T5.1]
   - ztensor docs/design.md: arena pinning + poison mode + accumulation policy
     (general terms). zerfoo docs/design.md: verification-harness usage for new
@@ -452,9 +452,9 @@ T5.1) serialize on the single GPU -- never fan those out.
 - [ ] T4.1 Deterministic mode
 
 ### Wave 5: Validation + ship (1 agent, GPU-serial)
-- [ ] T5.1 Wolf GB10 f32 clean fold x2
+- [x] T5.1 Wolf GB10 f32 clean fold x2  2026 06 11  (DONE verify9/verify9b, image 0066d970, acc 0.6760)
 - [ ] T5.2 Releases + Wolf bump
-- [ ] T5.3 Documentation
+- [x] T5.3 Documentation  2026 06 11  (DONE ztensor#139, zerfoo#859, wolf#200)
 
 ---
 


### PR DESCRIPTION
## Summary
Documentation close-out for plan-gpu-training-hardening T5.1 (docs portion) and T5.3:

- **design.md 7.5 Per-Op Verification Gates (ADR-091)**: when adding an op, the three gates it must pass -- gradcheck via the OpInfo registry (math correctness, ordinary CI), engine parity under arena stress (implementation correctness, GPU-host Spark runs), PyTorch oracle (convention correctness, pinned NGC container; `|ztensor − torch| ≤ atol + rtol·|torch|`, NaN always fails). Notes the single-source-of-truth OpInfo registration and the red-proof regression-fixture requirement.
- **design.md 21.4 Gradient Accumulation Policy**: accumulation runs device-resident as in-place dst-form adds on the graph's own engine/stream (`Graph.Engine()`), backed by ztensor's dst-form storage-identity and host-access synchronization contracts; host fallback retained for host-backed/non-f32/engine-less graphs.
- **devlog**: dated entry for the end-to-end GB10 f32 validation of #855/#857 (two consecutive clean runs, zero NaN, accuracy within 0.05pp of the CPU baseline).
- **plan**: T5.1 and T5.3 checked with date + evidence refs (follow-up commit on this PR).

Companion PRs: ztensor#139 (design/devlog), feza-ai/wolf#200 (ADR 072 resolution + devlog). Docs-only change.