### PR TITLE
docs: E127 Phase-0 de-risk (fp8=F8_E4M3; oracle harness in ztensor)

### DIFF
--- a/docs/adr/092-ltx2-diffusion-dit-first.md
+++ b/docs/adr/092-ltx2-diffusion-dit-first.md
@@ -60,11 +60,15 @@ FlowMatchEuler, 40-step full / 8-step distilled, Gemma3-12B encoder (hidden
 3840), VAE `vae_scale_factors=[8,32,32]` with 128-latent, audio VAE latent 8, and
 crucially **`patch_size=patch_size_t=audio_patch_size=audio_patch_size_t=1`** --
 the DiT ingests VAE latents directly with NO spatial patch folding; all spatial
-compression lives in the VAE. Three things the research could NOT independently
+compression lives in the VAE. Two things the research could NOT independently
 verify are carried as explicit "ASSUMPTION -- validate in T127.x" items, not
-asserted facts: (1) the fp8 sub-format (E4M3FN vs E5M2; binary header unreadable
-via WebFetch); (2) whether n>1 low-precision GPU GEMM at the denoise regime needs
-new kernels; (3) LTX-2.3 22B geometry (its binary header could not be re-fetched).
+asserted facts: (1) whether n>1 low-precision GPU GEMM at the denoise regime
+needs new kernels (hardware-gated -- GB10/Spark); (2) LTX-2.3 22B geometry (its
+binary header could not be re-fetched). A third -- the fp8 sub-format -- was
+**RESOLVED in Phase-0** (2026-06-16): a `huggingface_hub` byte-range header read
+of `ltx-2-19b-dev-fp8.safetensors` confirmed **F8_E4M3** (1,176 F8_E4M3 tensors,
+0 E5M2; mixed-precision F32 + BF16 + F8_E4M3), matched by the LTX-2.3-fp8
+checkpoint. Recorded in docs/devlog.md.
 
 The central tension is **breadth vs. bandwidth**: the full LTX-2 pipeline is a
 large surface (DiT + 2 VAEs + vocoder + text encoder + connectors + scheduler +
@@ -199,8 +203,9 @@ performance story lives.
   only. Conv2d/Conv3D/ConvTranspose **backward** is a known gap, tracked as a
   separate deferred issue; the conv ops are inference-only here and gated on
   forward-parity, not gradcheck.
-- fp8 sub-format (E4M3FN vs E5M2) confirmation is an explicit validate-before-use
-  task in Phase 0/3 (byte-range header read), not an assumption.
+- fp8 sub-format: **RESOLVED to F8_E4M3** (Phase-0 byte-range header read,
+  2026-06-16; mixed-precision F32 + BF16 + F8_E4M3). No longer an open item;
+  recorded in docs/devlog.md.
 
 ## Alternatives Considered
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,62 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-06-16: LTX-2 (E127) Phase-0 de-risk -- fp8 = F8_E4M3, ADR-091 oracle harness is op-generic (lives in ztensor)
+
+**Type:** finding
+**Tags:** ltx-2, e127, adr-092, diffusion, fp8, e4m3, safetensors, pytorch-oracle, ztensor, phase-0, #887, #888
+
+**Context:** After E127 (LTX-2 diffusion inference epic) + ADR-092 landed (PR #886),
+ran the autonomously-doable front of Phase 0 -- the "investigate-first" lines of
+T127.1.0a (oracle harness) and T127.1.0b (fp8 sub-format) -- to flip two
+`[uncertain]` assumptions before any implementation.
+
+**Finding 1 -- fp8 sub-format is F8_E4M3 (was an open ASSUMPTION).**
+Method: `huggingface_hub` byte-range read of the safetensors header (first 8 bytes
+= little-endian u64 header length, then the JSON header), scanning `"dtype"`
+values -- no full download, no WebFetch.
+- `Lightricks/LTX-2 :: ltx-2-19b-dev-fp8.safetensors` (27 GB): **1,176 F8_E4M3, 0
+  F8_E5M2**; header also carries 2,546 F32 + 2,682 BF16.
+- `Lightricks/LTX-2.3-fp8 :: ltx-2.3-22b-dev-fp8.safetensors`: **1,496 F8_E4M3, 0
+  F8_E5M2** (3,282 F32 + 4,161 BF16).
+- Conclusion: Lightricks ships fp8 as **F8_E4M3**, and checkpoints are
+  **mixed-precision (F32 + BF16 + F8_E4M3)** -- norms/embeds stay high-precision,
+  matmul weights are fp8. The T127.3.2 converter must preserve per-tensor dtype,
+  not assume one global precision. Unblocks the converter storage mapping.
+
+**Finding 2 -- repo layout correction (raw research was wrong).** The merged
+research claimed "no `model.safetensors.index.json` in any Lightricks LTX repo;
+each checkpoint single-file." That conflated the FLAT single-file LTX-2.3 line
+with the LTX-2 19B diffusers layout. Verified via the HF tree API: `Lightricks/LTX-2`
+ships bf16 in the `transformer/` subfolder as **8 shards +
+`diffusion_pytorch_model.safetensors.index.json`**, while the **quantized
+variants are flat single-files at repo root** (`ltx-2-19b-dev-fp8.safetensors`
+27 GB, `ltx-2-19b-dev-fp4.safetensors` 20 GB, `ltx-2-19b-distilled-fp8.safetensors`).
+The merged epic already said "sharded," so docs were correct; the converter task
+(T127.3.2) now records both layouts.
+
+**Finding 3 -- ADR-091 PyTorch-oracle harness EXISTS, is op-generic, and lives in
+ztensor (not zerfoo).** Location: `ztensor/testing/oracle/` (bundle.go,
+generate.go, torchmap.go, cmd/oracle-gen) + `ztensor/testing/gradcheck/registry.go`
++ `ztensor/scripts/oracle/run_oracle.py` (replays bundles in NGC PyTorch on GB10).
+Adding an op is a 2-step registration -- a `gradcheck.Registry()` entry + a
+`torchMap` PyTorch expression, lockstep-enforced by a cross-check test. 26 ops
+registered today (elementwise, activations, MatMul/Transpose/Reshape, Softmax,
+LayerNorm, reductions); **none** of conv/groupnorm/adaln/attn. So T127.1.0a is
+real but bounded: ~**M (6-8h)** to add 6 wrappers + registry entries + torch
+exprs (Conv3D templates from Conv1D/Conv2D; GroupNorm from LayerNorm; AdaLN and
+CrossAttn need custom backward). The epic's `tests/oracle/` zerfoo path was wrong
+and has been corrected to the ztensor harness.
+
+**Side-effects this session:** filed #887 (Conv2d/Conv3D/ConvTranspose backward
+for future VAE training -- deferred) and #888 (LTX-2.3 22B geometry header-read
+gate, T127.8.1). Updated E127 (T127.1.0a/0b/3.2) and ADR-092 to reflect the two
+resolved assumptions.
+
+**Still hardware-gated (need GB10/Spark, not done here):** T127.1.0b PART 2 (n>1
+fp8/Q4_K GEMM micro-benchmark -- the load-bearing perf risk) and T127.1.0c
+(provision the LTX2 diffusers dev build + fixture generator on Spark).
+
 ## 2026-06-11: GPU training hardening close-out -- device-resident gradient accumulation (#855) validated end-to-end on GB10 f32
 
 **Type:** finding

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -4113,15 +4113,16 @@ New code needed (all general primitives):
 
 #### E127.1: Oracle/Fixture Harness + DiT Denoiser Core + Conditioning Primitives (DiT-first) -- Size: L. Hardest: AdaLN-Zero cross-modality modulation node (zero-init, 6-vector split, timestep-conditioned)
 
-- [ ] T127.1.0a Extend the ADR-091 PyTorch-oracle harness to the new op classes  Owner: TBD  Est: 4h  verifies: [infrastructure]
-  File: tests/oracle/ (ADR-091 harness extension)
-  CONFIRM whether the ADR-091 oracle harness is op-generic; if it only covers existing LLM ops, extend it to generate torch reference tensors for: conv3d, conv_transpose, group_norm, adaln-zero, timestep/sinusoidal embed, and cross-attention. Without this, every op-parity AC in E127 references infrastructure that does not exist.
-  AC: harness emits reference tensors for all six new op classes; a smoke run produces a comparable tensor for each. `go test ./tests/oracle/...` green (or harness doc confirms op-generic).
+- [ ] T127.1.0a Extend the ADR-091 PyTorch-oracle harness to the new op classes  Owner: TBD  Est: 6-8h (M)  verifies: [infrastructure]
+  File: ztensor `testing/oracle/` (bundle.go, generate.go, torchmap.go) + `testing/gradcheck/registry.go` + `scripts/oracle/run_oracle.py` -- repo: **ztensor**, NOT zerfoo
+  RESOLVED (Phase-0 audit 2026-06-16): the harness EXISTS and IS op-generic -- adding an op is a 2-step registration (a `gradcheck.Registry()` entry in `registry.go` + a `torchMap` PyTorch expression in `torchmap.go`, lockstep-enforced by a cross-check test); references are generated on-the-fly by `cmd/oracle-gen` and replayed in NGC PyTorch on GB10. 26 ops registered today, **none** of conv/groupnorm/adaln/attn. Remaining work: add 6 op wrappers + registry entries + torch exprs for conv3d, conv_transpose, group_norm, adaln-zero, timestep/sinusoidal embed, cross-attention (Conv3D templates from Conv1D/Conv2D; GroupNorm templates from LayerNorm; AdaLN/CrossAttn need custom backward). NOTE: this is ztensor work -- the earlier `tests/oracle/` zerfoo path was wrong.
+  AC: `oracle-gen` emits bundles for all six new op classes and `run_oracle.py` reports per-op tolerance pass on GB10; ztensor gradcheck registry <-> torchmap lockstep test green.
 
 - [ ] T127.1.0b fp8 sub-format + n>1 low-precision GEMM spike (de-risk converter + perf early)  Owner: TBD  Est: 3h  verifies: [infrastructure]
   File: docs/devlog.md (spike findings), docs/bench/manifests/ltx2-fp8-spike.yaml
-  Read one real fp8 LTX-2 19B shard header via a **huggingface_hub byte-range request (NOT WebFetch)** to confirm **E4M3FN vs E5M2** before the converter storage mapping is committed (T127.3.2). Micro-benchmark one n>1 fp8 GEMM and one n>1 Q4_K GEMM on the GB10 via Spark to size whether the denoise-regime dequant-to-f32 path is acceptable or new kernels are needed. This is the load-bearing perf risk; surface it now, not in Phase 7.
-  AC: fp8 sub-format confirmed and recorded; n>1 fp8/Q4_K GEMM sec/op measured on GB10; go/no-go note on whether new kernels are required for the denoise regime.
+  PART 1 -- DONE (2026-06-16): fp8 sub-format confirmed **F8_E4M3** via `huggingface_hub` byte-range header read of `ltx-2-19b-dev-fp8.safetensors` (1,176 F8_E4M3 tensors, 0 E5M2). Checkpoints are **mixed-precision F32 + BF16 + F8_E4M3** (norms/embeds high-precision, matmul weights fp8); LTX-2.3-fp8 matches. Recorded in docs/devlog.md. The converter storage mapping (T127.3.2) may now be committed against E4M3.
+  PART 2 -- REMAINING (hardware-gated, GB10/Spark): micro-benchmark one n>1 fp8 GEMM and one n>1 Q4_K GEMM on the GB10 via Spark to size whether the denoise-regime dequant-to-f32 path is acceptable or new kernels are needed. This is the load-bearing perf risk.
+  AC: ~~fp8 sub-format confirmed and recorded~~ DONE; n>1 fp8/Q4_K GEMM sec/op measured on GB10; go/no-go note on whether new kernels are required for the denoise regime.
 
 - [ ] T127.1.0c Provision + pin the PyTorch/diffusers reference + fixture generator on Spark  Owner: TBD  Est: 3h  verifies: [infrastructure]
   File: docs/bench/manifests/ltx2-reference.yaml, scripts/ltx2-fixtures.py
@@ -4199,7 +4200,7 @@ New code needed (all general primitives):
 
 - [ ] T127.3.2 SafeTensors -> GGUF converter for the LTX-2 19B DiT (bf16/fp8/fp4)  Owner: TBD  Est: 5h  verifies: [infrastructure]
   File: zonnx (convert_ltx2.go)
-  Emit GGUF from the **LTX-2 19B transformer shards only**. Map storage using the fp8 sub-format **confirmed in T127.1.0b (E4M3 vs E5M2)** -- do not assume. Handle the LTX-2 19B bf16 dev / distilled and fp8/fp4 variants. **LTX-2.3 22B is OUT of scope (see T127.8.1).**
+  Emit GGUF from the **LTX-2 19B transformer**. Storage mapping: fp8 = **F8_E4M3** (confirmed T127.1.0b), and checkpoints are **mixed-precision F32 + BF16 + F8_E4M3** so the converter must preserve per-tensor dtype, not assume one global precision. Repo layout (verified): bf16 lives in the diffusers `transformer/` subfolder as 8 shards + `diffusion_pytorch_model.safetensors.index.json`, while quantized variants are flat single-files at repo root (`ltx-2-19b-dev-fp8.safetensors` 27 GB, `ltx-2-19b-dev-fp4.safetensors` 20 GB, `ltx-2-19b-distilled-fp8.safetensors`). **LTX-2.3 22B is OUT of scope (see T127.8.1).**
   Deps: T127.3.1, T127.1.0b
   AC: produces a loadable GGUF for the 19B DiT; round-trip tensor shapes match the safetensors header.
   repo: zonnx


### PR DESCRIPTION
Follow-up to #886. Plan-only (no code). Records the autonomously-doable front of **E127 Phase 0** and flips two `[uncertain]` assumptions to resolved.

## Resolved
- **fp8 sub-format → `F8_E4M3`** — `huggingface_hub` byte-range header read of `ltx-2-19b-dev-fp8.safetensors`: **1,176 F8_E4M3 / 0 E5M2**; checkpoints are **mixed-precision F32 + BF16 + F8_E4M3** (LTX-2.3-fp8 matches). Unblocks the T127.3.2 converter mapping.
- **ADR-091 oracle harness** → exists, is **op-generic**, lives in **ztensor** (`testing/oracle/` + `testing/gradcheck/registry.go` + `scripts/oracle/run_oracle.py`), 26 ops, none of conv/norm/adaln/attn. T127.1.0a scope **M (6–8h)**; epic path corrected from `tests/oracle/` (zerfoo) to the ztensor harness.

## Corrected
- LTX-2 19B repo layout: bf16 is **sharded** (`transformer/` 8 shards + `index.json`); fp8/fp4 are **flat single-files at root** — fixes the raw research "single-file/no-index" claim.

## Files
- `docs/devlog.md` — full Phase-0 finding entry (method + evidence).
- `docs/adr/092-*.md` — fp8 moved from assumptions to RESOLVED.
- `docs/plan.md` — T127.1.0a (path/scope), T127.1.0b (PART 1 done / PART 2 hardware-gated), T127.3.2 (E4M3 + mixed-precision + layout).

## Still hardware-gated (not in this PR)
T127.1.0b PART 2 (n>1 fp8/Q4_K GEMM micro-benchmark on GB10/Spark) and T127.1.0c (diffusers provisioning).

Refs #886, #887, #888.