### PR TITLE
fix(training): seed loss.Backward with 1.0, not the loss value (#872)

### DIFF
--- a/training/gradcheck_loss_seed_test.go
+++ b/training/gradcheck_loss_seed_test.go
@@ -1,0 +1,176 @@
+package training
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	core "github.com/zerfoo/zerfoo/layers/core"
+	"github.com/zerfoo/zerfoo/training/loss"
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// TestGradcheckLossSeed is the regression gate for issue #872.
+//
+// The single shared gradient call site (computeGradientsTensorCommon) must
+// seed loss.Backward with d(loss)/d(loss) = 1, NOT the scalar loss value L.
+// Loss layers end Backward with grad = localGrad * dOut, so seeding dOut with
+// L scales every parameter gradient by L: the analytic gradient becomes
+// L * dL/dparam (the gradient of (1/2)L^2) instead of dL/dparam.
+//
+// This finite-difference check builds a tiny Linear -> CrossEntropyLoss graph,
+// reads the analytic per-parameter gradient produced by the strategy, then
+// estimates dL/dparam by central differences. With the correct 1.0 seed the
+// two agree to fd tolerance; under the old L-seed they differ by a factor of
+// ~L, which this test detects and reports.
+//
+// It runs for both CrossEntropyLoss and MSE (both multiply by dOut), and for
+// each it asserts the analytic/numeric ratio is ~1, NOT ~L. On origin/main the
+// ratio is ~L for every parameter; with the fix it is ~1.
+func TestGradcheckLossSeed(t *testing.T) {
+	const (
+		eps = 1e-4
+		tol = 2e-3 // central-difference accuracy on float64 for this graph
+	)
+
+	tests := []struct {
+		name    string
+		newLoss func(compute.Engine[float64]) graph.Node[float64]
+		// targets fed to the loss; for CE these are class indices, for MSE
+		// they are regression targets matched to the output shape.
+		targets []float64
+		tShape  []int
+	}{
+		{
+			name: "cross_entropy",
+			newLoss: func(e compute.Engine[float64]) graph.Node[float64] {
+				return loss.NewCrossEntropyLoss[float64](e)
+			},
+			targets: []float64{2, 0}, // class indices for 2 samples
+			tShape:  []int{2},
+		},
+		{
+			name: "mse",
+			newLoss: func(e compute.Engine[float64]) graph.Node[float64] {
+				return loss.NewMSE[float64](e, numeric.Float64Ops{})
+			},
+			targets: []float64{0.1, -0.2, 0.3, 0.4, -0.5, 0.6}, // 2x3 regression targets
+			tShape:  []int{2, 3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := numeric.Float64Ops{}
+			engine := compute.NewCPUEngine[float64](ops)
+
+			// Tiny graph: Input[2,4] -> Linear(4->3) -> logits[2,3].
+			const (
+				batch = 2
+				in    = 4
+				out   = 3
+			)
+			lin, err := core.NewLinear[float64]("lin", engine, ops, in, out)
+			if err != nil {
+				t.Fatalf("NewLinear: %v", err)
+			}
+			// Deterministic, well-conditioned weights.
+			w := lin.Parameters()[0]
+			wd := w.Value.Data()
+			for i := range wd {
+				wd[i] = 0.05 * float64(i+1)
+			}
+
+			b := graph.NewBuilder[float64](engine)
+			inNode := b.Input([]int{batch, in})
+			b.AddNode(lin, inNode)
+			g, err := b.Build(lin)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+
+			lossNode := tt.newLoss(engine)
+
+			inputData := make([]float64, batch*in)
+			for i := range inputData {
+				inputData[i] = 0.1*float64(i) - 0.3
+			}
+			input, err := tensor.New[float64]([]int{batch, in}, inputData)
+			if err != nil {
+				t.Fatalf("input tensor: %v", err)
+			}
+			targets, err := tensor.New[float64](tt.tShape, tt.targets)
+			if err != nil {
+				t.Fatalf("targets tensor: %v", err)
+			}
+			batchData := Batch[float64]{
+				Inputs:  map[graph.Node[float64]]*tensor.TensorNumeric[float64]{inNode: input},
+				Targets: targets,
+			}
+
+			ctx := context.Background()
+
+			// scalarLoss recomputes the loss value for the current weights.
+			scalarLoss := func() float64 {
+				output, ferr := g.Forward(ctx, input)
+				if ferr != nil {
+					t.Fatalf("forward: %v", ferr)
+				}
+				lt, lerr := lossNode.Forward(ctx, output, targets)
+				if lerr != nil {
+					t.Fatalf("loss forward: %v", lerr)
+				}
+				v := lt.Data()[0]
+				g.ClearMemo()
+				return v
+			}
+
+			// Analytic gradient from the strategy (the code under test).
+			strategy := NewDefaultBackpropStrategy[float64]()
+			w.ClearGradient()
+			lossVal, err := strategy.ComputeGradients(ctx, g, lossNode, batchData)
+			if err != nil {
+				t.Fatalf("ComputeGradients: %v", err)
+			}
+			analytic := append([]float64(nil), w.Gradient.Data()...)
+
+			if lossVal <= 0 || math.Abs(lossVal-1) < 1e-6 {
+				// The whole point is L != 1, so that an L-seed is distinguishable
+				// from a 1-seed. Guard the fixture against an accidental L≈1.
+				t.Logf("loss value L = %g (L must differ from 1 for this test to discriminate)", lossVal)
+			}
+
+			// Numeric gradient by central finite differences.
+			maxRatioErr := 0.0
+			worstIdx := -1
+			for i := range wd {
+				orig := wd[i]
+
+				wd[i] = orig + eps
+				lp := scalarLoss()
+
+				wd[i] = orig - eps
+				lm := scalarLoss()
+
+				wd[i] = orig
+
+				numGrad := (lp - lm) / (2 * eps)
+				diff := math.Abs(analytic[i] - numGrad)
+				denom := math.Max(1e-8, math.Abs(numGrad))
+				if rel := diff / denom; rel > maxRatioErr {
+					maxRatioErr = rel
+					worstIdx = i
+				}
+
+				if diff > tol+tol*math.Abs(numGrad) {
+					t.Errorf("param[%d]: analytic=%.8f numeric=%.8f diff=%.3e (ratio analytic/numeric=%.4f, L=%.4f) -- a ratio ~L means loss.Backward was seeded with the loss value, not 1.0 (#872)",
+						i, analytic[i], numGrad, diff, analytic[i]/numGrad, lossVal)
+				}
+			}
+			t.Logf("%s: L=%.6f, max relative grad error=%.3e at param[%d] (tol=%.1e)", tt.name, lossVal, maxRatioErr, worstIdx, tol)
+		})
+	}
+}

--- a/training/strategy_common.go
+++ b/training/strategy_common.go
@@ -4,10 +4,78 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
 	"github.com/zerfoo/ztensor/types"
 )
+
+// onesLike builds a host-backed tensor of ones with the same shape as ref,
+// used as the d(loss)/d(loss) = 1 seed for loss.Backward (issue #872).
+//
+// The element value 1 is produced via the type's arithmetic ops so it is
+// correct for every supported numeric type (float32/64, minifloats, ints).
+// When the graph carries an engine (the production path) its ops are used;
+// some graphs are built with a nil engine (e.g. parameter-fixture tests), in
+// which case onesValue derives 1 from the type directly so the seed never
+// depends on an engine being wired in.
+//
+// The seed is deliberately a plain host tensor: the loss layers consume it
+// only through engine.Mul(localGrad, dOut), which already accepts the
+// host-backed scalar tensor that loss.Forward produces, so this preserves the
+// existing storage contract while flipping the value from L to 1.
+func onesLike[T tensor.Numeric](engine compute.Engine[T], ref *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	shape := ref.Shape()
+	n := 1
+	for _, d := range shape {
+		n *= d
+	}
+	one, err := onesValue[T](engine)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]T, n)
+	for i := range data {
+		data[i] = one
+	}
+	return tensor.New[T](shape, data)
+}
+
+// onesValue returns the value 1 of type T. It prefers the engine's arithmetic
+// ops (the only general source of 1 for minifloat types) and falls back to a
+// per-type literal for the built-in numeric kinds when no engine is available.
+func onesValue[T tensor.Numeric](engine compute.Engine[T]) (T, error) {
+	if engine != nil {
+		return engine.Ops().FromFloat64(1.0), nil
+	}
+	var zero T
+	switch any(zero).(type) {
+	case float32:
+		return any(float32(1)).(T), nil
+	case float64:
+		return any(float64(1)).(T), nil
+	case int:
+		return any(int(1)).(T), nil
+	case int8:
+		return any(int8(1)).(T), nil
+	case int16:
+		return any(int16(1)).(T), nil
+	case int32:
+		return any(int32(1)).(T), nil
+	case int64:
+		return any(int64(1)).(T), nil
+	case uint:
+		return any(uint(1)).(T), nil
+	case uint8:
+		return any(uint8(1)).(T), nil
+	case uint32:
+		return any(uint32(1)).(T), nil
+	case uint64:
+		return any(uint64(1)).(T), nil
+	default:
+		return zero, fmt.Errorf("training: cannot seed loss backward for type %T without an engine; build the graph with an engine so its ops can produce a unit seed", zero)
+	}
+}
 
 // computeGradientsCommon consolidates the shared logic between training strategies.
 //
@@ -64,8 +132,21 @@ func computeGradientsTensorCommon[T tensor.Numeric](
 		return nil, fmt.Errorf("loss computation failed: %w", err)
 	}
 
-	// Loss backward
-	lossGrads, err := loss.Backward(ctx, mode, lossTensor, output, batch.Targets)
+	// Loss backward.
+	//
+	// The upstream-gradient SEED handed to loss.Backward is d(loss)/d(loss) = 1,
+	// NOT the loss value. Loss layers (cross-entropy, MSE, BCE, ...) end their
+	// Backward with grad = local_grad * dOut (engine.Mul broadcasts dOut over
+	// the local gradient). Seeding dOut with the scalar loss value L would scale
+	// every model gradient by L, i.e. compute L * dL/dparams = the gradient of
+	// (1/2)L^2 -- a different objective with a loss-dependent effective learning
+	// rate (issue #872). A ones tensor matching the loss shape ([1] for the
+	// scalar loss) broadcasts correctly through that final Mul.
+	ones, err := onesLike[T](g.Engine(), lossTensor)
+	if err != nil {
+		return nil, fmt.Errorf("seeding loss backward failed: %w", err)
+	}
+	lossGrads, err := loss.Backward(ctx, mode, ones, output, batch.Targets)
 	if err != nil {
 		return nil, fmt.Errorf("loss backward pass failed: %w", err)
 	}


### PR DESCRIPTION
## The bug

The single shared gradient call site `computeGradientsCommon` /
`computeGradientsTensorCommon` in `training/strategy_common.go` (used by
**every** training strategy) passed `lossTensor` — the **scalar loss value L**
returned by `loss.Forward` — as the `dOut` upstream-gradient seed to
`loss.Backward`.

Every loss layer (`CrossEntropyLoss`, `CrossEntropyLossOneHot`, `MSE`, `BCE`, …)
ends its `Backward` with `grad = local_grad * dOut` (`engine.Mul`, broadcasts).
Their own comments note dOut is "usually 1.0 for loss". Standard backprop seeds
`d(loss)/d(loss) = 1` to compute `dL/dparams`; seeding with `L` instead computes
`L * dL/dparams` — the gradient of `(1/2)L²`, a *different* objective with a
loss-dependent effective learning rate. Present since `4cc38c61` (2025-08-25).
It affects MSE, BCE, and any loss whose `Backward` multiplies by `dOut`, not just
cross-entropy.

## Root cause (one line)

`training/strategy_common.go:68` (old) — `loss.Backward(ctx, mode, lossTensor, …)`
passes the loss **value** where the **seed** `1.0` belongs.

## The fix

Seed `loss.Backward` with a **ones tensor** matching the loss shape (`[1]` for
the scalar loss; broadcasts correctly through the losses' final
`engine.Mul(grad, dOut)`), representing `d(loss)/d(loss) = 1`. The loss
`Backward` implementations are **unchanged** — multiplying by `dOut` is correct
*layer* behavior; the defect was the strategy passing the wrong seed.

A new `onesValue` helper derives the unit seed from the graph engine's ops when
present, with a per-type fallback for engine-less graphs (parameter fixtures), so
the seed never depends on an engine being wired in.

Confirmed `grep -rn "loss.Backward(ctx" training/` returns **only** this one call
site.

## The gate: finite-difference gradcheck (before/after)

New `training/gradcheck_loss_seed_test.go` builds a tiny `Linear -> loss` graph,
reads the analytic per-parameter gradient from `DefaultBackpropStrategy`, and
compares it to a central finite-difference estimate of `dL/dparam`. Proven both
directions on the fixture:

| loss | seed | analytic/numeric ratio | max rel error | result |
|------|------|------------------------|---------------|--------|
| CrossEntropy | **L (origin/main)** | **1.1392 = L** | 1.4e-1 | **FAILS** |
| CrossEntropy | **1.0 (fixed)** | 1.0000 | 3.0e-8 | **PASSES** |
| MSE | **L (origin/main)** | **0.1800 = L** | 8.2e-1 | **FAILS** |
| MSE | **1.0 (fixed)** | 1.0000 | 6.1e-10 | **PASSES** |

The analytic gradient is scaled by *exactly* L under the bug; the fix restores
the agreement with the numeric gradient.

## Existing tests updated

**None.** No existing test hard-coded an L-seeded gradient. The
`passthroughLoss` used by the `grad_accum` / `capture_replay` strategy tests
ignores the `dOut` seed entirely (returns the targets tensor directly), so those
tests are insensitive to the seed value and continue to pass unchanged.

## Validation

- Tier 0: `go build ./...`, `go vet ./...`, `golangci-lint run` — clean for the
  changed files (pre-existing lint warnings exist only in unrelated files).
- Tier 1: `go test ./...` — **all 126 packages pass**. Under `-race`, the only
  failure is `timeseries/TestAllBackends_CPUTrainingBenchmark`, a wall-clock
  **performance-budget** flake (33.6s > 30s under race instrumentation) that
  **fails identically on clean origin/main** with no fix applied (all 7 backends
  pass functionally, identical loss values) — unrelated to this change.

Closes #872