### PR TITLE
test(optimizer): AdamW mixed-precision v equivalence tests

### DIFF
--- a/training/optimizer/adamw_mixedv_equivalence_test.go
+++ b/training/optimizer/adamw_mixedv_equivalence_test.go
@@ -202,3 +202,185 @@ func TestAdamW_MixedV_MatchesReference(t *testing.T) {
 		})
 	}
 }
+
+// referenceFullF64 is a straightforward, fully-float64 AdamW reference: the
+// parameters, both moments, and every intermediate live in float64 with no
+// rounding to float32 anywhere. It is the "ground truth" trajectory that the
+// mixed-precision path (f32 param/m, f64 v) is supposed to track closely;
+// ADR 070's premise is that promoting only v captures essentially all of the
+// f64 stability.
+type referenceFullF64 struct {
+	beta1, beta2, eps, lr, wd float64
+	t                         int
+	param                     []float64
+	m                         []float64
+	v                         []float64
+}
+
+func newReferenceFullF64(initParam []float32, lr, beta1, beta2, eps, wd float64) *referenceFullF64 {
+	p := make([]float64, len(initParam))
+	for i, v := range initParam {
+		p[i] = float64(v)
+	}
+	return &referenceFullF64{
+		beta1: beta1, beta2: beta2, eps: eps, lr: lr, wd: wd,
+		param: p,
+		m:     make([]float64, len(initParam)),
+		v:     make([]float64, len(initParam)),
+	}
+}
+
+func (r *referenceFullF64) step(grad []float32) {
+	r.t++
+	numer := math.Sqrt(1.0 - math.Pow(r.beta2, float64(r.t)))
+	denom := 1.0 - math.Pow(r.beta1, float64(r.t))
+	alpha := r.lr * (numer / denom)
+	lrWd := r.lr * r.wd
+
+	for i := range r.param {
+		g := float64(grad[i])
+		r.m[i] = r.beta1*r.m[i] + (1.0-r.beta1)*g
+		r.v[i] = r.beta2*r.v[i] + (1.0-r.beta2)*g*g
+
+		update := alpha * r.m[i] / (math.Sqrt(r.v[i]) + r.eps)
+		r.param[i] = r.param[i] - update - lrWd*r.param[i]
+	}
+}
+
+// TestAdamW_MixedV_TracksFullF64Reference asserts that the mixed-precision
+// stepMixedV path stays within a small tolerance of a straightforward
+// all-float64 AdamW over many steps, including gradient regimes where an
+// all-f32 second moment would lose precision (near-zero gradients whose
+// squares underflow f32, and gradients spanning several orders of magnitude).
+// Unlike TestAdamW_MixedV_MatchesReference -- which checks bit-equivalence
+// against an independent implementation of the same mixed algorithm -- this
+// test bounds the mixed path's drift from true f64 AdamW, i.e. it verifies
+// that promoting only v (per ADR 070) is sufficient to track the full-f64
+// trajectory.
+func TestAdamW_MixedV_TracksFullF64Reference(t *testing.T) {
+	type gradFn func(step, i int) float32
+
+	cases := []struct {
+		name        string
+		shape       []int
+		initParam   []float32
+		lr          float64
+		beta1       float64
+		beta2       float64
+		eps         float64
+		weightDecay float64
+		steps       int
+		relTol      float64 // tolerance relative to max(1, |ref param|)
+		grad        gradFn
+	}{
+		{
+			name:      "typical_gradients",
+			shape:     []int{4},
+			initParam: []float32{0.5, -0.25, 1.0, -1.0},
+			lr:        1e-3, beta1: 0.9, beta2: 0.999, eps: 1e-8, weightDecay: 0.0,
+			steps:  25,
+			relTol: 1e-5,
+			grad: func(step, i int) float32 {
+				return float32(0.1*float64(i+1)) * float32(math.Cos(float64(step)))
+			},
+		},
+		{
+			name:      "weight_decay_and_large_gradients",
+			shape:     []int{5},
+			initParam: []float32{1, -2, 3, -4, 5},
+			lr:        1e-3, beta1: 0.9, beta2: 0.999, eps: 1e-8, weightDecay: 0.01,
+			steps:  20,
+			relTol: 1e-5,
+			grad: func(step, i int) float32 {
+				// Large-magnitude gradients: up to 1e3.
+				return float32(math.Pow(10, float64(i%4)) * math.Sin(float64(step+i)))
+			},
+		},
+		{
+			name:      "tiny_gradients_f32_v_would_underflow",
+			shape:     []int{4},
+			initParam: []float32{0.5, 0.5, 0.5, 0.5},
+			lr:        1e-3, beta1: 0.9, beta2: 0.999, eps: 1e-5, weightDecay: 0.0,
+			steps: 50,
+			// Updates are ~lr in magnitude but param stays ~0.5; the only
+			// f32 rounding is on param/m, so drift stays tiny.
+			relTol: 1e-5,
+			grad: func(step, i int) float32 {
+				// g^2 = 1e-20 underflows toward the f32 denormal floor; an
+				// f32 v would make sqrt(v)+eps collapse to eps.
+				if i%2 == 0 {
+					return 1e-10
+				}
+				return -1e-10
+			},
+		},
+		{
+			name:      "wide_dynamic_range",
+			shape:     []int{8},
+			initParam: []float32{0.1, -0.1, 0.2, -0.2, 0.3, -0.3, 0.4, -0.4},
+			lr:        2e-3, beta1: 0.95, beta2: 0.9995, eps: 1e-7, weightDecay: 0.005,
+			steps:  30,
+			relTol: 1e-5,
+			grad: func(step, i int) float32 {
+				// Spans 1e-6 .. 1e1 across elements in the same tensor.
+				scale := math.Pow(10, float64(i-6))
+				return float32(scale * math.Sin(float64(step+i)))
+			},
+		},
+	}
+
+	ops := numeric.Float32Ops{}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := compute.NewCPUEngine[float32](ops)
+
+			paramTensor, err := tensor.New[float32](tc.shape, append([]float32(nil), tc.initParam...))
+			if err != nil {
+				t.Fatalf("new param tensor: %v", err)
+			}
+			param, err := graph.NewParameter[float32]("w", paramTensor, tensor.New[float32])
+			if err != nil {
+				t.Fatalf("new parameter: %v", err)
+			}
+
+			adam := NewAdamW[float32](engine, float32(tc.lr), float32(tc.beta1),
+				float32(tc.beta2), float32(tc.eps), float32(tc.weightDecay))
+			if !adam.useMixedV {
+				t.Fatalf("expected mixed-precision path active for float32 CPU engine")
+			}
+
+			ref := newReferenceFullF64(tc.initParam, tc.lr, tc.beta1, tc.beta2, tc.eps, tc.weightDecay)
+
+			n := len(tc.initParam)
+			for step := 0; step < tc.steps; step++ {
+				gradVals := make([]float32, n)
+				for i := range gradVals {
+					gradVals[i] = tc.grad(step, i)
+				}
+
+				gradTensor, err := tensor.New[float32](tc.shape, append([]float32(nil), gradVals...))
+				if err != nil {
+					t.Fatalf("step %d: new grad tensor: %v", step, err)
+				}
+				if err := param.AddGradient(gradTensor); err != nil {
+					t.Fatalf("step %d: add grad: %v", step, err)
+				}
+
+				if err := adam.Step(context.Background(), []*graph.Parameter[float32]{param}); err != nil {
+					t.Fatalf("step %d: optimizer step: %v", step, err)
+				}
+				ref.step(gradVals)
+
+				got := param.Value.Data()
+				for i := range got {
+					scale := math.Max(1.0, math.Abs(ref.param[i]))
+					if diff := math.Abs(float64(got[i]) - ref.param[i]); diff > tc.relTol*scale {
+						t.Fatalf("case %q step %d param[%d]: mixed=%v fullF64=%v (diff=%g, tol=%g)",
+							tc.name, step, i, got[i], ref.param[i], diff, tc.relTol*scale)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

Wolf plan tasks S14.1.1/S14.1.2 (follow-up to T14.1 = zerfoo#843/#844/#845, ADR 070 in the wolf repo): equivalence + unit-test coverage for the as-landed host mixed-precision `v` path in `AdamW.stepMixedV` (f64 second moment, f32 param/m, minimized host round-trip).

## Existing coverage found (not duplicated)

- `TestAdamW_MixedV_MatchesReference` (adamw_mixedv_equivalence_test.go, landed with #844): table-driven, 4 gradient regimes, 12-50 steps, bit-level equivalence against an independent implementation of the **same mixed algorithm**, plus per-step gradient-zeroing assertions.
- `TestAdamW_MixedPrecisionV_ResistsSmallGradientUnderflow` (adamw_test.go): 100-step stability under 1e-10 gradients.

## What this PR adds

`TestAdamW_MixedV_TracksFullF64Reference`: the one gap vs the acceptance criterion — comparison against a **straightforward all-float64 AdamW reference** (param, m, v all f64, no f32 rounding anywhere) within 1e-5 relative tolerance over 20-50 steps. Table-driven, 4 cases: typical gradients, weight decay + large gradients (up to 1e3), tiny gradients whose squares underflow an f32 `v` (g=1e-10, eps=1e-5), and a wide dynamic range (1e-6..1e1 across one tensor). This verifies ADR 070's premise that promoting only the second moment is sufficient to track the true f64 trajectory.

Test-only change; no production code touched.

## Validation

- Tier 0: `go build ./...`, `go vet ./...` clean; `golangci-lint run ./training/optimizer/...` shows only a pre-existing gocritic finding in `adamw_scalar.go` (present on main, untouched here).
- Tier 1: `go test ./training/... -race -count=1` — optimizer green; `TestSAC_ContinuousAction` (training/rl) flaked once under full-suite load, passes deterministically in isolation (2/2) and in the subsequent full run.
- Full `go test ./... -timeout 600s`: exit 0, zero failures.