### PR TITLE
fix(training): device-resident loss seed; unblock CUDA-graph capture (#875)

### DIFF
--- a/training/grad_accum.go
+++ b/training/grad_accum.go
@@ -32,6 +32,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
@@ -56,11 +57,111 @@ type gradAccumulator[T tensor.Numeric] struct {
 
 	// accums maps each parameter to its persistent accumulator tensor.
 	accums map[*graph.Parameter[T]]*tensor.TensorNumeric[T]
+
+	// seeds caches the d(loss)/d(loss) = 1 upstream-gradient seed handed to
+	// loss.Backward (issue #872), keyed by the loss tensor's shape. The seed
+	// is built ONCE -- on the GPU engine via a device-side Fill kernel that
+	// writes directly into freshly allocated device memory -- and reused for
+	// every subsequent ComputeGradients call (issue #875).
+	//
+	// Why this matters for CUDA-graph capture: the pre-#875 seed was a
+	// host-backed tensor.New ones tensor that the engine had to host->device
+	// cudaMemcpy on every step. CaptureReplayRunner records ComputeGradients
+	// INSIDE a stream-capture region, and a host->device memcpy on the legacy
+	// stream during capture is illegal ("operation not permitted when stream
+	// is capturing"). Because the strategy (and thus this accumulator) is
+	// reused across all steps, the first call -- which happens during an eager
+	// warmup step, OUTSIDE capture -- populates this cache; capture-step calls
+	// reuse the already-resident device seed and enqueue no host copy.
+	seeds map[string]*tensor.TensorNumeric[T]
 }
 
 // setEngine configures the optional engine used for in-place device-side
 // accumulation.
 func (a *gradAccumulator[T]) setEngine(e compute.Engine[T]) { a.engine = e }
+
+// seedFor returns the cached d(loss)/d(loss) = 1 upstream-gradient seed for a
+// loss tensor of ref's shape, building (and caching) it on first use (#875).
+//
+// engine is the graph's engine (g.Engine()); it is used to fill the seed with
+// the value 1 via the engine's device-resident Fill path so that, on a GPU
+// engine, the seed lives in device memory after the first call and no
+// host->device copy is enqueued on later calls -- the property CUDA-graph
+// capture requires (the first call lands on a warmup step outside capture).
+//
+// When engine is nil (parameter-fixture graphs) the seed is the same plain
+// host ones tensor onesLike produced before #875, preserving correctness on
+// engine-less graphs; it is still cached so repeated calls reuse one buffer.
+//
+// The returned tensor must be treated as read-only by callers: loss.Backward
+// only reads the seed through engine.Mul(localGrad, dOut) and never mutates
+// it, so a single cached buffer is safe to share across every step.
+func (a *gradAccumulator[T]) seedFor(engine compute.Engine[T], ref *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	key := shapeKey(ref.Shape())
+	if s, ok := a.seeds[key]; ok {
+		return s, nil
+	}
+
+	seed, err := buildOnesSeed[T](engine, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	if a.seeds == nil {
+		a.seeds = make(map[string]*tensor.TensorNumeric[T])
+	}
+	a.seeds[key] = seed
+	return seed, nil
+}
+
+// shapeKey renders a shape as a stable map key.
+func shapeKey(shape []int) string {
+	if len(shape) == 0 {
+		return "scalar"
+	}
+	var b []byte
+	for i, d := range shape {
+		if i > 0 {
+			b = append(b, 'x')
+		}
+		b = strconv.AppendInt(b, int64(d), 10)
+	}
+	return string(b)
+}
+
+// buildOnesSeed allocates a ones tensor of ref's shape whose storage is
+// DEVICE-RESIDENT when engine is a GPU engine, so reusing it across steps
+// enqueues no host->device copy (#875).
+//
+// With an engine present it allocates a same-shaped tensor and calls
+// engine.Fill(t, 1): on the GPU engine Fill runs a device-side fill kernel and
+// swaps in fresh GPU storage (no host memcpy of the seed values); on the CPU
+// engine it fills the host slice in place. With no engine it falls back to the
+// host-tensor onesLike path used before #875.
+func buildOnesSeed[T tensor.Numeric](engine compute.Engine[T], ref *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	if engine == nil {
+		return onesLike[T](engine, ref)
+	}
+	one, err := onesValue[T](engine)
+	if err != nil {
+		return nil, err
+	}
+	shape := ref.Shape()
+	n := 1
+	for _, d := range shape {
+		n *= d
+	}
+	// Start from a zeroed host tensor; engine.Fill overwrites every element
+	// with 1 (and, on the GPU engine, re-homes the storage to device memory).
+	seed, err := tensor.New[T](shape, make([]T, n))
+	if err != nil {
+		return nil, err
+	}
+	if err := engine.Fill(context.Background(), seed, one); err != nil {
+		return nil, fmt.Errorf("training: filling device-resident loss seed: %w", err)
+	}
+	return seed, nil
+}
 
 // capture is the post-Backward hook: for every trainable parameter of g
 // whose Gradient is arena-backed, accumulate the gradient into the

--- a/training/loss_seed_resident_test.go
+++ b/training/loss_seed_resident_test.go
@@ -1,0 +1,159 @@
+package training
+
+import (
+	"context"
+	"testing"
+
+	core "github.com/zerfoo/zerfoo/layers/core"
+	"github.com/zerfoo/zerfoo/training/loss"
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// TestLossSeedDeviceResident is the regression gate for issue #875.
+//
+// #872 fixed the loss-backward seed value (d(loss)/d(loss) = 1 instead of L),
+// but built the seed via a fresh host-backed tensor.New on EVERY
+// ComputeGradients call. On a GPU engine that host ones tensor is host->device
+// cudaMemcpy'd each step; CaptureReplayRunner records ComputeGradients inside a
+// CUDA-graph stream-capture region, and a host->device copy on the legacy
+// stream during capture is illegal ("operation not permitted when stream is
+// capturing"), so capture-on training crashed.
+//
+// The fix caches one DEVICE-RESIDENT ones seed per loss shape on the strategy's
+// accumulator, built once (during an eager warmup step, before capture begins)
+// and reused every step. A full capture-on assertion needs a GPU/GraphCapturer
+// engine and is out of scope here (the Wolf consumer re-benches capture-on on
+// the GB10 after release). The CPU-testable invariant that makes the capture
+// fix true is: the seed is allocated ONCE and reused -- no per-call host
+// allocation happens inside ComputeGradients. This test asserts that invariant
+// via pointer identity of the cached seed tensor (and its backing storage)
+// across multiple ComputeGradients calls, plus that the seed value is 1.0.
+func TestLossSeedDeviceResident(t *testing.T) {
+	ops := numeric.Float64Ops{}
+	engine := compute.NewCPUEngine[float64](ops)
+
+	const (
+		batch = 2
+		in    = 4
+		out   = 3
+	)
+	lin, err := core.NewLinear[float64]("lin", engine, ops, in, out)
+	if err != nil {
+		t.Fatalf("NewLinear: %v", err)
+	}
+	wd := lin.Parameters()[0].Value.Data()
+	for i := range wd {
+		wd[i] = 0.05 * float64(i+1)
+	}
+
+	b := graph.NewBuilder[float64](engine)
+	inNode := b.Input([]int{batch, in})
+	b.AddNode(lin, inNode)
+	g, err := b.Build(lin)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	lossNode := loss.NewCrossEntropyLoss[float64](engine)
+
+	inputData := make([]float64, batch*in)
+	for i := range inputData {
+		inputData[i] = 0.1*float64(i) - 0.3
+	}
+	input, err := tensor.New[float64]([]int{batch, in}, inputData)
+	if err != nil {
+		t.Fatalf("input tensor: %v", err)
+	}
+	targets, err := tensor.New[float64]([]int{batch}, []float64{2, 0})
+	if err != nil {
+		t.Fatalf("targets tensor: %v", err)
+	}
+	batchData := Batch[float64]{
+		Inputs:  map[graph.Node[float64]]*tensor.TensorNumeric[float64]{inNode: input},
+		Targets: targets,
+	}
+
+	ctx := context.Background()
+	strategy := NewDefaultBackpropStrategy[float64]()
+
+	// Step 1: populates the seed cache (this is the eager warmup step that, on
+	// a GPU engine, runs OUTSIDE any capture region).
+	if _, err := strategy.ComputeGradients(ctx, g, lossNode, batchData); err != nil {
+		t.Fatalf("ComputeGradients (step 1): %v", err)
+	}
+
+	if len(strategy.grads.seeds) != 1 {
+		t.Fatalf("after step 1: len(seeds) = %d, want 1 (exactly one cached seed)", len(strategy.grads.seeds))
+	}
+	var firstSeed *tensor.TensorNumeric[float64]
+	for _, s := range strategy.grads.seeds {
+		firstSeed = s
+	}
+	if firstSeed == nil {
+		t.Fatal("after step 1: cached seed is nil")
+	}
+
+	// The seed value must be exactly 1.0 (preserve the #872 fix): a seed of L
+	// would scale every gradient by the loss value.
+	for i, v := range firstSeed.Data() {
+		if v != 1.0 {
+			t.Fatalf("seed[%d] = %v, want 1.0 (#872): loss.Backward must be seeded with d(loss)/d(loss)=1, not the loss value", i, v)
+		}
+	}
+	// Scalar loss -> [1] seed.
+	if got := firstSeed.Shape(); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("seed shape = %v, want [1]", got)
+	}
+
+	firstStorage := firstSeed.GetStorage()
+
+	// Steps 2 and 3: must REUSE the same cached seed tensor and its backing
+	// storage -- no per-call host allocation. This is the property that makes
+	// CUDA-graph capture legal: capture-step ComputeGradients touches an
+	// already-resident buffer and enqueues no host->device copy.
+	for step := 2; step <= 3; step++ {
+		if _, err := strategy.ComputeGradients(ctx, g, lossNode, batchData); err != nil {
+			t.Fatalf("ComputeGradients (step %d): %v", step, err)
+		}
+		if len(strategy.grads.seeds) != 1 {
+			t.Fatalf("after step %d: len(seeds) = %d, want 1 (no new seed allocated)", step, len(strategy.grads.seeds))
+		}
+		got := strategy.grads.seeds[shapeKey(firstSeed.Shape())]
+		if got != firstSeed {
+			t.Fatalf("after step %d: cached seed tensor changed (got %p, want %p): seed must be reused, not reallocated per step (#875)", step, got, firstSeed)
+		}
+		if got.GetStorage() != firstStorage {
+			t.Fatalf("after step %d: cached seed storage changed: the seed must be device-resident and stable across steps (#875)", step)
+		}
+	}
+}
+
+// TestLossSeedDeviceResident_NilEngine verifies the engine-less graph path
+// (parameter-fixture graphs) still produces a correct 1.0 seed and caches it,
+// exercising buildOnesSeed's nil-engine fallback.
+func TestLossSeedDeviceResident_NilEngine(t *testing.T) {
+	var acc gradAccumulator[float64]
+	ref, err := tensor.New[float64]([]int{1}, []float64{0})
+	if err != nil {
+		t.Fatalf("ref tensor: %v", err)
+	}
+
+	first, err := acc.seedFor(nil, ref)
+	if err != nil {
+		t.Fatalf("seedFor (nil engine): %v", err)
+	}
+	if d := first.Data(); len(d) != 1 || d[0] != 1.0 {
+		t.Fatalf("nil-engine seed = %v, want [1]", first.Data())
+	}
+
+	second, err := acc.seedFor(nil, ref)
+	if err != nil {
+		t.Fatalf("seedFor (nil engine, second call): %v", err)
+	}
+	if second != first {
+		t.Fatalf("nil-engine seed not cached: got %p, want %p", second, first)
+	}
+}

--- a/training/strategy_common.go
+++ b/training/strategy_common.go
@@ -142,7 +142,24 @@ func computeGradientsTensorCommon[T tensor.Numeric](
 	// (1/2)L^2 -- a different objective with a loss-dependent effective learning
 	// rate (issue #872). A ones tensor matching the loss shape ([1] for the
 	// scalar loss) broadcasts correctly through that final Mul.
-	ones, err := onesLike[T](g.Engine(), lossTensor)
+	//
+	// The seed is DEVICE-RESIDENT and cached on the strategy's accumulator,
+	// built once (during an eager warmup step, outside any CUDA-graph capture
+	// region) and reused every step (issue #875). The pre-#875 per-call
+	// onesLike built a HOST tensor that the engine host->device cudaMemcpy'd on
+	// every step; inside CaptureReplayRunner's capture region that host copy is
+	// illegal ("operation not permitted when stream is capturing") and crashed
+	// capture-on training. Reusing the cached device seed enqueues no host copy.
+	//
+	// When acc is nil (a few unit tests bypass the strategy accumulator) there
+	// is nowhere to cache, so fall back to the per-call host seed: those paths
+	// never run inside a capture region.
+	var ones *tensor.TensorNumeric[T]
+	if acc != nil {
+		ones, err = acc.seedFor(g.Engine(), lossTensor)
+	} else {
+		ones, err = onesLike[T](g.Engine(), lossTensor)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("seeding loss backward failed: %w", err)
 	}


### PR DESCRIPTION
## Regression (#875)

The #872 fix (v1.50.1) changed `training/strategy_common.go` to seed `loss.Backward` with `onesLike(...)` = d(loss)/d(loss) = 1 instead of the loss value — correct for gradients (dL/dL=1). **But `onesLike` builds a HOST-backed ones tensor**, which the engine then host→device `cudaMemcpy`'s to use.

`CaptureReplayRunner` (the capture-once-per-fold path) records `ComputeGradients` **inside** a CUDA-graph stream-capture region. A host→device memcpy on the legacy stream during capture is illegal — `operation not permitted when stream is capturing` / `legacy stream depend on a capturing blocking stream` — so **capture-on training crashes** for both the per-sample and batched paths. Net effect for the Wolf consumer: the ~2x CUDA-graph capture speedup is unusable on v1.50.1.

## Root cause

`computeGradientsTensorCommon` called `onesLike(g.Engine(), lossTensor)` on **every** step, allocating a fresh host tensor each call → an implicit per-step host→device copy inside the capture region.

## Fix — device-resident, cached seed allocated outside the capture region

- Cache **one** ones seed per loss shape on the strategy's `gradAccumulator` (`seeds map[string]*tensor.TensorNumeric[T]`). The strategy is reused across all steps of a run, so the cache survives.
- The seed is built **once** via `buildOnesSeed` → `engine.Fill(seed, 1)`. On the GPU engine `Fill` runs a **device-side fill kernel** and swaps in fresh device storage — no host memcpy of seed values. The first `ComputeGradients` call lands on an **eager warmup step (outside capture)** per `CaptureReplayRunner`'s warmup→capture→replay schedule, so the device buffer is fully resident before `BeginCapture`.
- Capture-step calls reuse the already-resident buffer and enqueue **no** host copy. The seed is only ever read via `engine.Mul(localGrad, dOut)` (verified across CE/MSE/BCE/Corr backwards) — never mutated — so sharing one buffer across steps is safe.
- Nil-engine graphs (parameter fixtures) fall back to the host `onesLike` ones tensor (still cached); `acc == nil` test paths fall back to per-call `onesLike` and never run inside capture.

**#872 is preserved**: the seed value is still exactly 1.0; the loss `Backward` implementations are untouched.

## Proof

- **`TestGradcheckLossSeed` (the #872 gate) still PASSES**: analytic≈numeric, max relative grad error `3.05e-08` (cross_entropy, L=1.139) and `6.11e-10` (mse, L=0.180), tol 2e-3.
- **New `TestLossSeedDeviceResident`** asserts the no-per-call-allocation invariant: exactly one cached seed after step 1, seed value == 1.0, shape [1], and **pointer identity of both the seed tensor and its backing storage** reused across steps 2–3 (no reallocation). Plus `TestLossSeedDeviceResident_NilEngine` covers the engine-less fallback + caching.
- A full GB10 capture-on test needs a GraphCapturer/GPU engine and is **out of scope here** (the Wolf consumer re-benches capture-on on the GB10 after release). The CPU-testable invariant that makes the capture fix true — seed allocated once, reused, no per-step host alloc — is explicitly tested.

## Validation

- Tier 0: `go build ./...`, `go vet ./training/...` clean; `golangci-lint` clean on changed files (the 54 repo-wide issues are pre-existing on `origin/main`, none in changed files).
- Tier 1: `go test ./... -race -timeout 600s` — all `training/` packages green. The only failure is the **pre-existing** `timeseries/TestAllBackends_CPUTrainingBenchmark` -race wall-clock-budget flake (33–38s > 30s budget), which **reproduces identically on clean `origin/main`** and is unrelated (different package; my diff touches only `training/`).

Closes #875