### PR TITLE
feat(layers): Conv3d + ConvTranspose3d forward (E127/T127.4.2-4.3)

### DIFF
--- a/layers/core/conv3d.go
+++ b/layers/core/conv3d.go
@@ -1,0 +1,251 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// Conv3d performs 3D convolution (inference-only) -- the canonical video/
+// volumetric convolution used by causal 3D VAEs/UNets (E127 video VAE decode,
+// T127.4.2). Forward expects inputs (X, W [,B]) where:
+//   - X: [N, C_in, D, H, W]
+//   - W: [C_out, C_in/groups, kD, kH, kW]
+//   - B: [C_out] (optional)
+//
+// It composes im2col + engine.MatMul exactly like Conv2d, so the heavy GEMM
+// runs on the engine (CPU/GPU). Inference-only: Backward returns nil; conv
+// backward (for future VAE training) is tracked as a separate deferred issue
+// (ADR-092). Unlocks the 3D-conv primitive for the whole diffusion/vision class.
+type Conv3d[T tensor.Numeric] struct {
+	engine      compute.Engine[T]
+	ops         numeric.Arithmetic[T]
+	strides     [3]int
+	pads        [6]int // dBegin, hBegin, wBegin, dEnd, hEnd, wEnd (ONNX N-D order)
+	dilations   [3]int
+	groups      int
+	outputShape []int
+}
+
+// NewConv3d creates a Conv3d layer.
+// strides: [sD,sH,sW]; pads: [dBegin,hBegin,wBegin,dEnd,hEnd,wEnd]; dilations: [dD,dH,dW].
+func NewConv3d[T tensor.Numeric](
+	engine compute.Engine[T],
+	ops numeric.Arithmetic[T],
+	strides []int,
+	pads []int,
+	dilations []int,
+	groups int,
+) *Conv3d[T] {
+	c := &Conv3d[T]{engine: engine, ops: ops, groups: groups}
+	if groups <= 0 {
+		c.groups = 1
+	}
+	if len(strides) >= 3 {
+		c.strides = [3]int{strides[0], strides[1], strides[2]}
+	} else {
+		c.strides = [3]int{1, 1, 1}
+	}
+	if len(pads) >= 6 {
+		c.pads = [6]int{pads[0], pads[1], pads[2], pads[3], pads[4], pads[5]}
+	}
+	if len(dilations) >= 3 {
+		c.dilations = [3]int{dilations[0], dilations[1], dilations[2]}
+	} else {
+		c.dilations = [3]int{1, 1, 1}
+	}
+	return c
+}
+
+// im2col3d extracts input patches into a column matrix for one sample and
+// group. Returns [cInG*kD*kH*kW, outD*outH*outW]. Mirrors im2col (2D).
+func im2col3d[T tensor.Numeric](
+	xData []T,
+	inD, inH, inW int,
+	cInG, kD, kH, kW int,
+	sD, sH, sW, padD, padH, padW, dD, dH, dW int,
+	outD, outH, outW int,
+	icOffset int,
+) []T {
+	colRows := cInG * kD * kH * kW
+	colCols := outD * outH * outW
+	col := make([]T, colRows*colCols)
+	for ic := range cInG {
+		for kd := range kD {
+			for kh := range kH {
+				for kw := range kW {
+					row := ((ic*kD+kd)*kH+kh)*kW + kw
+					for od := range outD {
+						id := od*sD - padD + kd*dD
+						if id < 0 || id >= inD {
+							continue
+						}
+						for oh := range outH {
+							ih := oh*sH - padH + kh*dH
+							if ih < 0 || ih >= inH {
+								continue
+							}
+							for ow := range outW {
+								iw := ow*sW - padW + kw*dW
+								if iw >= 0 && iw < inW {
+									col[row*colCols+(od*outH+oh)*outW+ow] =
+										xData[(((icOffset+ic)*inD+id)*inH+ih)*inW+iw]
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return col
+}
+
+// Forward computes 3D convolution via im2col + engine.MatMul.
+func (c *Conv3d[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	if len(inputs) < 2 || len(inputs) > 3 {
+		return nil, fmt.Errorf("Conv3d requires 2 or 3 inputs (X, W [,B]), got %d", len(inputs))
+	}
+	x, w := inputs[0], inputs[1]
+	xShape := x.Shape()
+	wShape := w.Shape()
+	if len(xShape) != 5 {
+		return nil, fmt.Errorf("Conv3d: X must be 5D [N,C,D,H,W], got shape %v", xShape)
+	}
+	if len(wShape) != 5 {
+		return nil, fmt.Errorf("Conv3d: W must be 5D [C_out,C_in/groups,kD,kH,kW], got shape %v", wShape)
+	}
+
+	n, cIn, inD, inH, inW := xShape[0], xShape[1], xShape[2], xShape[3], xShape[4]
+	cOut, cInG, kD, kH, kW := wShape[0], wShape[1], wShape[2], wShape[3], wShape[4]
+	sD, sH, sW := c.strides[0], c.strides[1], c.strides[2]
+	padDb, padHb, padWb := c.pads[0], c.pads[1], c.pads[2]
+	padDe, padHe, padWe := c.pads[3], c.pads[4], c.pads[5]
+	dD, dH, dW := c.dilations[0], c.dilations[1], c.dilations[2]
+
+	if cInG*c.groups != cIn {
+		return nil, fmt.Errorf("Conv3d: C_in %d != C_in/groups %d * groups %d", cIn, cInG, c.groups)
+	}
+
+	outD := (inD+padDb+padDe-dD*(kD-1)-1)/sD + 1
+	outH := (inH+padHb+padHe-dH*(kH-1)-1)/sH + 1
+	outW := (inW+padWb+padWe-dW*(kW-1)-1)/sW + 1
+	if outD <= 0 || outH <= 0 || outW <= 0 {
+		return nil, fmt.Errorf("Conv3d: non-positive output spatial size [%d,%d,%d]", outD, outH, outW)
+	}
+
+	groups := c.groups
+	cOutPerGroup := cOut / groups
+	colK := cInG * kD * kH * kW
+	spatialSize := outD * outH * outW
+
+	wData := w.Data()
+	xData := x.Data()
+	outData := make([]T, n*cOut*spatialSize)
+
+	for ni := range n {
+		batchOffset := ni * cIn * inD * inH * inW
+		for g := range groups {
+			colData := im2col3d[T](xData[batchOffset:], inD, inH, inW,
+				cInG, kD, kH, kW, sD, sH, sW, padDb, padHb, padWb, dD, dH, dW,
+				outD, outH, outW, g*cInG)
+
+			colTensor, err := tensor.New[T]([]int{colK, spatialSize}, colData)
+			if err != nil {
+				return nil, fmt.Errorf("Conv3d: im2col tensor: %w", err)
+			}
+
+			wGroupStart := g * cOutPerGroup * colK
+			wGroup, err := tensor.New[T]([]int{cOutPerGroup, colK}, wData[wGroupStart:wGroupStart+cOutPerGroup*colK])
+			if err != nil {
+				return nil, fmt.Errorf("Conv3d: weight reshape: %w", err)
+			}
+
+			result, err := c.engine.MatMul(ctx, wGroup, colTensor)
+			if err != nil {
+				return nil, fmt.Errorf("Conv3d: MatMul: %w", err)
+			}
+
+			rData := result.Data()
+			ocOffset := g * cOutPerGroup
+			for oc := range cOutPerGroup {
+				dstStart := ni*cOut*spatialSize + (ocOffset+oc)*spatialSize
+				copy(outData[dstStart:dstStart+spatialSize], rData[oc*spatialSize:(oc+1)*spatialSize])
+			}
+		}
+	}
+
+	out, err := tensor.New[T]([]int{n, cOut, outD, outH, outW}, outData)
+	if err != nil {
+		return nil, fmt.Errorf("Conv3d: failed to create output tensor: %w", err)
+	}
+
+	if len(inputs) == 3 {
+		biasReshaped, err := c.engine.Reshape(ctx, inputs[2], []int{1, cOut, 1, 1, 1})
+		if err != nil {
+			return nil, fmt.Errorf("Conv3d: bias reshape: %w", err)
+		}
+		out, err = c.engine.Add(ctx, out, biasReshaped)
+		if err != nil {
+			return nil, fmt.Errorf("Conv3d: bias add: %w", err)
+		}
+	}
+
+	c.outputShape = out.Shape()
+	return out, nil
+}
+
+// Backward returns nil (inference-only; see ADR-092).
+func (c *Conv3d[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	return nil, nil
+}
+
+// OpType returns "Conv".
+func (c *Conv3d[T]) OpType() string { return "Conv" }
+
+// Attributes returns the layer configuration.
+func (c *Conv3d[T]) Attributes() map[string]interface{} {
+	return map[string]interface{}{
+		"strides":   c.strides,
+		"pads":      c.pads,
+		"dilations": c.dilations,
+		"group":     c.groups,
+	}
+}
+
+// OutputShape returns the output shape (populated after Forward).
+func (c *Conv3d[T]) OutputShape() []int { return c.outputShape }
+
+// Parameters returns nil (weight/bias are passed as forward inputs).
+func (c *Conv3d[T]) Parameters() []*graph.Parameter[T] { return nil }
+
+// BuildConv3d constructs a Conv3d layer from registry attributes.
+func BuildConv3d[T tensor.Numeric](
+	engine compute.Engine[T],
+	ops numeric.Arithmetic[T],
+	_ string,
+	_ map[string]*graph.Parameter[T],
+	attributes map[string]interface{},
+) (graph.Node[T], error) {
+	strides := extractInts(attributes, "strides", []int{1, 1, 1})
+	pads := extractInts(attributes, "pads", []int{0, 0, 0, 0, 0, 0})
+	dilations := extractInts(attributes, "dilations", []int{1, 1, 1})
+	group := 1
+	if v, ok := attributes["group"]; ok {
+		switch g := v.(type) {
+		case int64:
+			group = int(g)
+		case int:
+			group = g
+		}
+	}
+	return NewConv3d(engine, ops, strides, pads, dilations, group), nil
+}
+
+// Statically assert that Conv3d implements graph.Node.
+var _ graph.Node[float32] = (*Conv3d[float32])(nil)

--- a/layers/core/conv3d_test.go
+++ b/layers/core/conv3d_test.go
@@ -1,0 +1,164 @@
+package core
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// naiveConv3d is an independent, direct nested-loop reference (groups=1) used
+// to validate the im2col+MatMul Conv3d.Forward without needing torch.
+func naiveConv3d(
+	x []float64, n, cIn, inD, inH, inW int,
+	w []float64, cOut, kD, kH, kW int,
+	bias []float64,
+	sD, sH, sW, padDb, padHb, padWb, dD, dH, dW int,
+) ([]float64, int, int, int) {
+	outD := (inD+2*padDb-dD*(kD-1)-1)/sD + 1 // tests use symmetric begin/end pads
+	outH := (inH+2*padHb-dH*(kH-1)-1)/sH + 1
+	outW := (inW+2*padWb-dW*(kW-1)-1)/sW + 1
+	out := make([]float64, n*cOut*outD*outH*outW)
+	for ni := range n {
+		for oc := range cOut {
+			b := 0.0
+			if bias != nil {
+				b = bias[oc]
+			}
+			for od := range outD {
+				for oh := range outH {
+					for ow := range outW {
+						acc := b
+						for ic := range cIn {
+							for kd := range kD {
+								id := od*sD - padDb + kd*dD
+								if id < 0 || id >= inD {
+									continue
+								}
+								for kh := range kH {
+									ih := oh*sH - padHb + kh*dH
+									if ih < 0 || ih >= inH {
+										continue
+									}
+									for kw := range kW {
+										iw := ow*sW - padWb + kw*dW
+										if iw < 0 || iw >= inW {
+											continue
+										}
+										xv := x[(((ni*cIn+ic)*inD+id)*inH+ih)*inW+iw]
+										wv := w[(((oc*cIn+ic)*kD+kd)*kH+kh)*kW+kw]
+										acc += xv * wv
+									}
+								}
+							}
+						}
+						out[(((ni*cOut+oc)*outD+od)*outH+oh)*outW+ow] = acc
+					}
+				}
+			}
+		}
+	}
+	return out, outD, outH, outW
+}
+
+func seqData(n int, seed float64) []float64 {
+	d := make([]float64, n)
+	s := seed
+	for i := range d {
+		// deterministic, varied values in ~[-1,1]
+		s = math.Mod(s*1.123456789+0.314159, 2.0)
+		d[i] = s - 1.0
+	}
+	return d
+}
+
+func TestConv3d_OnesForward(t *testing.T) {
+	ops := numeric.Float64Ops{}
+	engine := compute.NewCPUEngine[float64](ops)
+	mkOnes := func(shape []int) *tensor.TensorNumeric[float64] {
+		size := 1
+		for _, d := range shape {
+			size *= d
+		}
+		data := make([]float64, size)
+		for i := range data {
+			data[i] = 1
+		}
+		tt, _ := tensor.New[float64](shape, data)
+		return tt
+	}
+	x := mkOnes([]int{1, 1, 3, 3, 3})
+	w := mkOnes([]int{1, 1, 2, 2, 2})
+	conv := NewConv3d[float64](engine, ops, []int{1, 1, 1}, []int{0, 0, 0, 0, 0, 0}, []int{1, 1, 1}, 1)
+	out, err := conv.Forward(context.Background(), x, w)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if !shapeEq(out.Shape(), []int{1, 1, 2, 2, 2}) {
+		t.Fatalf("shape = %v, want [1 1 2 2 2]", out.Shape())
+	}
+	for i, v := range out.Data() {
+		if math.Abs(v-8) > 1e-9 { // 2*2*2 sum of ones
+			t.Fatalf("out[%d] = %v, want 8", i, v)
+		}
+	}
+}
+
+func TestConv3d_MatchesNaiveReference(t *testing.T) {
+	type tc struct {
+		name                      string
+		n, cIn, inD, inH, inW     int
+		cOut, kD, kH, kW          int
+		sD, sH, sW                int
+		padD, padH, padW          int
+		dD, dH, dW                int
+		bias                      bool
+	}
+	cases := []tc{
+		{"valid_stride1", 2, 3, 4, 5, 6, 4, 2, 2, 2, 1, 1, 1, 0, 0, 0, 1, 1, 1, false},
+		{"strided_padded_bias", 1, 2, 5, 5, 5, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 1, true},
+		{"dilated", 1, 2, 6, 6, 6, 2, 2, 2, 2, 1, 1, 1, 0, 0, 0, 2, 2, 2, true},
+	}
+	ops := numeric.Float64Ops{}
+	engine := compute.NewCPUEngine[float64](ops)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			xData := seqData(c.n*c.cIn*c.inD*c.inH*c.inW, 0.7)
+			wData := seqData(c.cOut*c.cIn*c.kD*c.kH*c.kW, 1.3)
+			var bData []float64
+			if c.bias {
+				bData = seqData(c.cOut, 2.1)
+			}
+			x, _ := tensor.New[float64]([]int{c.n, c.cIn, c.inD, c.inH, c.inW}, xData)
+			w, _ := tensor.New[float64]([]int{c.cOut, c.cIn, c.kD, c.kH, c.kW}, wData)
+			inputs := []*tensor.TensorNumeric[float64]{x, w}
+			if c.bias {
+				b, _ := tensor.New[float64]([]int{c.cOut}, bData)
+				inputs = append(inputs, b)
+			}
+			conv := NewConv3d[float64](engine, ops,
+				[]int{c.sD, c.sH, c.sW},
+				[]int{c.padD, c.padH, c.padW, c.padD, c.padH, c.padW},
+				[]int{c.dD, c.dH, c.dW}, 1)
+			out, err := conv.Forward(context.Background(), inputs...)
+			if err != nil {
+				t.Fatalf("Forward: %v", err)
+			}
+			want, oD, oH, oW := naiveConv3d(xData, c.n, c.cIn, c.inD, c.inH, c.inW,
+				wData, c.cOut, c.kD, c.kH, c.kW, bData,
+				c.sD, c.sH, c.sW, c.padD, c.padH, c.padW, c.dD, c.dH, c.dW)
+			if !shapeEq(out.Shape(), []int{c.n, c.cOut, oD, oH, oW}) {
+				t.Fatalf("shape = %v, want [%d %d %d %d %d]", out.Shape(), c.n, c.cOut, oD, oH, oW)
+			}
+			got := out.Data()
+			for i := range want {
+				if math.Abs(got[i]-want[i]) > 1e-9 {
+					t.Fatalf("mismatch at %d: got %v want %v", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}

--- a/layers/core/conv_transpose.go
+++ b/layers/core/conv_transpose.go
@@ -1,0 +1,240 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// ConvTranspose3d performs 3D transposed (fractionally-strided) convolution --
+// the upsampling convolution used by convolutional VAE/UNet decoders (E127
+// video VAE decode, T127.4.3). Forward expects inputs (X, W [,B]) where:
+//   - X: [N, C_in, D, H, W]
+//   - W: [C_in, C_out, kD, kH, kW]   (torch conv_transpose weight layout)
+//   - B: [C_out] (optional)
+//
+// It computes cols = Wᵀ @ X via engine.MatMul (heavy GEMM on the engine) then
+// scatters them into the (larger) output with col2im -- the exact transpose of
+// Conv3d's im2col path. Inference-only: Backward returns nil (ADR-092). groups
+// are currently limited to 1. Unlocks the transposed-conv primitive for the
+// whole convolutional-decoder class.
+type ConvTranspose3d[T tensor.Numeric] struct {
+	engine        compute.Engine[T]
+	ops           numeric.Arithmetic[T]
+	strides       [3]int
+	pads          [6]int // dBegin, hBegin, wBegin, dEnd, hEnd, wEnd
+	dilations     [3]int
+	outputPadding [3]int
+	groups        int
+	outputShape   []int
+}
+
+// NewConvTranspose3d creates a ConvTranspose3d layer (groups=1 supported).
+func NewConvTranspose3d[T tensor.Numeric](
+	engine compute.Engine[T],
+	ops numeric.Arithmetic[T],
+	strides []int,
+	pads []int,
+	dilations []int,
+	outputPadding []int,
+	groups int,
+) *ConvTranspose3d[T] {
+	c := &ConvTranspose3d[T]{engine: engine, ops: ops, groups: groups}
+	if groups <= 0 {
+		c.groups = 1
+	}
+	if len(strides) >= 3 {
+		c.strides = [3]int{strides[0], strides[1], strides[2]}
+	} else {
+		c.strides = [3]int{1, 1, 1}
+	}
+	if len(pads) >= 6 {
+		c.pads = [6]int{pads[0], pads[1], pads[2], pads[3], pads[4], pads[5]}
+	}
+	if len(dilations) >= 3 {
+		c.dilations = [3]int{dilations[0], dilations[1], dilations[2]}
+	} else {
+		c.dilations = [3]int{1, 1, 1}
+	}
+	if len(outputPadding) >= 3 {
+		c.outputPadding = [3]int{outputPadding[0], outputPadding[1], outputPadding[2]}
+	}
+	return c
+}
+
+// Forward computes 3D transposed convolution via engine.MatMul (Wᵀ@X) + col2im.
+func (c *ConvTranspose3d[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	if len(inputs) < 2 || len(inputs) > 3 {
+		return nil, fmt.Errorf("ConvTranspose3d requires 2 or 3 inputs (X, W [,B]), got %d", len(inputs))
+	}
+	if c.groups != 1 {
+		return nil, fmt.Errorf("ConvTranspose3d: only groups=1 is supported, got %d", c.groups)
+	}
+	x, w := inputs[0], inputs[1]
+	xShape := x.Shape()
+	wShape := w.Shape()
+	if len(xShape) != 5 {
+		return nil, fmt.Errorf("ConvTranspose3d: X must be 5D [N,C,D,H,W], got %v", xShape)
+	}
+	if len(wShape) != 5 {
+		return nil, fmt.Errorf("ConvTranspose3d: W must be 5D [C_in,C_out,kD,kH,kW], got %v", wShape)
+	}
+
+	n, cIn, inD, inH, inW := xShape[0], xShape[1], xShape[2], xShape[3], xShape[4]
+	wCin, cOut, kD, kH, kW := wShape[0], wShape[1], wShape[2], wShape[3], wShape[4]
+	if wCin != cIn {
+		return nil, fmt.Errorf("ConvTranspose3d: W C_in %d != X C_in %d", wCin, cIn)
+	}
+	sD, sH, sW := c.strides[0], c.strides[1], c.strides[2]
+	padDb, padHb, padWb := c.pads[0], c.pads[1], c.pads[2]
+	padDe, padHe, padWe := c.pads[3], c.pads[4], c.pads[5]
+	dD, dH, dW := c.dilations[0], c.dilations[1], c.dilations[2]
+	opD, opH, opW := c.outputPadding[0], c.outputPadding[1], c.outputPadding[2]
+
+	outD := (inD-1)*sD - (padDb + padDe) + dD*(kD-1) + opD + 1
+	outH := (inH-1)*sH - (padHb + padHe) + dH*(kH-1) + opH + 1
+	outW := (inW-1)*sW - (padWb + padWe) + dW*(kW-1) + opW + 1
+	if outD <= 0 || outH <= 0 || outW <= 0 {
+		return nil, fmt.Errorf("ConvTranspose3d: non-positive output spatial size [%d,%d,%d]", outD, outH, outW)
+	}
+
+	kSize := kD * kH * kW
+	sIn := inD * inH * inW
+	outS := outD * outH * outW
+
+	// Wmat = reshape(W, [C_in, C_out*K]); WmatT = [C_out*K, C_in].
+	wMat, err := tensor.New[T]([]int{cIn, cOut * kSize}, w.Data())
+	if err != nil {
+		return nil, fmt.Errorf("ConvTranspose3d: weight reshape: %w", err)
+	}
+	wMatT, err := c.engine.Transpose(ctx, wMat, []int{1, 0})
+	if err != nil {
+		return nil, fmt.Errorf("ConvTranspose3d: weight transpose: %w", err)
+	}
+
+	xData := x.Data()
+	outData := make([]T, n*cOut*outS)
+
+	for ni := range n {
+		// Xmat for this sample: [C_in, sIn] (already contiguous in xData).
+		xMat, err := tensor.New[T]([]int{cIn, sIn}, xData[ni*cIn*sIn:(ni+1)*cIn*sIn])
+		if err != nil {
+			return nil, fmt.Errorf("ConvTranspose3d: input reshape: %w", err)
+		}
+		// cols[C_out*K, sIn] = WmatT @ Xmat (sum over C_in).
+		cols, err := c.engine.MatMul(ctx, wMatT, xMat)
+		if err != nil {
+			return nil, fmt.Errorf("ConvTranspose3d: MatMul: %w", err)
+		}
+		colData := cols.Data()
+		base := ni * cOut * outS
+		// col2im: scatter each (cout, k, input-pos) into the strided output pos.
+		for oc := range cOut {
+			for kd := range kD {
+				for kh := range kH {
+					for kw := range kW {
+						kidx := (kd*kH+kh)*kW + kw
+						rowBase := (oc*kSize + kidx) * sIn
+						for id := range inD {
+							od := id*sD - padDb + kd*dD
+							if od < 0 || od >= outD {
+								continue
+							}
+							for ih := range inH {
+								oh := ih*sH - padHb + kh*dH
+								if oh < 0 || oh >= outH {
+									continue
+								}
+								for iw := range inW {
+									ow := iw*sW - padWb + kw*dW
+									if ow < 0 || ow >= outW {
+										continue
+									}
+									src := colData[rowBase+(id*inH+ih)*inW+iw]
+									dst := base + ((oc*outD+od)*outH+oh)*outW + ow
+									outData[dst] += src
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	out, err := tensor.New[T]([]int{n, cOut, outD, outH, outW}, outData)
+	if err != nil {
+		return nil, fmt.Errorf("ConvTranspose3d: failed to create output tensor: %w", err)
+	}
+
+	if len(inputs) == 3 {
+		biasReshaped, err := c.engine.Reshape(ctx, inputs[2], []int{1, cOut, 1, 1, 1})
+		if err != nil {
+			return nil, fmt.Errorf("ConvTranspose3d: bias reshape: %w", err)
+		}
+		out, err = c.engine.Add(ctx, out, biasReshaped)
+		if err != nil {
+			return nil, fmt.Errorf("ConvTranspose3d: bias add: %w", err)
+		}
+	}
+
+	c.outputShape = out.Shape()
+	return out, nil
+}
+
+// Backward returns nil (inference-only; see ADR-092).
+func (c *ConvTranspose3d[T]) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[T], _ ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	return nil, nil
+}
+
+// OpType returns "ConvTranspose".
+func (c *ConvTranspose3d[T]) OpType() string { return "ConvTranspose" }
+
+// Attributes returns the layer configuration.
+func (c *ConvTranspose3d[T]) Attributes() map[string]interface{} {
+	return map[string]interface{}{
+		"strides":        c.strides,
+		"pads":           c.pads,
+		"dilations":      c.dilations,
+		"output_padding": c.outputPadding,
+		"group":          c.groups,
+	}
+}
+
+// OutputShape returns the output shape (populated after Forward).
+func (c *ConvTranspose3d[T]) OutputShape() []int { return c.outputShape }
+
+// Parameters returns nil (weight/bias are passed as forward inputs).
+func (c *ConvTranspose3d[T]) Parameters() []*graph.Parameter[T] { return nil }
+
+// BuildConvTranspose3d constructs a ConvTranspose3d layer from registry attributes.
+func BuildConvTranspose3d[T tensor.Numeric](
+	engine compute.Engine[T],
+	ops numeric.Arithmetic[T],
+	_ string,
+	_ map[string]*graph.Parameter[T],
+	attributes map[string]interface{},
+) (graph.Node[T], error) {
+	strides := extractInts(attributes, "strides", []int{1, 1, 1})
+	pads := extractInts(attributes, "pads", []int{0, 0, 0, 0, 0, 0})
+	dilations := extractInts(attributes, "dilations", []int{1, 1, 1})
+	outputPadding := extractInts(attributes, "output_padding", []int{0, 0, 0})
+	group := 1
+	if v, ok := attributes["group"]; ok {
+		switch g := v.(type) {
+		case int64:
+			group = int(g)
+		case int:
+			group = g
+		}
+	}
+	return NewConvTranspose3d(engine, ops, strides, pads, dilations, outputPadding, group), nil
+}
+
+// Statically assert that ConvTranspose3d implements graph.Node.
+var _ graph.Node[float32] = (*ConvTranspose3d[float32])(nil)

--- a/layers/core/conv_transpose_test.go
+++ b/layers/core/conv_transpose_test.go
@@ -1,0 +1,135 @@
+package core
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+func TestConvTranspose3d_TinyScatter(t *testing.T) {
+	ops := numeric.Float64Ops{}
+	engine := compute.NewCPUEngine[float64](ops)
+	// X = [[v]] (single element), ones kernel 2x2x2, stride1 pad0 -> [1,1,2,2,2]
+	// all = v (each kernel tap deposits v*1 at a distinct output position).
+	x, _ := tensor.New[float64]([]int{1, 1, 1, 1, 1}, []float64{2.5})
+	w := func() *tensor.TensorNumeric[float64] {
+		d := make([]float64, 8)
+		for i := range d {
+			d[i] = 1
+		}
+		tt, _ := tensor.New[float64]([]int{1, 1, 2, 2, 2}, d)
+		return tt
+	}()
+	ct := NewConvTranspose3d[float64](engine, ops, []int{1, 1, 1}, []int{0, 0, 0, 0, 0, 0}, []int{1, 1, 1}, []int{0, 0, 0}, 1)
+	out, err := ct.Forward(context.Background(), x, w)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if !shapeEq(out.Shape(), []int{1, 1, 2, 2, 2}) {
+		t.Fatalf("shape = %v, want [1 1 2 2 2]", out.Shape())
+	}
+	for i, v := range out.Data() {
+		if math.Abs(v-2.5) > 1e-9 {
+			t.Fatalf("out[%d] = %v, want 2.5", i, v)
+		}
+	}
+}
+
+func TestConvTranspose3d_StridedUpsampleShape(t *testing.T) {
+	ops := numeric.Float64Ops{}
+	engine := compute.NewCPUEngine[float64](ops)
+	// stride 2, kernel 2, input 2^3 ones -> output 4^3, each position covered
+	// exactly once (no overlap) -> all ones.
+	xd := make([]float64, 8)
+	for i := range xd {
+		xd[i] = 1
+	}
+	x, _ := tensor.New[float64]([]int{1, 1, 2, 2, 2}, xd)
+	wd := make([]float64, 8)
+	for i := range wd {
+		wd[i] = 1
+	}
+	w, _ := tensor.New[float64]([]int{1, 1, 2, 2, 2}, wd)
+	ct := NewConvTranspose3d[float64](engine, ops, []int{2, 2, 2}, []int{0, 0, 0, 0, 0, 0}, []int{1, 1, 1}, []int{0, 0, 0}, 1)
+	out, err := ct.Forward(context.Background(), x, w)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if !shapeEq(out.Shape(), []int{1, 1, 4, 4, 4}) {
+		t.Fatalf("shape = %v, want [1 1 4 4 4]", out.Shape())
+	}
+	for i, v := range out.Data() {
+		if math.Abs(v-1) > 1e-9 {
+			t.Fatalf("out[%d] = %v, want 1", i, v)
+		}
+	}
+}
+
+// flipSwapWeight converts a conv_transpose weight Wt[Cin,Cout,kD,kH,kW] into the
+// equivalent conv weight Wc[Cout,Cin,kD,kH,kW] (swap in/out channels, flip the
+// kernel spatially). With stride1/dilation1 and full padding (k-1), a plain
+// convolution with Wc reproduces the transposed convolution -- an independent
+// cross-check of ConvTranspose3d against the naive-verified Conv3d.
+func flipSwapWeight(wt []float64, cIn, cOut, kD, kH, kW int) []float64 {
+	wc := make([]float64, cOut*cIn*kD*kH*kW)
+	for cin := range cIn {
+		for cout := range cOut {
+			for kd := range kD {
+				for kh := range kH {
+					for kw := range kW {
+						src := (((cin*cOut+cout)*kD+(kD-1-kd))*kH+(kH-1-kh))*kW + (kW - 1 - kw)
+						dst := (((cout*cIn+cin)*kD+kd)*kH+kh)*kW + kw
+						wc[dst] = wt[src]
+					}
+				}
+			}
+		}
+	}
+	return wc
+}
+
+func TestConvTranspose3d_AdjointMatchesConv3d(t *testing.T) {
+	ops := numeric.Float64Ops{}
+	engine := compute.NewCPUEngine[float64](ops)
+	const (
+		n, cIn, cOut    = 2, 3, 4
+		inD, inH, inW   = 3, 4, 3
+		kD, kH, kW      = 2, 3, 2
+	)
+	xData := seqData(n*cIn*inD*inH*inW, 0.55)
+	wtData := seqData(cIn*cOut*kD*kH*kW, 1.7) // [Cin,Cout,kD,kH,kW]
+
+	x, _ := tensor.New[float64]([]int{n, cIn, inD, inH, inW}, xData)
+	wt, _ := tensor.New[float64]([]int{cIn, cOut, kD, kH, kW}, wtData)
+
+	// Transposed conv (stride1, pad0, dilation1).
+	ct := NewConvTranspose3d[float64](engine, ops, []int{1, 1, 1}, []int{0, 0, 0, 0, 0, 0}, []int{1, 1, 1}, []int{0, 0, 0}, 1)
+	ctOut, err := ct.Forward(context.Background(), x, wt)
+	if err != nil {
+		t.Fatalf("ConvTranspose3d Forward: %v", err)
+	}
+
+	// Equivalent plain conv: flipped/swapped weight, full padding (k-1).
+	wcData := flipSwapWeight(wtData, cIn, cOut, kD, kH, kW)
+	wc, _ := tensor.New[float64]([]int{cOut, cIn, kD, kH, kW}, wcData)
+	conv := NewConv3d[float64](engine, ops, []int{1, 1, 1},
+		[]int{kD - 1, kH - 1, kW - 1, kD - 1, kH - 1, kW - 1}, []int{1, 1, 1}, 1)
+	convOut, err := conv.Forward(context.Background(), x, wc)
+	if err != nil {
+		t.Fatalf("Conv3d Forward: %v", err)
+	}
+
+	if !shapeEq(ctOut.Shape(), convOut.Shape()) {
+		t.Fatalf("shape mismatch: convT %v vs conv %v", ctOut.Shape(), convOut.Shape())
+	}
+	a, b := ctOut.Data(), convOut.Data()
+	for i := range a {
+		if math.Abs(a[i]-b[i]) > 1e-9 {
+			t.Fatalf("adjoint mismatch at %d: convT %v vs conv %v", i, a[i], b[i])
+		}
+	}
+}


### PR DESCRIPTION
Completes the **conv forward-parity work** — the two op classes from T127.1.0a that are **forward-only** (per ADR-092: inference-only VAE, forward-parity not gradcheck) and therefore don't fit the backward-checking gradcheck oracle. Implemented as real zerfoo layers (the E127 video-VAE primitives), each verified on CPU **without torch**.

## What
- **`layers/core/conv3d.go`** — `Conv3d`: 3D convolution via im2col + `engine.MatMul`, mirroring `Conv2d` (stride/pad/dilation/groups, optional bias). Inference-only.
- **`layers/core/conv_transpose.go`** — `ConvTranspose3d`: transposed conv via `engine.MatMul` (Wᵀ@X) + col2im scatter (stride/pad/dilation/output_padding; groups=1). Inference-only.

## Forward-parity verification (CPU, runs in CI)
- **Conv3d** vs an independent **naive nested-loop reference** across `valid` / `strided+padded+bias` / `dilated`, plus an all-ones value check.
- **ConvTranspose3d** via a tiny hand-checked scatter, a strided-upsample shape/value check, and an **adjoint cross-check**: a stride-1 transposed conv equals a full convolution with flipped/swapped kernel — validated against the naive-verified `Conv3d`.

`go vet` + full `layers/core` suite green; full module builds.

## Scope notes
- Inference-only; `Backward` returns nil (conv backward for VAE training is tracked in #887).
- `ConvTranspose3d` supports groups=1 (errors otherwise); GGUF-registry wiring and torch-oracle (GB10/NGC) forward parity are follow-ups.

Refs #886, #887. Completes the T127.1.0a op-class set (the other 4 — GroupNorm/CrossAttention/AdaLN/TimestepEmbed — landed in ztensor #159, #164).