### PR TITLE
plan: check S2.3.1 -- poison-mode full-suite GB10 run green (ztensor#140)

### DIFF
--- a/docs/plan-gpu-training-hardening.md
+++ b/docs/plan-gpu-training-hardening.md
@@ -287,7 +287,7 @@ under poison mode.
   - Acceptance: audit table complete; both repos' suites green; parity harness
     (T1.2) under ZTENSOR_ARENA_POISON=1 green across the registry.
 
-- [ ] S2.3.1 Poison-mode full-suite run on GB10 (Spark, serial)
+- [x] S2.3.1 Poison-mode full-suite run on GB10 (Spark, serial)  2026 06 11  (DONE ztensor#140: Spark pod ztensor-parity-4b4d759c, ZTENSOR_ARENA_POISON=1, 64MiB arena -- parity schedules 26/26 + 26/26 green, GPU red-proof red, Wolf-pattern training loop finite + CPU-parity; ztensor devlog 2026-06-11)
        Owner: TBD  Est: 2h  verifies: [UC-GH-004]  kind: agent  blocked-by: [T2.3]
   - The proof: parity harness + a small training loop with per-sample
     ResetPool (the Wolf gr-12 pattern: accumulate gradients across a batch,


### PR DESCRIPTION
Marks S2.3.1 done in docs/plan-gpu-training-hardening.md.

Evidence: Spark pod `ztensor-parity-4b4d759c` on the GB10, ref ztensor `test/s231-poison-gb10` (4b4d759c = v1.11.0 + ztensor#140), `ZTENSOR_ARENA_POISON=1`, 64 MiB test arena, GPU serialized:
- `TestParity_GPUvsCPU_ArenaStressSchedules_GPU`: no-reset 26/26, reset-between-fwd-bwd 26/26, 0 failed / 0 errored (JSON reports archived; worst max_abs ~7e-06 on Tanh grads).
- `TestParity_GPURedProof_GPU`: raw cached-intermediate fixture red on the real CUDA arena, contract twin green.
- `TestTrainingLoop_WolfPattern_GPU` (new in ztensor#140): per-sample ResetPool + persistent in-place grad accumulation + per-batch SGD under poison -- all parameters finite and within f32 tolerance of the identical CPU run.

Run details in ztensor docs/devlog.md (2026-06-11 entry). Pod deleted after log/report capture.