### PR TITLE
feat(training): CUDA-graph capture-replay runner, capture-safe CE loss, device Concat backward

### DIFF
--- a/layers/core/concat.go
+++ b/layers/core/concat.go
@@ -100,7 +100,7 @@ func (c *Concat[T]) Forward(_ context.Context, inputs ...*tensor.TensorNumeric[T
 }
 
 // Backward computes the gradients for the Concat layer.
-func (c *Concat[T]) Backward(_ context.Context, mode types.BackwardMode, outputGradient *tensor.TensorNumeric[T], inputs ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+func (c *Concat[T]) Backward(ctx context.Context, mode types.BackwardMode, outputGradient *tensor.TensorNumeric[T], inputs ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
 	if len(inputs) == 0 {
 		return nil, fmt.Errorf("Concat layer requires at least 1 input")
 	}
@@ -116,6 +116,31 @@ func (c *Concat[T]) Backward(_ context.Context, mode types.BackwardMode, outputG
 	axis := c.axis
 	if axis < 0 {
 		axis = len(shape) + axis
+	}
+
+	// Equal-split fast path: when every input has the same length along the
+	// concat axis, the backward is exactly engine.Split. On GPU engines this
+	// keeps the gradient on the device (the generic path below reads the
+	// whole output gradient back to the host and re-slices it there, which
+	// is both slow and illegal inside a CUDA-graph capture region; see
+	// training.CaptureReplayRunner).
+	if axis >= 0 && axis < len(shape) {
+		equal := true
+		first := inputs[0].Shape()
+		for _, in := range inputs {
+			inShape := in.Shape()
+			if len(inShape) != len(shape) || inShape[axis] != first[axis] {
+				equal = false
+				break
+			}
+		}
+		if equal && first[axis]*len(inputs) == shape[axis] {
+			grads, err := c.engine.Split(ctx, outputGradient, len(inputs), axis)
+			if err == nil && len(grads) == len(inputs) {
+				return grads, nil
+			}
+			// Fall through to the generic host path on any Split error.
+		}
 	}
 
 	// Compute block size (product of dims after axis) and outer (product before axis)

--- a/layers/core/concat_test.go
+++ b/layers/core/concat_test.go
@@ -148,3 +148,65 @@ func TestConcat_BackwardAxis0(t *testing.T) {
 	testutils.AssertFloat32SliceApproxEqual(t, expG1, grads[0].Data(), 0, "grad1 data")
 	testutils.AssertFloat32SliceApproxEqual(t, expG2, grads[1].Data(), 0, "grad2 data")
 }
+
+// TestConcat_BackwardEqualSplit exercises the engine.Split fast path
+// (equal-length inputs along the concat axis), the route taken by GPU
+// engines to keep the gradient device-resident (CUDA-graph capture
+// compatibility). Values must match the generic host path exactly.
+func TestConcat_BackwardEqualSplit(t *testing.T) {
+	tests := []struct {
+		name     string
+		axis     int
+		inShape  []int
+		inputs   int
+		gOut     []float32
+		outShape []int
+		expected [][]float32
+	}{
+		{
+			name:     "axis0 wolf pattern [1,d] x3",
+			axis:     0,
+			inShape:  []int{1, 3},
+			inputs:   3,
+			outShape: []int{3, 3},
+			gOut:     []float32{10, 11, 12, 20, 21, 22, 30, 31, 32},
+			expected: [][]float32{{10, 11, 12}, {20, 21, 22}, {30, 31, 32}},
+		},
+		{
+			name:     "axis1 equal halves",
+			axis:     1,
+			inShape:  []int{2, 2},
+			inputs:   2,
+			outShape: []int{2, 4},
+			gOut:     []float32{1, 2, 3, 4, 5, 6, 7, 8},
+			expected: [][]float32{{1, 2, 5, 6}, {3, 4, 7, 8}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+			layer := NewConcat[float32](engine, tt.axis)
+
+			ins := make([]*tensor.TensorNumeric[float32], tt.inputs)
+			n := 1
+			for _, d := range tt.inShape {
+				n *= d
+			}
+			for i := range ins {
+				var err error
+				ins[i], err = tensor.New[float32](tt.inShape, make([]float32, n))
+				testutils.AssertNoError(t, err, "create input")
+			}
+			gOut, err := tensor.New[float32](tt.outShape, tt.gOut)
+			testutils.AssertNoError(t, err, "create gOut")
+
+			grads, err := layer.Backward(context.Background(), types.FullBackprop, gOut, ins...)
+			testutils.AssertNoError(t, err, "backward")
+			testutils.AssertEqual(t, tt.inputs, len(grads), "grads len")
+			for i, exp := range tt.expected {
+				testutils.AssertTrue(t, testutils.IntSliceEqual(tt.inShape, grads[i].Shape()), "grad shape")
+				testutils.AssertFloat32SliceApproxEqual(t, exp, grads[i].Data(), 0, "grad data")
+			}
+		})
+	}
+}

--- a/layers/normalization/layer_normalization.go
+++ b/layers/normalization/layer_normalization.go
@@ -37,11 +37,21 @@ type LayerNormalization[T tensor.Numeric] struct {
 	outputShape []int
 
 	useMixedBackward bool // Run Backward per-element in float64 on CPU.
+	// engineGradAssign: in the engine-ops backward, hand gamma/beta
+	// gradients to the trainer by ASSIGNING the fresh engine tensors
+	// (the Linear/Bias pattern, migrated to persistent buffers by the
+	// strategy's issue-#850 hook) instead of host AddGradient, which
+	// reads device tensors back per step and is illegal inside a
+	// CUDA-graph capture. Set by WithLayerNormEngineBackward.
+	engineGradAssign bool
 }
 
 // LayerNormalizationOptions holds configuration options for LayerNormalization layers.
 type LayerNormalizationOptions[T tensor.Numeric] struct {
 	Epsilon T // Small constant to avoid division by zero
+	// EngineBackward forces the engine-ops backward path; see
+	// WithLayerNormEngineBackward.
+	EngineBackward bool
 }
 
 // LayerNormalizationOption is a functional option for configuring LayerNormalization layers.
@@ -51,6 +61,31 @@ type LayerNormalizationOption[T tensor.Numeric] func(*LayerNormalizationOptions[
 func WithLayerNormEpsilon[T tensor.Numeric](epsilon T) LayerNormalizationOption[T] {
 	return func(opts *LayerNormalizationOptions[T]) {
 		opts.Epsilon = epsilon
+	}
+}
+
+// WithLayerNormEngineBackward forces Backward to run as engine ops in the
+// element type T, overriding the host float64 mixed-precision backward
+// that shouldUseMixedPrecisionBackward enables for low-precision types.
+//
+// The mixed-precision backward reads the input, upstream gradient, and
+// gamma back to the host every step -- D2H copies plus host math that are
+// illegal inside a CUDA-graph capture region (compute.GraphCapturer /
+// training.CaptureReplayRunner). Callers that capture training steps must
+// opt in to the engine path and supply their own overflow guards
+// (gradient clipping, divergence detection): the float64 backward exists
+// because float32 LayerNorm backward can overflow on early-training
+// gradient spikes (the CrossAsset f32 cliff).
+//
+// Gradient storage semantics also change: gamma/beta gradients are
+// ASSIGNED as fresh engine tensors each Backward (the Linear/Bias
+// pattern) instead of host-accumulated via Parameter.AddGradient.
+// Trainers built on DefaultBackpropStrategy accumulate them across steps
+// via the persistent-gradient hook (issue #850); bespoke trainers that
+// relied on AddGradient's in-place accumulation must not use this option.
+func WithLayerNormEngineBackward[T tensor.Numeric]() LayerNormalizationOption[T] {
+	return func(opts *LayerNormalizationOptions[T]) {
+		opts.EngineBackward = true
 	}
 }
 
@@ -100,7 +135,8 @@ func NewLayerNormalization[T tensor.Numeric](engine compute.Engine[T], featureDi
 		epsilon:          opts.Epsilon,
 		gamma:            gamma,
 		beta:             beta,
-		useMixedBackward: shouldUseMixedPrecisionBackward[T](engine),
+		useMixedBackward: shouldUseMixedPrecisionBackward[T](engine) && !opts.EngineBackward,
+		engineGradAssign: opts.EngineBackward,
 	}, nil
 }
 
@@ -316,10 +352,6 @@ func (ln *LayerNormalization[T]) Backward(ctx context.Context, mode types.Backwa
 		}
 	}
 
-	if err := ln.gamma.AddGradient(dGamma); err != nil {
-		return nil, err
-	}
-
 	// dL/dbeta = sum(dOut) along the batch dimensions (all non-feature dims)
 	dBeta := dOut
 	for i := 0; i < len(inputShape)-1; i++ {
@@ -329,8 +361,24 @@ func (ln *LayerNormalization[T]) Backward(ctx context.Context, mode types.Backwa
 		}
 	}
 
-	if err := ln.beta.AddGradient(dBeta); err != nil {
-		return nil, err
+	if ln.engineGradAssign {
+		// Capture-safe storage: assign the fresh engine tensors and let
+		// the strategy's persistent-gradient hook (issue #850) accumulate
+		// them into stable device buffers, exactly like Linear/Bias.
+		// AddGradient below is a host element-wise loop -- a per-step D2H
+		// read of device gradients, illegal during CUDA-graph capture.
+		// NOTE: without the hook (plain per-step trainers), assignment
+		// semantics replace cross-step accumulation -- documented on
+		// WithLayerNormEngineBackward.
+		ln.gamma.Gradient = dGamma
+		ln.beta.Gradient = dBeta
+	} else {
+		if err := ln.gamma.AddGradient(dGamma); err != nil {
+			return nil, err
+		}
+		if err := ln.beta.AddGradient(dBeta); err != nil {
+			return nil, err
+		}
 	}
 
 	// Gradient for input (dL/dx)

--- a/layers/normalization/layer_normalization_test.go
+++ b/layers/normalization/layer_normalization_test.go
@@ -410,3 +410,95 @@ func TestLayerNormalization_BackwardMixedCPUResistsUnderflow(t *testing.T) {
 		}
 	}
 }
+
+// TestLayerNormalization_WithEngineBackwardOption: the T9.1 capture-safe
+// option must (a) disable the host mixed-precision backward, (b) store
+// gamma/beta gradients by assigning the fresh engine tensors (the
+// Linear/Bias pattern consumed by the strategy's persistent-gradient
+// hook), and (c) produce gradients matching the mixed path within
+// float32-vs-float64 rounding tolerance.
+func TestLayerNormalization_WithEngineBackwardOption(t *testing.T) {
+	ctx := context.Background()
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine[float32](ops)
+
+	const featureDim = 8
+	const batch = 4
+	shape := []int{batch, featureDim}
+
+	lnMixed, err := NewLayerNormalization[float32](engine, featureDim)
+	if err != nil {
+		t.Fatalf("NewLayerNormalization(mixed) failed: %v", err)
+	}
+	lnOpt, err := NewLayerNormalization[float32](engine, featureDim, WithLayerNormEngineBackward[float32]())
+	if err != nil {
+		t.Fatalf("NewLayerNormalization(engine option) failed: %v", err)
+	}
+	if lnOpt.useMixedBackward {
+		t.Fatal("WithLayerNormEngineBackward must disable the mixed-precision backward")
+	}
+	if !lnOpt.engineGradAssign {
+		t.Fatal("WithLayerNormEngineBackward must enable gradient assignment")
+	}
+
+	inputData := make([]float32, batch*featureDim)
+	gradData := make([]float32, batch*featureDim)
+	for i := range inputData {
+		inputData[i] = float32(i+1) * 0.13
+		gradData[i] = float32(i%featureDim+1) * 0.017
+	}
+	newT := func(data []float32) *tensor.TensorNumeric[float32] {
+		tn, terr := tensor.New[float32](shape, append([]float32(nil), data...))
+		if terr != nil {
+			t.Fatalf("tensor.New: %v", terr)
+		}
+		return tn
+	}
+
+	inMixed, inOpt := newT(inputData), newT(inputData)
+	gMixed, gOpt := newT(gradData), newT(gradData)
+
+	if _, err := lnMixed.Forward(ctx, inMixed); err != nil {
+		t.Fatalf("Forward mixed: %v", err)
+	}
+	if _, err := lnOpt.Forward(ctx, inOpt); err != nil {
+		t.Fatalf("Forward option: %v", err)
+	}
+
+	prevGamma := lnOpt.gamma.Gradient
+	dMixed, err := lnMixed.Backward(ctx, types.FullBackprop, gMixed, inMixed)
+	if err != nil {
+		t.Fatalf("Backward mixed: %v", err)
+	}
+	dOpt, err := lnOpt.Backward(ctx, types.FullBackprop, gOpt, inOpt)
+	if err != nil {
+		t.Fatalf("Backward option: %v", err)
+	}
+
+	if lnOpt.gamma.Gradient == prevGamma {
+		t.Error("engine-backward option must ASSIGN a fresh gamma gradient tensor")
+	}
+	if lnOpt.beta.Gradient == nil {
+		t.Fatal("beta gradient not set")
+	}
+
+	const tol = 1e-4
+	for i := range dMixed[0].Data() {
+		diff := float64(dMixed[0].Data()[i]) - float64(dOpt[0].Data()[i])
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > tol {
+			t.Errorf("dInput[%d]: mixed=%v option=%v (diff %g)", i, dMixed[0].Data()[i], dOpt[0].Data()[i], diff)
+		}
+	}
+	for i := range lnMixed.gamma.Gradient.Data() {
+		diff := float64(lnMixed.gamma.Gradient.Data()[i]) - float64(lnOpt.gamma.Gradient.Data()[i])
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > tol {
+			t.Errorf("dGamma[%d]: mixed=%v option=%v (diff %g)", i, lnMixed.gamma.Gradient.Data()[i], lnOpt.gamma.Gradient.Data()[i], diff)
+		}
+	}
+}

--- a/training/capture_replay.go
+++ b/training/capture_replay.go
@@ -1,0 +1,195 @@
+// Package training: CUDA-graph capture-replay for repeated identical
+// training steps.
+package training
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// DisableCUDAGraphEnv is the environment variable that disables CUDA-graph
+// capture-replay when set to a non-empty value. It is read ONCE, at
+// NewCaptureReplayRunner time -- a debug toggle, not a hot-path read.
+const DisableCUDAGraphEnv = "ZERFOO_DISABLE_CUDA_GRAPH"
+
+// CaptureReplayRunner drives a per-step training loop (forward + loss +
+// backward + gradient accumulation) through CUDA-graph capture-replay on
+// engines that implement compute.GraphCapturer:
+//
+//	step 0 .. warmup-1 : normal eager walk (allocates persistent gradient
+//	                     accumulators, lazy engine workspaces, ...)
+//	step warmup        : the walk runs inside BeginCapture/EndCapture and
+//	                     is recorded into a CUDA graph, then the graph is
+//	                     launched once so the step actually executes
+//	step warmup+1 ..   : ReplayGraph only -- one graph launch replaces the
+//	                     entire per-step kernel-launch sequence
+//
+// Counters: CapturesPerformed increments once per capture (one per runner
+// when capture succeeds), ReplaysPerformed once per graph launch (including
+// the launch immediately after capture). For an N-step run the expected
+// steady state is CapturesPerformed == 1 and ReplaysPerformed == N-warmup.
+//
+// Contract (the caller owns all of these; violating any of them silently
+// corrupts training, because graph replay re-executes the recorded kernels
+// with the recorded device pointers):
+//
+//   - Stable operands: every tensor in batch (inputs and targets) must be
+//     the SAME tensor on every Step call. Per-step data is staged by
+//     copying into those tensors (engine.Copy / memcpy into device storage)
+//     BEFORE Step; the copies run outside the captured region.
+//   - Static shapes: the graph, loss node, and batch shapes must be
+//     identical on every Step.
+//   - Device-pure walk: every node Forward/Backward and the loss node must
+//     issue engine ops only -- no .Data() reads, no host math on tensor
+//     contents, no per-call host tensor creation feeding engine ops. Nodes
+//     that read tensor values on the host (e.g. loss nodes that compute the
+//     loss value on the CPU) cannot be captured.
+//   - No host-driven randomness: dropout masks or any host-RNG-dependent
+//     values are frozen at capture time. Capture-replay is only valid when
+//     such nodes are disabled.
+//   - Stable parameter/gradient storage: parameters must be device-resident
+//     with stable pointers (e.g. compute.WeightUploader), and the optimizer
+//     must update weights and zero gradients IN PLACE (never reallocate or
+//     repoint storage).
+//
+// The loss value returned by Step is read from the loss tensor recorded at
+// capture time, AFTER the graph has executed (ReplayGraph synchronizes the
+// stream), so it is exact for every step.
+type CaptureReplayRunner[T tensor.Numeric] struct {
+	strategy *DefaultBackpropStrategy[T]
+	gc       compute.GraphCapturer
+
+	enabled     bool
+	warmupSteps int
+	stepsSeen   uint64
+
+	captured   bool
+	handle     compute.GraphHandle
+	lossTensor *tensor.TensorNumeric[T]
+
+	capturesPerformed uint64
+	replaysPerformed  uint64
+}
+
+// NewCaptureReplayRunner constructs a CaptureReplayRunner around strategy
+// and engine. Capture is enabled only when the engine implements
+// compute.GraphCapturer and ZERFOO_DISABLE_CUDA_GRAPH is unset/empty (read
+// once, here). warmupSteps is the number of eager steps to run before
+// capturing; values < 1 are clamped to 1 (the first step must run eagerly
+// to allocate persistent gradient accumulators and lazy workspaces).
+//
+// When capture is disabled the runner is a transparent passthrough to
+// strategy.ComputeGradients and the counters stay at zero.
+func NewCaptureReplayRunner[T tensor.Numeric](
+	strategy *DefaultBackpropStrategy[T],
+	engine compute.Engine[T],
+	warmupSteps int,
+) *CaptureReplayRunner[T] {
+	if warmupSteps < 1 {
+		warmupSteps = 1
+	}
+	r := &CaptureReplayRunner[T]{
+		strategy:    strategy,
+		warmupSteps: warmupSteps,
+	}
+	gc, ok := engine.(compute.GraphCapturer)
+	if !ok {
+		return r
+	}
+	if os.Getenv(DisableCUDAGraphEnv) != "" {
+		return r
+	}
+	r.gc = gc
+	r.enabled = true
+	return r
+}
+
+// Enabled reports whether capture-replay is active (GraphCapturer engine
+// and not disabled via ZERFOO_DISABLE_CUDA_GRAPH).
+func (r *CaptureReplayRunner[T]) Enabled() bool { return r.enabled }
+
+// CapturesPerformed returns the number of CUDA-graph captures performed.
+func (r *CaptureReplayRunner[T]) CapturesPerformed() uint64 { return r.capturesPerformed }
+
+// ReplaysPerformed returns the number of CUDA-graph launches performed.
+func (r *CaptureReplayRunner[T]) ReplaysPerformed() uint64 { return r.replaysPerformed }
+
+// Step runs one training step. Depending on runner state this is an eager
+// walk (disabled or warmup), a capture (recording the walk into a CUDA
+// graph, then launching it once), or a replay (one graph launch).
+func (r *CaptureReplayRunner[T]) Step(
+	ctx context.Context,
+	g *graph.Graph[T],
+	loss graph.Node[T],
+	batch Batch[T],
+) (T, error) {
+	var zero T
+
+	if !r.enabled {
+		return r.strategy.ComputeGradients(ctx, g, loss, batch)
+	}
+
+	// Replay steady state: one graph launch re-executes the recorded
+	// forward + loss + backward + gradient accumulation. ReplayGraph
+	// synchronizes the stream, so the loss tensor holds this step's value.
+	if r.captured {
+		if err := r.gc.ReplayGraph(r.handle); err != nil {
+			return zero, fmt.Errorf("training: capture-replay: replay: %w", err)
+		}
+		r.replaysPerformed++
+		return r.lossTensor.Data()[0], nil
+	}
+
+	// Warmup: eager walks allocate the persistent gradient accumulators
+	// (issue #850) and any lazily-initialized engine workspaces so the
+	// capture region performs no foreign allocations.
+	if r.stepsSeen < uint64(r.warmupSteps) {
+		r.stepsSeen++
+		return r.strategy.ComputeGradients(ctx, g, loss, batch)
+	}
+
+	// Capture: record the walk into a CUDA graph. Stream capture RECORDS
+	// the kernels without executing them, so the loss readback must wait
+	// until the graph has launched.
+	if err := r.gc.BeginCapture(); err != nil {
+		return zero, fmt.Errorf("training: capture-replay: begin capture: %w", err)
+	}
+	lossTensor, walkErr := r.strategy.ComputeGradientsTensor(ctx, g, loss, batch)
+	handle, endErr := r.gc.EndCapture()
+	if walkErr != nil {
+		if endErr == nil {
+			_ = r.gc.DestroyGraph(handle)
+		}
+		return zero, fmt.Errorf("training: capture-replay: captured walk: %w", walkErr)
+	}
+	if endErr != nil {
+		return zero, fmt.Errorf("training: capture-replay: end capture: %w", endErr)
+	}
+	r.handle = handle
+	r.lossTensor = lossTensor
+	r.captured = true
+	r.capturesPerformed++
+
+	// The capture recorded this step but did not execute it: launch the
+	// graph once so step `warmup` actually happens.
+	if err := r.gc.ReplayGraph(r.handle); err != nil {
+		return zero, fmt.Errorf("training: capture-replay: post-capture launch: %w", err)
+	}
+	r.replaysPerformed++
+	return r.lossTensor.Data()[0], nil
+}
+
+// Close destroys the captured graph, if any. The runner must not be used
+// after Close.
+func (r *CaptureReplayRunner[T]) Close() error {
+	if !r.captured {
+		return nil
+	}
+	r.captured = false
+	return r.gc.DestroyGraph(r.handle)
+}

--- a/training/capture_replay_test.go
+++ b/training/capture_replay_test.go
@@ -1,0 +1,206 @@
+package training
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// fakeCaptureEngine wraps a real CPU engine (every compute op delegates to
+// it) and implements compute.GraphCapturer with instrumented stubs, so the
+// CaptureReplayRunner state machine can be exercised without CUDA hardware.
+type fakeCaptureEngine struct {
+	compute.Engine[float32]
+
+	beginCalls   int
+	endCalls     int
+	replayCalls  int
+	destroyCalls int
+
+	capturing bool
+}
+
+func newFakeCaptureEngine() *fakeCaptureEngine {
+	return &fakeCaptureEngine{
+		Engine: compute.NewCPUEngine[float32](numeric.Float32Ops{}),
+	}
+}
+
+func (f *fakeCaptureEngine) BeginCapture() error {
+	f.beginCalls++
+	f.capturing = true
+	return nil
+}
+
+func (f *fakeCaptureEngine) EndCapture() (compute.GraphHandle, error) {
+	f.endCalls++
+	f.capturing = false
+	return compute.GraphHandle{}, nil
+}
+
+func (f *fakeCaptureEngine) ReplayGraph(_ compute.GraphHandle) error {
+	f.replayCalls++
+	return nil
+}
+
+func (f *fakeCaptureEngine) DestroyGraph(_ compute.GraphHandle) error {
+	f.destroyCalls++
+	return nil
+}
+
+var _ compute.GraphCapturer = (*fakeCaptureEngine)(nil)
+
+// captureFixture builds a minimal trainable graph (the grad_accum bias
+// fixture without an arena) plus a stable batch, mirroring the runner's
+// stable-operand contract.
+func captureFixture(t *testing.T) (*graph.Graph[float32], graph.Node[float32], Batch[float32]) {
+	t.Helper()
+	g, in, _ := wolfHazardFixture(t, false, nil)
+	input, err := tensor.New([]int{2}, []float32{1, 1})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	targets, err := tensor.New([]int{2}, []float32{1, 10})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	return g, in, Batch[float32]{
+		Inputs:  map[graph.Node[float32]]*tensor.TensorNumeric[float32]{in: input},
+		Targets: targets,
+	}
+}
+
+// TestCaptureReplayRunner_CounterSchedule is the S9.1.1 acceptance test:
+// for an N-step run with W warmup steps, capturesPerformed must equal 1 and
+// replaysPerformed must equal N-W, with warmup steps counted in neither.
+func TestCaptureReplayRunner_CounterSchedule(t *testing.T) {
+	tests := []struct {
+		name         string
+		warmup       int
+		steps        int
+		wantCaptures uint64
+		wantReplays  uint64
+		wantBegin    int
+	}{
+		{name: "default warmup 1", warmup: 1, steps: 5, wantCaptures: 1, wantReplays: 4, wantBegin: 1},
+		{name: "warmup 2", warmup: 2, steps: 6, wantCaptures: 1, wantReplays: 4, wantBegin: 1},
+		{name: "warmup clamped from 0", warmup: 0, steps: 3, wantCaptures: 1, wantReplays: 2, wantBegin: 1},
+		{name: "all warmup no capture", warmup: 4, steps: 3, wantCaptures: 0, wantReplays: 0, wantBegin: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eng := newFakeCaptureEngine()
+			strategy := NewDefaultBackpropStrategy[float32]()
+			runner := NewCaptureReplayRunner(strategy, eng, tt.warmup)
+			if !runner.Enabled() {
+				t.Fatal("runner should be enabled with a GraphCapturer engine")
+			}
+
+			g, _, batch := captureFixture(t)
+			loss := &passthroughLoss{}
+			ctx := context.Background()
+			for i := 0; i < tt.steps; i++ {
+				if _, err := runner.Step(ctx, g, loss, batch); err != nil {
+					t.Fatalf("Step %d: %v", i, err)
+				}
+			}
+
+			if got := runner.CapturesPerformed(); got != tt.wantCaptures {
+				t.Errorf("CapturesPerformed = %d, want %d", got, tt.wantCaptures)
+			}
+			if got := runner.ReplaysPerformed(); got != tt.wantReplays {
+				t.Errorf("ReplaysPerformed = %d, want %d", got, tt.wantReplays)
+			}
+			if eng.beginCalls != tt.wantBegin {
+				t.Errorf("BeginCapture calls = %d, want %d", eng.beginCalls, tt.wantBegin)
+			}
+			if eng.endCalls != tt.wantBegin {
+				t.Errorf("EndCapture calls = %d, want %d", eng.endCalls, tt.wantBegin)
+			}
+			if uint64(eng.replayCalls) != tt.wantReplays {
+				t.Errorf("ReplayGraph calls = %d, want %d", eng.replayCalls, tt.wantReplays)
+			}
+			if eng.capturing {
+				t.Error("engine left in capturing state")
+			}
+		})
+	}
+}
+
+// TestCaptureReplayRunner_DisabledByEnv: ZERFOO_DISABLE_CUDA_GRAPH is a
+// construction-time toggle -- the runner becomes a passthrough and never
+// touches the capture API.
+func TestCaptureReplayRunner_DisabledByEnv(t *testing.T) {
+	t.Setenv(DisableCUDAGraphEnv, "1")
+
+	eng := newFakeCaptureEngine()
+	strategy := NewDefaultBackpropStrategy[float32]()
+	runner := NewCaptureReplayRunner(strategy, eng, 1)
+	if runner.Enabled() {
+		t.Fatal("runner must be disabled when ZERFOO_DISABLE_CUDA_GRAPH is set")
+	}
+
+	g, _, batch := captureFixture(t)
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if _, err := runner.Step(ctx, g, &passthroughLoss{}, batch); err != nil {
+			t.Fatalf("Step %d: %v", i, err)
+		}
+	}
+	if runner.CapturesPerformed() != 0 || runner.ReplaysPerformed() != 0 {
+		t.Errorf("counters = %d/%d, want 0/0 when disabled",
+			runner.CapturesPerformed(), runner.ReplaysPerformed())
+	}
+	if eng.beginCalls != 0 || eng.replayCalls != 0 {
+		t.Errorf("capture API touched while disabled: begin=%d replay=%d",
+			eng.beginCalls, eng.replayCalls)
+	}
+}
+
+// TestCaptureReplayRunner_NonCapturerEngine: a plain engine (no
+// GraphCapturer) yields a disabled passthrough runner.
+func TestCaptureReplayRunner_NonCapturerEngine(t *testing.T) {
+	cpu := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	strategy := NewDefaultBackpropStrategy[float32]()
+	runner := NewCaptureReplayRunner[float32](strategy, cpu, 1)
+	if runner.Enabled() {
+		t.Fatal("runner must be disabled for engines without GraphCapturer")
+	}
+
+	g, _, batch := captureFixture(t)
+	if _, err := runner.Step(context.Background(), g, &passthroughLoss{}, batch); err != nil {
+		t.Fatalf("Step: %v", err)
+	}
+	if runner.CapturesPerformed() != 0 || runner.ReplaysPerformed() != 0 {
+		t.Errorf("counters = %d/%d, want 0/0 for non-capturer engine",
+			runner.CapturesPerformed(), runner.ReplaysPerformed())
+	}
+}
+
+// TestCaptureReplayRunner_Close destroys the captured graph exactly once.
+func TestCaptureReplayRunner_Close(t *testing.T) {
+	eng := newFakeCaptureEngine()
+	strategy := NewDefaultBackpropStrategy[float32]()
+	runner := NewCaptureReplayRunner(strategy, eng, 1)
+
+	g, _, batch := captureFixture(t)
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if _, err := runner.Step(ctx, g, &passthroughLoss{}, batch); err != nil {
+			t.Fatalf("Step %d: %v", i, err)
+		}
+	}
+	if err := runner.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := runner.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if eng.destroyCalls != 1 {
+		t.Errorf("DestroyGraph calls = %d, want 1 (Close must be idempotent)", eng.destroyCalls)
+	}
+}

--- a/training/loss/cross_entropy_one_hot.go
+++ b/training/loss/cross_entropy_one_hot.go
@@ -1,0 +1,193 @@
+package loss
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// logFloor is added to the softmax probabilities before the Log so a class
+// probability that underflows to exactly 0 in the element type produces a
+// large-but-finite negative log instead of -Inf. For float32 the smallest
+// normal is ~1.18e-38, so log(p+1e-40) differs from log(p) only when p is
+// already far below any numerically meaningful probability.
+const logFloor = 1e-40
+
+// CrossEntropyLossOneHot computes the mean cross-entropy loss against
+// one-hot (or soft) target distributions using engine ops only.
+//
+// Unlike CrossEntropyLoss, which computes the loss value on the host in
+// float64 (reading the logits back mid-step) and converts the integer
+// targets on the host each call, every Forward/Backward operation here is
+// an engine op on the input tensors. This makes the node usable inside a
+// CUDA-graph capture region (compute.GraphCapturer): no .Data() reads, no
+// host-side math, no per-call host tensor conversions. See
+// training.CaptureReplayRunner.
+//
+// Inputs: predictions (logits, shape [..., C]) and targets as a
+// PRE-ENCODED one-hot tensor of the same shape [..., C]. Callers that hold
+// integer labels encode them once up front (and, on GPU engines, upload
+// them once) instead of per step.
+//
+// Gradient semantics are identical to CrossEntropyLoss.Backward:
+// dL/dlogits = (softmax(logits) - onehot) / positions * dOut, where
+// positions is the number of class distributions (total elements / C).
+// The loss VALUE is computed as -mean(sum(onehot * log(softmax + floor)))
+// in the element type T, which matches CrossEntropyLoss's host-float64
+// fused log-softmax up to rounding in T.
+type CrossEntropyLossOneHot[T tensor.Numeric] struct {
+	engine compute.Engine[T]
+
+	// Cached tensors for backward.
+	softmaxOutput *tensor.TensorNumeric[T]
+	onehot        *tensor.TensorNumeric[T]
+	outputShape   []int
+}
+
+// NewCrossEntropyLossOneHot creates a CrossEntropyLossOneHot node.
+func NewCrossEntropyLossOneHot[T tensor.Numeric](engine compute.Engine[T]) *CrossEntropyLossOneHot[T] {
+	return &CrossEntropyLossOneHot[T]{engine: engine}
+}
+
+// OutputShape returns the output shape of the loss (a scalar, [1]).
+func (cel *CrossEntropyLossOneHot[T]) OutputShape() []int {
+	return cel.outputShape
+}
+
+// Parameters returns nil: the loss has no trainable parameters.
+func (cel *CrossEntropyLossOneHot[T]) Parameters() []*graph.Parameter[T] {
+	return nil
+}
+
+// Forward computes the mean cross-entropy loss from logits and one-hot
+// targets via engine ops only.
+func (cel *CrossEntropyLossOneHot[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	if len(inputs) != 2 {
+		return nil, fmt.Errorf("CrossEntropyLossOneHot expects 2 inputs (logits, onehot), got %d", len(inputs))
+	}
+	predictions := inputs[0]
+	onehot := inputs[1]
+
+	pShape := predictions.Shape()
+	if !tensor.ShapesEqual(pShape, onehot.Shape()) {
+		return nil, fmt.Errorf("CrossEntropyLossOneHot: logits shape %v != one-hot targets shape %v",
+			pShape, onehot.Shape())
+	}
+	if len(pShape) == 0 {
+		return nil, fmt.Errorf("CrossEntropyLossOneHot: logits must have at least 1 dimension")
+	}
+	classes := pShape[len(pShape)-1]
+	if classes <= 0 {
+		return nil, fmt.Errorf("CrossEntropyLossOneHot: class dimension must be positive, got %d", classes)
+	}
+	positions := 1
+	for _, d := range pShape[:len(pShape)-1] {
+		positions *= d
+	}
+	if positions <= 0 {
+		return nil, fmt.Errorf("CrossEntropyLossOneHot: no class distributions in shape %v", pShape)
+	}
+
+	cel.outputShape = []int{1}
+	cel.onehot = onehot
+
+	// Numerically stable softmax (engine kernels subtract the row max).
+	softmaxOutput, err := cel.engine.Softmax(ctx, predictions, len(pShape)-1, nil)
+	if err != nil {
+		return nil, err
+	}
+	cel.softmaxOutput = softmaxOutput
+
+	// log(softmax + floor): the floor keeps a fully-saturated wrong class
+	// finite. See logFloor.
+	ops := cel.engine.Ops()
+	safe, err := cel.engine.AddScalar(ctx, softmaxOutput, ops.FromFloat64(logFloor))
+	if err != nil {
+		return nil, err
+	}
+	logProbs, err := cel.engine.Log(ctx, safe)
+	if err != nil {
+		return nil, err
+	}
+
+	// Pick out the target log-probs and reduce to a scalar:
+	// sum(onehot * logProbs) over every axis, highest to lowest.
+	picked, err := cel.engine.Mul(ctx, logProbs, onehot)
+	if err != nil {
+		return nil, err
+	}
+	total := picked
+	for axis := len(pShape) - 1; axis >= 0; axis-- {
+		total, err = cel.engine.ReduceSum(ctx, total, axis, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// loss = -(1/positions) * total, as a [1] tensor.
+	loss, err := cel.engine.MulScalar(ctx, total, ops.FromFloat64(-1.0/float64(positions)))
+	if err != nil {
+		return nil, err
+	}
+	if len(loss.Shape()) != 1 || loss.Shape()[0] != 1 {
+		loss, err = cel.engine.Reshape(ctx, loss, []int{1})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return loss, nil
+}
+
+// Backward computes dL/dlogits = (softmax - onehot) / positions * dOut.
+// The one-hot targets receive no gradient.
+func (cel *CrossEntropyLossOneHot[T]) Backward(ctx context.Context, _ types.BackwardMode, dOut *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	if cel.softmaxOutput == nil || cel.onehot == nil {
+		return nil, fmt.Errorf("CrossEntropyLossOneHot: Backward called before Forward")
+	}
+	sShape := cel.softmaxOutput.Shape()
+	classes := sShape[len(sShape)-1]
+	positions := 1
+	for _, d := range sShape[:len(sShape)-1] {
+		positions *= d
+	}
+	_ = classes
+
+	grad, err := cel.engine.Sub(ctx, cel.softmaxOutput, cel.onehot, nil)
+	if err != nil {
+		return nil, err
+	}
+	invN := cel.engine.Ops().FromFloat64(1.0 / float64(positions))
+	grad, err = cel.engine.MulScalar(ctx, grad, invN)
+	if err != nil {
+		return nil, err
+	}
+	// Scale by upstream gradient (usually the [1] loss seed); broadcasts.
+	final, err := cel.engine.Mul(ctx, grad, dOut, nil)
+	if err != nil {
+		return nil, err
+	}
+	return []*tensor.TensorNumeric[T]{final, nil}, nil
+}
+
+// SoftmaxOutput returns the cached softmax output from the most recent
+// Forward call.
+func (cel *CrossEntropyLossOneHot[T]) SoftmaxOutput() *tensor.TensorNumeric[T] {
+	return cel.softmaxOutput
+}
+
+// OpType returns the operation type of the loss node.
+func (cel *CrossEntropyLossOneHot[T]) OpType() string {
+	return "CrossEntropyLossOneHot"
+}
+
+// Attributes returns nil: the loss has no serializable attributes.
+func (cel *CrossEntropyLossOneHot[T]) Attributes() map[string]interface{} {
+	return nil
+}
+
+// Statically assert that the type implements the graph.Node interface.
+var _ graph.Node[float32] = (*CrossEntropyLossOneHot[float32])(nil)

--- a/training/loss/cross_entropy_one_hot_test.go
+++ b/training/loss/cross_entropy_one_hot_test.go
@@ -1,0 +1,181 @@
+package loss
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// oneHotEncode builds the [positions, classes] one-hot float encoding of
+// integer labels, the caller-side preparation CrossEntropyLossOneHot expects.
+func oneHotEncode(t *testing.T, labels []int, classes int) *tensor.TensorNumeric[float32] {
+	t.Helper()
+	data := make([]float32, len(labels)*classes)
+	for i, l := range labels {
+		data[i*classes+l] = 1
+	}
+	oh, err := tensor.New([]int{len(labels), classes}, data)
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	return oh
+}
+
+// TestCrossEntropyLossOneHot_MatchesCrossEntropyLoss: the device-op loss
+// must reproduce the host-float64 CrossEntropyLoss: identical gradients
+// (same Sub/MulScalar/Mul chain over the same softmax) and a loss value
+// equal up to element-type rounding.
+func TestCrossEntropyLossOneHot_MatchesCrossEntropyLoss(t *testing.T) {
+	tests := []struct {
+		name   string
+		shape  []int
+		logits []float32
+		labels []int
+	}{
+		{
+			name:   "wolf shape 4x3",
+			shape:  []int{4, 3},
+			logits: []float32{2, -1, 0.5, -3, 4, 0, 0.1, 0.1, 0.1, -2, -2, 5},
+			labels: []int{0, 1, 2, 2},
+		},
+		{
+			name:   "skewed logits",
+			shape:  []int{2, 3},
+			logits: []float32{30, -30, 0, -25, 25, 1},
+			labels: []int{2, 0},
+		},
+		{
+			name:   "single position",
+			shape:  []int{1, 3},
+			logits: []float32{0.3, 0.2, 0.5},
+			labels: []int{1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+			preds, err := tensor.New(tt.shape, tt.logits)
+			if err != nil {
+				t.Fatalf("tensor.New: %v", err)
+			}
+			intTargets := make([]float32, len(tt.labels))
+			for i, l := range tt.labels {
+				intTargets[i] = float32(l)
+			}
+			labelT, err := tensor.New([]int{len(tt.labels)}, intTargets)
+			if err != nil {
+				t.Fatalf("tensor.New: %v", err)
+			}
+			onehot := oneHotEncode(t, tt.labels, tt.shape[1])
+
+			ref := NewCrossEntropyLoss[float32](engine)
+			refLoss, err := ref.Forward(ctx, preds, labelT)
+			if err != nil {
+				t.Fatalf("reference Forward: %v", err)
+			}
+
+			oh := NewCrossEntropyLossOneHot[float32](engine)
+			gotLoss, err := oh.Forward(ctx, preds, onehot)
+			if err != nil {
+				t.Fatalf("one-hot Forward: %v", err)
+			}
+			if got := gotLoss.Shape(); len(got) != 1 || got[0] != 1 {
+				t.Fatalf("loss shape = %v, want [1]", got)
+			}
+
+			refVal := float64(refLoss.Data()[0])
+			gotVal := float64(gotLoss.Data()[0])
+			if math.Abs(refVal-gotVal) > 1e-5*math.Max(1, math.Abs(refVal)) {
+				t.Errorf("loss = %v, reference = %v", gotVal, refVal)
+			}
+
+			// Backward parity with the SAME upstream gradient (the strategy
+			// passes the loss tensor itself as dOut).
+			refGrads, err := ref.Backward(ctx, types.FullBackprop, refLoss)
+			if err != nil {
+				t.Fatalf("reference Backward: %v", err)
+			}
+			gotGrads, err := oh.Backward(ctx, types.FullBackprop, refLoss)
+			if err != nil {
+				t.Fatalf("one-hot Backward: %v", err)
+			}
+			if len(gotGrads) != 2 || gotGrads[1] != nil {
+				t.Fatalf("Backward must return [grad, nil], got %d grads", len(gotGrads))
+			}
+			refG := refGrads[0].Data()
+			gotG := gotGrads[0].Data()
+			if len(refG) != len(gotG) {
+				t.Fatalf("grad length %d != reference %d", len(gotG), len(refG))
+			}
+			for i := range refG {
+				if diff := math.Abs(float64(refG[i] - gotG[i])); diff > 1e-7 {
+					t.Errorf("grad[%d] = %v, reference %v (diff %g)", i, gotG[i], refG[i], diff)
+				}
+			}
+		})
+	}
+}
+
+// TestCrossEntropyLossOneHot_SaturatedClassStaysFinite: a class probability
+// that underflows to zero must produce a finite loss (the logFloor guard),
+// never -Inf/NaN -- the failure mode that motivated the host-float64 fused
+// log-softmax in CrossEntropyLoss.
+func TestCrossEntropyLossOneHot_SaturatedClassStaysFinite(t *testing.T) {
+	ctx := context.Background()
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+
+	// Target class logit is ~200 below the max: softmax(target) underflows
+	// to exactly 0 in float32.
+	preds, err := tensor.New([]int{1, 3}, []float32{200, 0, 0})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	onehot := oneHotEncode(t, []int{1}, 3)
+
+	oh := NewCrossEntropyLossOneHot[float32](engine)
+	lossT, err := oh.Forward(ctx, preds, onehot)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	v := float64(lossT.Data()[0])
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		t.Fatalf("loss = %v, want finite (logFloor guard)", v)
+	}
+	if v <= 0 {
+		t.Fatalf("loss = %v, want large positive", v)
+	}
+}
+
+// TestCrossEntropyLossOneHot_InputValidation rejects malformed inputs.
+func TestCrossEntropyLossOneHot_InputValidation(t *testing.T) {
+	ctx := context.Background()
+	engine := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	oh := NewCrossEntropyLossOneHot[float32](engine)
+
+	preds, err := tensor.New([]int{2, 3}, []float32{1, 2, 3, 4, 5, 6})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+	badTargets, err := tensor.New([]int{2, 2}, []float32{1, 0, 0, 1})
+	if err != nil {
+		t.Fatalf("tensor.New: %v", err)
+	}
+
+	if _, err := oh.Forward(ctx, preds); err == nil {
+		t.Error("Forward with 1 input must fail")
+	}
+	if _, err := oh.Forward(ctx, preds, badTargets); err == nil {
+		t.Error("Forward with mismatched target shape must fail")
+	}
+	if _, err := oh.Backward(ctx, types.FullBackprop, nil); err == nil {
+		t.Error("Backward before Forward must fail")
+	}
+}

--- a/training/strategy_backprop.go
+++ b/training/strategy_backprop.go
@@ -49,5 +49,21 @@ func (s *DefaultBackpropStrategy[T]) ComputeGradients(
 	return computeGradientsCommon[T](ctx, g, loss, batch, types.FullBackprop, &s.grads)
 }
 
+// ComputeGradientsTensor is ComputeGradients without the final host
+// readback of the loss value: it returns the loss tensor produced by the
+// loss node. On GPU engines the readback is a D2H copy, which is illegal
+// inside a CUDA-graph capture region; CaptureReplayRunner records the step
+// through this variant and reads the loss only after the captured graph
+// has executed. Callers outside a capture region can read the value with
+// lossTensor.Data()[0].
+func (s *DefaultBackpropStrategy[T]) ComputeGradientsTensor(
+	ctx context.Context,
+	g *graph.Graph[T],
+	loss graph.Node[T],
+	batch Batch[T],
+) (*tensor.TensorNumeric[T], error) {
+	return computeGradientsTensorCommon[T](ctx, g, loss, batch, types.FullBackprop, &s.grads)
+}
+
 // Statically assert that the type implements the GradientStrategy interface.
 var _ GradientStrategy[float32] = (*DefaultBackpropStrategy[float32])(nil)

--- a/training/strategy_common.go
+++ b/training/strategy_common.go
@@ -25,6 +25,27 @@ func computeGradientsCommon[T tensor.Numeric](
 	acc *gradAccumulator[T],
 ) (T, error) {
 	var zero T
+	lossTensor, err := computeGradientsTensorCommon(ctx, g, loss, batch, mode, acc)
+	if err != nil {
+		return zero, err
+	}
+	return lossTensor.Data()[0], nil
+}
+
+// computeGradientsTensorCommon is computeGradientsCommon without the final
+// host readback of the loss value: it returns the loss TENSOR produced by
+// the loss node instead of loss.Data()[0]. On a GPU engine the readback is
+// a device-to-host copy, which is illegal inside a CUDA-graph capture
+// region; CaptureReplayRunner uses this variant during capture and defers
+// the read until after the captured graph has actually executed.
+func computeGradientsTensorCommon[T tensor.Numeric](
+	ctx context.Context,
+	g *graph.Graph[T],
+	loss graph.Node[T],
+	batch Batch[T],
+	mode types.BackwardMode,
+	acc *gradAccumulator[T],
+) (*tensor.TensorNumeric[T], error) {
 	// Materialize inputs in graph input order
 	var inputSlice []*tensor.TensorNumeric[T]
 	for _, inputNode := range g.Inputs() {
@@ -34,38 +55,36 @@ func computeGradientsCommon[T tensor.Numeric](
 	// Forward pass
 	output, err := g.Forward(ctx, inputSlice...)
 	if err != nil {
-		return zero, fmt.Errorf("forward pass failed: %w", err)
+		return nil, fmt.Errorf("forward pass failed: %w", err)
 	}
 
 	// Loss forward
 	lossTensor, err := loss.Forward(ctx, output, batch.Targets)
 	if err != nil {
-		return zero, fmt.Errorf("loss computation failed: %w", err)
+		return nil, fmt.Errorf("loss computation failed: %w", err)
 	}
 
 	// Loss backward
 	lossGrads, err := loss.Backward(ctx, mode, lossTensor, output, batch.Targets)
 	if err != nil {
-		return zero, fmt.Errorf("loss backward pass failed: %w", err)
+		return nil, fmt.Errorf("loss backward pass failed: %w", err)
 	}
 
 	// Model backward
 	if err := g.Backward(ctx, mode, lossGrads[0]); err != nil {
-		return zero, fmt.Errorf("model backward pass failed: %w", err)
+		return nil, fmt.Errorf("model backward pass failed: %w", err)
 	}
 
 	// Migrate arena-backed parameter gradients to persistent buffers BEFORE
 	// any tensor release / arena reset can recycle them (issue #850).
 	if acc != nil {
 		if err := acc.capture(ctx, g); err != nil {
-			return zero, fmt.Errorf("persistent gradient accumulation failed: %w", err)
+			return nil, fmt.Errorf("persistent gradient accumulation failed: %w", err)
 		}
 	}
-
-	lossVal := lossTensor.Data()[0]
 
 	// Release intermediate tensors to free GPU memory between training steps.
 	g.ClearMemo()
 
-	return lossVal, nil
+	return lossTensor, nil
 }


### PR DESCRIPTION
## Summary

Three general mechanisms that make repeated identical training steps capturable into a CUDA graph on engines implementing `compute.GraphCapturer` (first consumer: Wolf CrossAsset capture-once-per-fold, wolf T9.1):

- **`training.CaptureReplayRunner`** — warmup -> capture -> replay state machine around `DefaultBackpropStrategy`, with `capturesPerformed`/`replaysPerformed` counters as first-class evidence (nsys cuda-trace is not usable on capture-on GB10 runs). `ZERFOO_DISABLE_CUDA_GRAPH` is read once at construction — a CI-gatable debug toggle, not a hot-path env read. The doc comment spells out the caller contract (stable batch tensors, static shapes, device-pure walk, no host RNG, in-place optimizer).
- **`DefaultBackpropStrategy.ComputeGradientsTensor`** — the existing walk minus the final host loss readback (`lossTensor.Data()[0]` is a D2H copy, illegal inside stream capture). `ComputeGradients` now delegates to the same common path and reads the value at the end; behavior unchanged.
- **`loss.CrossEntropyLossOneHot`** — engine-ops-only cross-entropy against pre-encoded one-hot targets. The existing `CrossEntropyLoss` computes the loss value on the host in float64 (reading logits back mid-step) and converts int targets on the host per call — both capture-incompatible. Gradient semantics are identical (`(softmax - onehot)/positions * dOut`); the loss value is computed in T via stable engine softmax + log floor.
- **`core.Concat.Backward`** — equal-split fast path via `engine.Split` (device-resident, capture-safe); the generic host re-slice remains for unequal splits.

## Why

The Wolf CrossAsset per-sample training walk could not capture: five host-compute/D2H interleavings (host-f64 CE loss, per-step loss readback, host Concat backward, host scalar reads, distinct per-sample input pointers). These are framework-level gaps, fixed here at the contract level; Wolf-side consumption (QK-temp device path, stable input staging) ships separately in wolf.

## Testing

- `training`: runner counter-schedule table tests (captures==1, replays==N-warmup), env-disable, non-capturer passthrough, idempotent Close — via a fake GraphCapturer over the real CPU engine.
- `training/loss`: one-hot CE vs reference CrossEntropyLoss parity (loss to 1e-5, grads to 1e-7), saturated-class finiteness (log floor), input validation.
- `layers/core`: equal-split backward parity tests; existing unequal-split tests still cover the host path.
- Full `go test ./...` green, `-race` green on touched packages, `golangci-lint --new-from-rev origin/main` clean.
- GB10 in-situ validation runs in wolf (capture probe + matched bench); results recorded in the wolf PR/devlog.