### PR TITLE
fix(training): bf16 device-resident gradient accumulation uses the engine

### DIFF
--- a/training/grad_accum.go
+++ b/training/grad_accum.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/zerfoo/float16"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/graph"
 	"github.com/zerfoo/ztensor/tensor"
@@ -236,7 +237,13 @@ func (a *gradAccumulator[T]) engineFor(g *graph.Graph[T], accum, grad *tensor.Te
 		return a.engine
 	}
 	var zero T
-	if _, isF32 := any(zero).(float32); !isF32 {
+	_, isF32 := any(zero).(float32)
+	_, isBF16 := any(zero).(float16.BFloat16)
+	// f32 and bf16 both have native, in-place device Add kernels (bf16 via
+	// launch_add_bf16, ztensor v1.13.0+). Any other element type has no native
+	// device accumulation and its CPU fallback does not honor the in-place dst
+	// contract for device-backed tensors, so it takes the host fallback.
+	if !isF32 && !isBF16 {
 		return nil
 	}
 	if _, ok := accum.GetStorage().(*tensor.GPUStorage[T]); !ok {


### PR DESCRIPTION
## What

`gradAccumulator.engineFor` now uses the graph engine for **bf16** device-resident gradient accumulation, not just f32.

## Why

bf16 GPU training crashed in the backward:
```
accumulating gradient for "beta": unsupported numeric type for host gradient accumulation; set an engine on the strategy
```
`engineFor` gated every non-f32 type to the host `addSlice` fallback, which has no bf16 case. f32 GPU avoided this because its device-resident branch returns `g.Engine()` (in-place device Add) even with no explicitly-set strategy engine — bf16 was excluded.

## Fix

Include bf16 in the device-resident implicit-engine branch. bf16 has a native in-place device Add (`launch_add_bf16`, ztensor v1.13.0+), so accumulation runs on-device on the graph's stream, exactly like f32. `addInto` still guards the in-place dst contract (errors if `engine.Add` relocates the accumulator), so a non-native fallback can never silently corrupt the buffer. CPU bf16 is unaffected (it sets an explicit engine on the strategy).

## Verification

- Build + `training` tests green.
- Unblocks the bf16 CrossAsset GPU backward (T14L4.2) past the transpose-GEMM fix (ztensor v1.16.0 / zerfoo v1.53.0). Re-validated end-to-end on GB10 via the Wolf bf16 bench (next step in the chain).

ADR-075 lever L4.