### PR TITLE
plan(gpu-hardening): mark T2.4 done (ztensor#141)

### DIFF
--- a/docs/plan-gpu-training-hardening.md
+++ b/docs/plan-gpu-training-hardening.md
@@ -293,7 +293,7 @@ under poison mode.
     ResetPool (the Wolf gr-12 pattern: accumulate gradients across a batch,
     reset arena every sample) runs clean under poison.
 
-- [ ] T2.4 Wolf-pattern integration stress test in ztensor
+- [x] T2.4 Wolf-pattern integration stress test in ztensor  2026 06 12  (DONE ztensor#141: attention graph Q@K^T->softmax->@V + residual/RMS-norm on SaveForBackward, reset-between-fwd-bwd + per-sample ResetPool, persistent Parameters; StressCI green, GB10 pod ztensor-parity-853a7fa1 green under poison, red-proof verified)
        Owner: TBD  Est: 4h  verifies: [UC-GH-004, UC-GH-007]  kind: agent  blocked-by: [T2.1, T2.2]
   - A ztensor integration test reproducing the exact hazard schedule that bit
     Wolf: multi-sample gradient accumulation into persistent Parameters with


### PR DESCRIPTION
T2.4 Wolf-pattern attention stress test landed as ztensor#141 (merge ea0fdfbc).

- CPU: TestAttentionTraining_WolfPattern_StressCI green in ztensor CI (host-backed-arena StressEngine, poison on, zero leaked pins).
- GPU: TestAttentionTraining_WolfPattern_GPU green on GB10 under ZTENSOR_ARENA_POISON=1 (Spark pod ztensor-parity-853a7fa1, ref 853a7fa1, pod exit 0, VALIDATION_OK; Wq/Wk/Wv finite + within f32 tolerance of the CPU run; full existing parity/red-proof/training-loop gate still green).
- Red-proof: removing SaveForBackward makes the CI variant fail with deterministic poison NaN.
- scripts/parity/run.sh now hard-gates the new GPU test (exit 7).

Closes the M2 Wolf-pattern stress leg. Evidence: ztensor docs/devlog.md 2026-06-12.