### PR TITLE
perf(linear): device-resident dInput via MatMulTransposeB (ADR 075 L1 / Wolf T14L1.1)

### DIFF
--- a/layers/core/linear.go
+++ b/layers/core/linear.go
@@ -138,14 +138,34 @@ func (l *Linear[T]) Backward(ctx context.Context, mode types.BackwardMode, outpu
 		return nil, err
 	}
 
-	// Gradient with respect to input
-	transposedWeights, err := l.engine.Transpose(ctx, l.weights.Value, []int{1, 0})
-	if err != nil {
-		return nil, err
-	}
-	dx, err := l.engine.MatMul(ctx, gradReshaped, transposedWeights)
-	if err != nil {
-		return nil, err
+	// Gradient with respect to input: dx = grad @ W^T.
+	//
+	// device-resident-operand path (ADR 075 L1): when the engine can multiply
+	// by a transposed B directly (cuBLAS NT), compute dx = MatMulTransposeB(
+	// grad, W). This reads the weight parameter -- which is device-resident
+	// after UploadWeights -- in its NATURAL [in,out] layout, with NO explicit
+	// Transpose allocation/kernel and NO opportunity for a transposed view to
+	// drop GPUStorage and trigger a per-op host->device re-upload of the
+	// weight. The explicit-transpose fallback below is byte-identical for
+	// engines without the NT path (notably the CPU engine), so the CPU result
+	// is unchanged.
+	var dx *tensor.TensorNumeric[T]
+	if tb, ok := l.engine.(interface {
+		MatMulTransposeB(context.Context, *tensor.TensorNumeric[T], *tensor.TensorNumeric[T], ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error)
+	}); ok {
+		dx, err = tb.MatMulTransposeB(ctx, gradReshaped, l.weights.Value)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		transposedWeights, terr := l.engine.Transpose(ctx, l.weights.Value, []int{1, 0})
+		if terr != nil {
+			return nil, terr
+		}
+		dx, err = l.engine.MatMul(ctx, gradReshaped, transposedWeights)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Reshape back to original input shape

--- a/layers/core/linear_device_resident_test.go
+++ b/layers/core/linear_device_resident_test.go
@@ -1,0 +1,142 @@
+package core
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/testing/gradcheck"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// TestLinear_Backward_Gradcheck pins the Linear backward (both dW and the
+// dInput = grad @ W^T path) against float64 central finite differences. The
+// CPU engine has no MatMulTransposeB, so this exercises the explicit-transpose
+// fallback branch -- the byte-identical reference the GPU NT path (ADR 075 L1,
+// device-resident operands) must match. A randomized upstream gradient catches
+// a transposed-Jacobian error, which is exactly the failure mode a wrong
+// MatMulTransposeB wiring would introduce.
+func TestLinear_Backward_Gradcheck(t *testing.T) {
+	ops := numeric.Float64Ops{}
+	engine := compute.NewCPUEngine[float64](ops)
+	ctx := context.Background()
+
+	const inF, outF = 4, 3
+	makeNode := func() (graph.Node[float64], error) {
+		return NewLinear[float64]("gc_linear", engine, ops, inF, outF)
+	}
+
+	in, err := tensor.New[float64]([]int{2, inF}, []float64{
+		0.1, -0.2, 0.3, 0.4,
+		-0.5, 0.6, -0.7, 0.8,
+	})
+	if err != nil {
+		t.Fatalf("tensor.New input: %v", err)
+	}
+
+	rep, err := gradcheck.Check(ctx, makeNode, []*tensor.TensorNumeric[float64]{in}, &gradcheck.Config{Seed: 42})
+	if err != nil {
+		t.Fatalf("gradcheck.Check: %v", err)
+	}
+	if !rep.OK() {
+		t.Fatalf("Linear backward gradcheck failed:\n%s", rep.String())
+	}
+}
+
+// TestLinear_Backward_DeviceResidentParity asserts the device-resident-operand
+// dInput path (GPU MatMulTransposeB, reading the weight in its natural [in,out]
+// layout with no explicit transpose) produces the SAME dInput as the CPU
+// explicit-transpose reference. This is the GPU-vs-CPU half of the L1 gate:
+// the optimization must not change the numerics. Skips cleanly on CPU-only
+// machines / CI.
+func TestLinear_Backward_DeviceResidentParity(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	cpu := compute.NewCPUEngine[float32](ops)
+	gpu, err := compute.NewGPUEngine[float32](ops, 0)
+	if err != nil {
+		t.Skipf("GPU not available: %v", err)
+	}
+	defer func() { _ = gpu.Close() }()
+	ctx := context.Background()
+
+	const inF, outF, batch = 8, 5, 4
+
+	// Identical weights on both engines.
+	wData := make([]float32, inF*outF)
+	for i := range wData {
+		wData[i] = float32(math.Sin(float64(i)*0.37)) * 0.5
+	}
+	mkLinear := func(engine compute.Engine[float32]) (*Linear[float32], error) {
+		l, e := NewLinear[float32]("dr_linear", engine, ops, inF, outF)
+		if e != nil {
+			return nil, e
+		}
+		copy(l.weights.Value.Data(), wData)
+		return l, nil
+	}
+	lCPU, err := mkLinear(cpu)
+	if err != nil {
+		t.Fatalf("cpu linear: %v", err)
+	}
+	lGPU, err := mkLinear(gpu)
+	if err != nil {
+		t.Fatalf("gpu linear: %v", err)
+	}
+
+	inData := make([]float32, batch*inF)
+	for i := range inData {
+		inData[i] = float32(math.Cos(float64(i)*0.21)) * 0.7
+	}
+	gradData := make([]float32, batch*outF)
+	for i := range gradData {
+		gradData[i] = float32(math.Sin(float64(i)*0.53)+0.1) * 0.3
+	}
+
+	newPair := func() (*tensor.TensorNumeric[float32], *tensor.TensorNumeric[float32], error) {
+		in, e := tensor.New[float32]([]int{batch, inF}, append([]float32(nil), inData...))
+		if e != nil {
+			return nil, nil, e
+		}
+		g, e := tensor.New[float32]([]int{batch, outF}, append([]float32(nil), gradData...))
+		return in, g, e
+	}
+
+	inCPU, gradCPU, err := newPair()
+	if err != nil {
+		t.Fatalf("cpu tensors: %v", err)
+	}
+	inGPU, gradGPU, err := newPair()
+	if err != nil {
+		t.Fatalf("gpu tensors: %v", err)
+	}
+
+	dxCPU, err := lCPU.Backward(ctx, types.FullBackprop, gradCPU, inCPU)
+	if err != nil {
+		t.Fatalf("cpu backward: %v", err)
+	}
+	dxGPU, err := lGPU.Backward(ctx, types.FullBackprop, gradGPU, inGPU)
+	if err != nil {
+		t.Fatalf("gpu backward: %v", err)
+	}
+
+	cpuDX := dxCPU[0].Data()
+	gpuDX := dxGPU[0].Data() // D2H on GPU storage.
+	if len(cpuDX) != len(gpuDX) {
+		t.Fatalf("dInput length mismatch: cpu=%d gpu=%d", len(cpuDX), len(gpuDX))
+	}
+	const tol = 1e-4
+	var maxAbs float64
+	for i := range cpuDX {
+		d := math.Abs(float64(cpuDX[i] - gpuDX[i]))
+		if d > maxAbs {
+			maxAbs = d
+		}
+	}
+	if maxAbs > tol {
+		t.Fatalf("GPU NT dInput diverges from CPU transpose reference: max|diff|=%.3g > %g", maxAbs, tol)
+	}
+}


### PR DESCRIPTION
## Context — ADR 075 Lever 1 (device-resident operands)

Wolf CrossAsset GPU training (GB10, f32, batched-eager B=256) loses 62.4% of
host CUDA-API time to synchronous `cudaMemcpy(H2D)`; the T11.0c nsys backtrace
(Wolf `docs/devlog.md` 2026-06-15) attributes **211 GB/epoch** of it to
re-uploading weight-class operands every op — `[256,256]` (q/k/v/output proj)
and `[1024,256]` (FFN).

`Linear` is the densest weight consumer. Its `Backward` computes
`dInput = grad @ Wᵀ` as `Transpose(W)` **+** `MatMul(grad, Wᵀ)`. On GPU that:
- allocates a transposed weight copy and launches a transpose kernel every
  backward, and
- routes the weight through a transposed VIEW, which is exactly the kind of
  derived operand that can drop `GPUStorage` and make the next op re-upload the
  weight host→device.

## Change

When the engine implements `MatMulTransposeB` (the cuBLAS NT path — the GPU
engine does; the CPU engine does **not**), compute
`dInput = MatMulTransposeB(grad, W)` directly. This reads the weight parameter
in its **natural `[in,out]` layout** — device-resident after `UploadWeights` —
with no explicit transpose alloc/kernel and no transposed view that could
re-home the weight to the host.

Engines without the NT path (CPU) keep the explicit-transpose fallback, so the
**CPU result is byte-identical**. The dInput math is unchanged: `MatMulTransposeB(grad[bs,out], W[in,out]) = grad @ Wᵀ = dInput[bs,in]`.

## Universal quality gate
- **Gradcheck**: `TestLinear_Backward_Gradcheck` — float64 central finite
  differences over the full Linear backward (dW + dInput), randomized upstream
  (catches a transposed-Jacobian wiring error). Green.
- **GPU-vs-CPU parity**: `TestLinear_Backward_DeviceResidentParity` — asserts
  the GPU NT dInput matches the CPU explicit-transpose reference within 1e-4.
  Skips cleanly on CPU-only CI; runs on the GB10 lane.
- `go build ./...`, `go vet ./layers/core/`, `go test ./layers/core/` green.
- No new dependency: builds against the already-pinned ztensor (NT path has
  shipped).

## Scope note
This is the Linear half of Lever 1. The full firehose attribution (which exact
operands arrive CPU-backed, via the `ZERFOO_TRACE_H2D` instrument in
zerfoo/ztensor#146) and the GB10 H2D-drop measurement (211 GB → a few GB, new
s/epoch) follow once the instrumented ztensor + this change are released into a
Wolf GB10 build.