### PR TITLE
feat(layers): GroupNormalization layer + LTX-2 VAE decoder skeleton (E127)

### DIFF
--- a/layers/normalization/group_norm.go
+++ b/layers/normalization/group_norm.go
@@ -1,0 +1,338 @@
+package normalization
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// GroupNormalization implements Group Normalization (Wu & He, 2018) -- the
+// canonical normalization of convolutional VAE/UNet/diffusion decoders (E127
+// video VAE, T127.4.1). For input X [N, C, *spatial] it splits the C channels
+// into `numGroups` groups and normalizes each group's (C/groups channels x all
+// spatial positions) jointly, per sample, then applies a learnable per-channel
+// affine (scale, bias of shape [C]):
+//
+//	y = scale[c] * (x - mean_g) / sqrt(var_g + epsilon) + bias[c]
+//
+// where mean_g/var_g are computed over the C/groups channels and every spatial
+// position within group g. All math flows through Engine primitives so it
+// appears in the ExecutionPlan tape and runs on CPU/GPU. groups must divide C.
+//
+// When scale/bias are graph.Parameters (NewGroupNormalizationWithParams),
+// Backward accumulates their gradients and returns dX. The group statistics
+// fall out of the same reduce/elementwise ops as LayerNorm, applied to the
+// grouped [N*groups, (C/groups)*S] view.
+type GroupNormalization[T tensor.Numeric] struct {
+	engine    compute.Engine[T]
+	ops       numeric.Arithmetic[T]
+	numGroups int
+	epsilon   T
+
+	scale *graph.Parameter[T] // [C], optional
+	bias  *graph.Parameter[T] // [C], optional
+
+	// Cache for backward (registered with the save-for-backward contract).
+	normGrouped *tensor.TensorNumeric[T] // normalized, grouped view [N*groups, M]
+	invStd      *tensor.TensorNumeric[T] // 1/sqrt(var+eps) per group [N*groups, 1]
+	scaleBC     *tensor.TensorNumeric[T] // scale reshaped to [1,C,1,...] (nil if no scale)
+	inputShape  []int
+	groupedRows int // N*groups
+	groupM      int // (C/groups)*S
+	saver       graph.Saver[T]
+}
+
+// SetSaver implements graph.SaverAware.
+func (g *GroupNormalization[T]) SetSaver(sv graph.Saver[T]) { g.saver = sv }
+
+// NewGroupNormalization creates an inference layer with no affine (scale/bias nil).
+func NewGroupNormalization[T tensor.Numeric](engine compute.Engine[T], ops numeric.Arithmetic[T], numGroups int, epsilon T) *GroupNormalization[T] {
+	return &GroupNormalization[T]{engine: engine, ops: ops, numGroups: numGroups, epsilon: epsilon}
+}
+
+// NewGroupNormalizationWithParams creates a layer with learnable per-channel
+// scale and bias (each shape [C]).
+func NewGroupNormalizationWithParams[T tensor.Numeric](engine compute.Engine[T], ops numeric.Arithmetic[T], numGroups int, epsilon T, scale, bias *graph.Parameter[T]) *GroupNormalization[T] {
+	return &GroupNormalization[T]{engine: engine, ops: ops, numGroups: numGroups, epsilon: epsilon, scale: scale, bias: bias}
+}
+
+// Forward computes group normalization. inputs: [X].
+func (g *GroupNormalization[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	if len(inputs) != 1 {
+		return nil, fmt.Errorf("GroupNormalization requires 1 input (X), got %d", len(inputs))
+	}
+	x := inputs[0]
+	xShape := x.Shape()
+	if len(xShape) < 2 {
+		return nil, fmt.Errorf("GroupNormalization: X must have at least rank 2 [N,C,...], got %v", xShape)
+	}
+	n, c := xShape[0], xShape[1]
+	if g.numGroups <= 0 || c%g.numGroups != 0 {
+		return nil, fmt.Errorf("GroupNormalization: C %d not divisible by numGroups %d", c, g.numGroups)
+	}
+	s := 1
+	for i := 2; i < len(xShape); i++ {
+		s *= xShape[i]
+	}
+	rows := n * g.numGroups
+	m := (c / g.numGroups) * s
+
+	e := g.engine
+	grouped, err := e.Reshape(ctx, x, []int{rows, m})
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization: reshape grouped: %w", err)
+	}
+	mean, err := e.ReduceMean(ctx, grouped, 1, true)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization: mean: %w", err)
+	}
+	centered, err := e.Sub(ctx, grouped, mean)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization: center: %w", err)
+	}
+	sq, err := e.Mul(ctx, centered, centered)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization: square: %w", err)
+	}
+	variance, err := e.ReduceMean(ctx, sq, 1, true)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization: var: %w", err)
+	}
+	veps, err := e.AddScalar(ctx, variance, g.epsilon)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization: var+eps: %w", err)
+	}
+	invStd, err := e.Rsqrt(ctx, veps)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization: rsqrt: %w", err)
+	}
+	normGrouped, err := e.Mul(ctx, centered, invStd)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization: normalize: %w", err)
+	}
+
+	out, err := e.Reshape(ctx, normGrouped, xShape)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization: reshape back: %w", err)
+	}
+
+	// Per-channel affine via [1, C, 1, ...] broadcast.
+	bShape := make([]int, len(xShape))
+	bShape[0], bShape[1] = 1, c
+	for i := 2; i < len(xShape); i++ {
+		bShape[i] = 1
+	}
+	var scaleBC *tensor.TensorNumeric[T]
+	if g.scale != nil {
+		scaleBC, err = e.Reshape(ctx, g.scale.Value, bShape)
+		if err != nil {
+			return nil, fmt.Errorf("GroupNormalization: reshape scale: %w", err)
+		}
+		out, err = e.Mul(ctx, out, scaleBC)
+		if err != nil {
+			return nil, fmt.Errorf("GroupNormalization: mul scale: %w", err)
+		}
+	}
+	if g.bias != nil {
+		biasBC, err := e.Reshape(ctx, g.bias.Value, bShape)
+		if err != nil {
+			return nil, fmt.Errorf("GroupNormalization: reshape bias: %w", err)
+		}
+		out, err = e.Add(ctx, out, biasBC)
+		if err != nil {
+			return nil, fmt.Errorf("GroupNormalization: add bias: %w", err)
+		}
+	}
+
+	g.normGrouped = normGrouped
+	g.invStd = invStd
+	g.scaleBC = scaleBC
+	g.inputShape = xShape
+	g.groupedRows = rows
+	g.groupM = m
+	if g.saver != nil {
+		if scaleBC != nil {
+			g.saver.SaveForBackward(normGrouped, invStd, scaleBC)
+		} else {
+			g.saver.SaveForBackward(normGrouped, invStd)
+		}
+	}
+	return out, nil
+}
+
+// Backward returns dX and accumulates scale/bias gradients. inputs: [X].
+func (g *GroupNormalization[T]) Backward(ctx context.Context, _ types.BackwardMode, dOut *tensor.TensorNumeric[T], inputs ...*tensor.TensorNumeric[T]) ([]*tensor.TensorNumeric[T], error) {
+	if len(inputs) != 1 {
+		return nil, fmt.Errorf("GroupNormalization: %w, expected 1 input for backward, got %d", graph.ErrInvalidInputCount, len(inputs))
+	}
+	if g.normGrouped == nil || g.invStd == nil {
+		return nil, fmt.Errorf("GroupNormalization: backward called before forward")
+	}
+	e := g.engine
+
+	// normalized in original shape, for per-channel parameter gradients.
+	normalized, err := e.Reshape(ctx, g.normGrouped, g.inputShape)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: reshape normalized: %w", err)
+	}
+
+	// Parameter gradients: reduce over all dims except channel (dim 1).
+	if g.scale != nil {
+		dScaleFull, err := e.Mul(ctx, dOut, normalized)
+		if err != nil {
+			return nil, fmt.Errorf("GroupNormalization backward: dScale mul: %w", err)
+		}
+		if err := g.reduceToChannelAndAccum(ctx, dScaleFull, g.scale); err != nil {
+			return nil, err
+		}
+	}
+	if g.bias != nil {
+		if err := g.reduceToChannelAndAccum(ctx, dOut, g.bias); err != nil {
+			return nil, err
+		}
+	}
+
+	// dNormalized = dOut * scale (broadcast); then group-norm input gradient.
+	dNorm := dOut
+	if g.scaleBC != nil {
+		dNorm, err = e.Mul(ctx, dOut, g.scaleBC)
+		if err != nil {
+			return nil, fmt.Errorf("GroupNormalization backward: dNorm mul scale: %w", err)
+		}
+	}
+	dNormG, err := e.Reshape(ctx, dNorm, []int{g.groupedRows, g.groupM})
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: reshape dNorm: %w", err)
+	}
+	// dX_g = invStd * (dNorm - mean_M(dNorm) - normGrouped * mean_M(dNorm*normGrouped))
+	m1, err := e.ReduceMean(ctx, dNormG, 1, true)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: mean(dNorm): %w", err)
+	}
+	dn, err := e.Mul(ctx, dNormG, g.normGrouped)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: dNorm*norm: %w", err)
+	}
+	m2, err := e.ReduceMean(ctx, dn, 1, true)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: mean(dNorm*norm): %w", err)
+	}
+	t1, err := e.Sub(ctx, dNormG, m1)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: sub m1: %w", err)
+	}
+	nm2, err := e.Mul(ctx, g.normGrouped, m2)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: norm*m2: %w", err)
+	}
+	t2, err := e.Sub(ctx, t1, nm2)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: sub nm2: %w", err)
+	}
+	dXg, err := e.Mul(ctx, t2, g.invStd)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: mul invStd: %w", err)
+	}
+	dX, err := e.Reshape(ctx, dXg, g.inputShape)
+	if err != nil {
+		return nil, fmt.Errorf("GroupNormalization backward: reshape dX: %w", err)
+	}
+	return []*tensor.TensorNumeric[T]{dX}, nil
+}
+
+// reduceToChannelAndAccum reduces `full` ([N,C,*]) over every dim except the
+// channel dim, reshapes to the parameter's [C] shape, and accumulates.
+func (g *GroupNormalization[T]) reduceToChannelAndAccum(ctx context.Context, full *tensor.TensorNumeric[T], param *graph.Parameter[T]) error {
+	red := full
+	var err error
+	for dim := len(red.Shape()) - 1; dim >= 0; dim-- {
+		if dim == 1 {
+			continue
+		}
+		red, err = g.engine.ReduceSum(ctx, red, dim, true)
+		if err != nil {
+			return fmt.Errorf("GroupNormalization backward: reduce dim %d: %w", dim, err)
+		}
+	}
+	red, err = red.Reshape(param.Value.Shape())
+	if err != nil {
+		return fmt.Errorf("GroupNormalization backward: reshape param grad: %w", err)
+	}
+	if param.Gradient == nil {
+		param.Gradient = red
+	} else {
+		param.Gradient, err = g.engine.Add(ctx, param.Gradient, red, param.Gradient)
+		if err != nil {
+			return fmt.Errorf("GroupNormalization backward: accumulate param grad: %w", err)
+		}
+	}
+	return nil
+}
+
+// OpType returns "GroupNormalization".
+func (g *GroupNormalization[T]) OpType() string { return "GroupNormalization" }
+
+// Attributes returns the layer configuration.
+func (g *GroupNormalization[T]) Attributes() map[string]interface{} {
+	return map[string]interface{}{"num_groups": g.numGroups, "epsilon": g.epsilon}
+}
+
+// OutputShape returns the output shape (same as input; populated after Forward).
+func (g *GroupNormalization[T]) OutputShape() []int { return g.inputShape }
+
+// Parameters returns the learnable affine parameters when set.
+func (g *GroupNormalization[T]) Parameters() []*graph.Parameter[T] {
+	var params []*graph.Parameter[T]
+	if g.scale != nil {
+		params = append(params, g.scale)
+	}
+	if g.bias != nil {
+		params = append(params, g.bias)
+	}
+	return params
+}
+
+// BuildGroupNormalization constructs a GroupNormalization layer for the registry.
+// Reads "num_groups" (int/int64, default 32) and "epsilon" (default 1e-5).
+func BuildGroupNormalization[T tensor.Numeric](
+	engine compute.Engine[T],
+	ops numeric.Arithmetic[T],
+	_ string,
+	params map[string]*graph.Parameter[T],
+	attributes map[string]interface{},
+) (graph.Node[T], error) {
+	numGroups := 32
+	if v, ok := attributes["num_groups"]; ok {
+		switch g := v.(type) {
+		case int64:
+			numGroups = int(g)
+		case int:
+			numGroups = g
+		}
+	}
+	eps := 1e-5
+	if v, ok := attributes["epsilon"]; ok {
+		switch e := v.(type) {
+		case float64:
+			eps = e
+		case float32:
+			eps = float64(e)
+		}
+	}
+	scale, bias := params["scale"], params["bias"]
+	if scale != nil || bias != nil {
+		return NewGroupNormalizationWithParams(engine, ops, numGroups, ops.FromFloat64(eps), scale, bias), nil
+	}
+	return NewGroupNormalization(engine, ops, numGroups, ops.FromFloat64(eps)), nil
+}
+
+// Statically assert that GroupNormalization implements graph.Node + SaverAware.
+var (
+	_ graph.Node[float32]       = (*GroupNormalization[float32])(nil)
+	_ graph.SaverAware[float32] = (*GroupNormalization[float32])(nil)
+)

--- a/layers/normalization/group_norm_test.go
+++ b/layers/normalization/group_norm_test.go
@@ -1,0 +1,209 @@
+package normalization
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+func gnSeq(n int, seed float64) []float64 {
+	d := make([]float64, n)
+	s := seed
+	for i := range d {
+		s = math.Mod(s*1.123456789+0.314159, 2.0)
+		d[i] = s - 1.0
+	}
+	return d
+}
+
+// naiveGroupNorm is an independent reference: per (sample, group) mean/var over
+// the (C/groups)*S elements, then per-channel affine.
+func naiveGroupNorm(x []float64, n, c, s, groups int, eps float64, scale, bias []float64) []float64 {
+	cg := c / groups
+	m := cg * s
+	out := make([]float64, n*c*s)
+	for ni := range n {
+		for gi := range groups {
+			// mean/var over the group's m elements.
+			mean := 0.0
+			for cc := range cg {
+				ch := gi*cg + cc
+				for si := range s {
+					mean += x[(ni*c+ch)*s+si]
+				}
+			}
+			mean /= float64(m)
+			varr := 0.0
+			for cc := range cg {
+				ch := gi*cg + cc
+				for si := range s {
+					d := x[(ni*c+ch)*s+si] - mean
+					varr += d * d
+				}
+			}
+			varr /= float64(m)
+			inv := 1.0 / math.Sqrt(varr+eps)
+			for cc := range cg {
+				ch := gi*cg + cc
+				for si := range s {
+					idx := (ni*c+ch)*s + si
+					y := (x[idx] - mean) * inv
+					if scale != nil {
+						y *= scale[ch]
+					}
+					if bias != nil {
+						y += bias[ch]
+					}
+					out[idx] = y
+				}
+			}
+		}
+	}
+	return out
+}
+
+func TestGroupNorm_ForwardMatchesNaive(t *testing.T) {
+	type tc struct {
+		name   string
+		shape  []int
+		groups int
+	}
+	cases := []tc{
+		{"2d_no_spatial", []int{2, 4, 3}, 2},
+		{"4d_image", []int{2, 6, 2, 2}, 3},
+		{"5d_video", []int{1, 8, 2, 2, 2}, 4},
+	}
+	ops := numeric.Float64Ops{}
+	engine := compute.NewCPUEngine[float64](ops)
+	const eps = 1e-5
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			n, ch := c.shape[0], c.shape[1]
+			s := 1
+			for _, d := range c.shape[2:] {
+				s *= d
+			}
+			xData := gnSeq(n*ch*s, 0.6)
+			scaleData := gnSeq(ch, 1.1)
+			biasData := gnSeq(ch, 2.2)
+			x, _ := tensor.New[float64](c.shape, xData)
+			scaleT, _ := tensor.New[float64]([]int{ch}, scaleData)
+			biasT, _ := tensor.New[float64]([]int{ch}, biasData)
+			scale, _ := graph.NewParameter[float64]("scale", scaleT, tensor.New[float64])
+			bias, _ := graph.NewParameter[float64]("bias", biasT, tensor.New[float64])
+			gn := NewGroupNormalizationWithParams[float64](engine, ops, c.groups, eps, scale, bias)
+			out, err := gn.Forward(context.Background(), x)
+			if err != nil {
+				t.Fatalf("Forward: %v", err)
+			}
+			want := naiveGroupNorm(xData, n, ch, s, c.groups, eps, scaleData, biasData)
+			got := out.Data()
+			for i := range want {
+				if math.Abs(got[i]-want[i]) > 1e-9 {
+					t.Fatalf("mismatch at %d: got %v want %v", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGroupNorm_BackwardFiniteDiff(t *testing.T) {
+	ops := numeric.Float64Ops{}
+	engine := compute.NewCPUEngine[float64](ops)
+	const (
+		n, ch, s, groups = 2, 4, 3, 2
+		eps              = 1e-5
+		h                = 1e-6
+	)
+	shape := []int{n, ch, s}
+	xData := gnSeq(n*ch*s, 0.42)
+	scaleData := gnSeq(ch, 1.7)
+	biasData := gnSeq(ch, 0.9)
+	dOut := gnSeq(n*ch*s, 3.3) // arbitrary upstream gradient
+
+	// forwardData runs a fresh layer and returns the flat output.
+	forwardData := func(x, sc, bi []float64) []float64 {
+		xt, _ := tensor.New[float64](shape, append([]float64(nil), x...))
+		st, _ := tensor.New[float64]([]int{ch}, append([]float64(nil), sc...))
+		bt, _ := tensor.New[float64]([]int{ch}, append([]float64(nil), bi...))
+		sp, _ := graph.NewParameter[float64]("scale", st, tensor.New[float64])
+		bp, _ := graph.NewParameter[float64]("bias", bt, tensor.New[float64])
+		gn := NewGroupNormalizationWithParams[float64](engine, ops, groups, eps, sp, bp)
+		out, err := gn.Forward(context.Background(), xt)
+		if err != nil {
+			t.Fatalf("Forward: %v", err)
+		}
+		return out.Data()
+	}
+	lossAt := func(x, sc, bi []float64) float64 {
+		y := forwardData(x, sc, bi)
+		l := 0.0
+		for i := range y {
+			l += dOut[i] * y[i]
+		}
+		return l
+	}
+
+	// Analytic gradients.
+	xt, _ := tensor.New[float64](shape, append([]float64(nil), xData...))
+	st, _ := tensor.New[float64]([]int{ch}, append([]float64(nil), scaleData...))
+	bt, _ := tensor.New[float64]([]int{ch}, append([]float64(nil), biasData...))
+	sp, _ := graph.NewParameter[float64]("scale", st, tensor.New[float64])
+	bp, _ := graph.NewParameter[float64]("bias", bt, tensor.New[float64])
+	gn := NewGroupNormalizationWithParams[float64](engine, ops, groups, eps, sp, bp)
+	if _, err := gn.Forward(context.Background(), xt); err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	dOutT, _ := tensor.New[float64](shape, append([]float64(nil), dOut...))
+	grads, err := gn.Backward(context.Background(), 0, dOutT, xt)
+	if err != nil {
+		t.Fatalf("Backward: %v", err)
+	}
+	dXAnalytic := grads[0].Data()
+
+	central := func(perturb func(i int, delta float64) ([]float64, []float64, []float64), i int) float64 {
+		xp, sp, bp := perturb(i, +h)
+		lp := lossAt(xp, sp, bp)
+		xm, sm, bm := perturb(i, -h)
+		lm := lossAt(xm, sm, bm)
+		return (lp - lm) / (2 * h)
+	}
+
+	// dX check.
+	for i := range xData {
+		num := central(func(j int, delta float64) ([]float64, []float64, []float64) {
+			xp := append([]float64(nil), xData...)
+			xp[j] += delta
+			return xp, scaleData, biasData
+		}, i)
+		if math.Abs(num-dXAnalytic[i]) > 1e-5 {
+			t.Fatalf("dX[%d]: analytic %v vs finite-diff %v", i, dXAnalytic[i], num)
+		}
+	}
+	// dScale / dBias checks.
+	dScale := sp.Gradient.Data()
+	dBias := bp.Gradient.Data()
+	for cidx := range ch {
+		numS := central(func(j int, delta float64) ([]float64, []float64, []float64) {
+			scp := append([]float64(nil), scaleData...)
+			scp[j] += delta
+			return xData, scp, biasData
+		}, cidx)
+		if math.Abs(numS-dScale[cidx]) > 1e-5 {
+			t.Fatalf("dScale[%d]: analytic %v vs finite-diff %v", cidx, dScale[cidx], numS)
+		}
+		numB := central(func(j int, delta float64) ([]float64, []float64, []float64) {
+			bip := append([]float64(nil), biasData...)
+			bip[j] += delta
+			return xData, scaleData, bip
+		}, cidx)
+		if math.Abs(numB-dBias[cidx]) > 1e-5 {
+			t.Fatalf("dBias[%d]: analytic %v vs finite-diff %v", cidx, dBias[cidx], numB)
+		}
+	}
+}

--- a/layers/vision/ltx_vae_decode.go
+++ b/layers/vision/ltx_vae_decode.go
@@ -1,0 +1,185 @@
+package vision
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zerfoo/zerfoo/layers/activations"
+	"github.com/zerfoo/zerfoo/layers/core"
+	"github.com/zerfoo/zerfoo/layers/normalization"
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// LTXVAEDecoderSkeleton is a SKELETON of the LTX-2 video VAE decoder (E127
+// T127.4.4). It wires the E127 convolutional primitives -- Conv3d,
+// ConvTranspose3d (zerfoo#896) and GroupNormalization -- together with GELU
+// into a representative residual + 2x-upsample decode forward, to prove the
+// primitive set composes end-to-end and produces correctly shaped output.
+//
+// It is intentionally NOT the weight-accurate LTX-2 VAE: the real decoder's
+// block_out_channels = [256,512,1024,2048], 32x spatial / 8x temporal upsample,
+// stacked ResNet3D blocks, mid-block 3D attention, and the actual converted
+// weights are the remainder of T127.4.4. Treat this as scaffolding/integration
+// surface, not a correctness reference. The weights here are small deterministic
+// fixtures so the forward runs and is finite.
+//
+// Pipeline (latent [N, Clatent, D, H, W] -> [N, OutChannels, 2D, 2H, 2W]):
+//
+//	in-conv (1x1x1)
+//	-> residual{ GroupNorm -> GELU -> Conv3d(3x3x3, same) } (+ skip)
+//	-> ConvTranspose3d(2x2x2, stride 2)  [2x upsample]
+//	-> GroupNorm -> GELU -> out-conv(3x3x3, same -> OutChannels)
+type LTXVAEDecoderSkeleton[T tensor.Float] struct {
+	engine compute.Engine[T]
+
+	inConv, midConv, outConv *core.Conv3d[T]
+	up                       *core.ConvTranspose3d[T]
+	gn1, gn2                 *normalization.GroupNormalization[T]
+	act                      *activations.Gelu[T]
+
+	inW, midW, outW, upW *tensor.TensorNumeric[T]
+	outputShape          []int
+}
+
+// LTXVAEDecoderConfig parameterizes the skeleton.
+type LTXVAEDecoderConfig struct {
+	LatentChannels int // input channels (e.g. 128 for LTX-2)
+	MidChannels    int // working channels (must be divisible by NumGroups)
+	OutChannels    int // output channels (3 for RGB)
+	NumGroups      int
+	Epsilon        float64
+}
+
+// fixtureWeights builds a deterministic small weight tensor of the given shape.
+func fixtureWeights[T tensor.Float](shape []int, seed int) (*tensor.TensorNumeric[T], error) {
+	size := 1
+	for _, d := range shape {
+		size *= d
+	}
+	data := make([]T, size)
+	s := uint64(seed*2654435761 + 1)
+	for i := range data {
+		s = s*6364136223846793005 + 1442695040888963407
+		data[i] = T(float64(int64(s>>40))/float64(1<<24)*0.1 - 0.05) // ~[-0.05,0.05]
+	}
+	return tensor.New[T](shape, data)
+}
+
+// NewLTXVAEDecoderSkeleton builds the skeleton with deterministic fixture weights.
+func NewLTXVAEDecoderSkeleton[T tensor.Float](
+	engine compute.Engine[T],
+	ops numeric.Arithmetic[T],
+	cfg LTXVAEDecoderConfig,
+) (*LTXVAEDecoderSkeleton[T], error) {
+	if cfg.OutChannels == 0 {
+		cfg.OutChannels = 3
+	}
+	if cfg.NumGroups == 0 {
+		cfg.NumGroups = 1
+	}
+	if cfg.Epsilon == 0 {
+		cfg.Epsilon = 1e-5
+	}
+	if cfg.MidChannels%cfg.NumGroups != 0 {
+		return nil, fmt.Errorf("LTXVAEDecoderSkeleton: MidChannels %d not divisible by NumGroups %d", cfg.MidChannels, cfg.NumGroups)
+	}
+
+	mkGN := func() (*normalization.GroupNormalization[T], error) {
+		scaleData := make([]T, cfg.MidChannels)
+		for i := range scaleData {
+			scaleData[i] = T(1) // identity scale, zero bias -> clean fixture
+		}
+		biasData := make([]T, cfg.MidChannels)
+		st, err := tensor.New[T]([]int{cfg.MidChannels}, scaleData)
+		if err != nil {
+			return nil, err
+		}
+		bt, err := tensor.New[T]([]int{cfg.MidChannels}, biasData)
+		if err != nil {
+			return nil, err
+		}
+		sp, err := graph.NewParameter[T]("scale", st, tensor.New[T])
+		if err != nil {
+			return nil, err
+		}
+		bp, err := graph.NewParameter[T]("bias", bt, tensor.New[T])
+		if err != nil {
+			return nil, err
+		}
+		return normalization.NewGroupNormalizationWithParams[T](engine, ops, cfg.NumGroups, ops.FromFloat64(cfg.Epsilon), sp, bp), nil
+	}
+
+	d := &LTXVAEDecoderSkeleton[T]{engine: engine, act: activations.NewGelu[T](engine, ops)}
+	var err error
+	if d.gn1, err = mkGN(); err != nil {
+		return nil, err
+	}
+	if d.gn2, err = mkGN(); err != nil {
+		return nil, err
+	}
+	d.inConv = core.NewConv3d[T](engine, ops, []int{1, 1, 1}, []int{0, 0, 0, 0, 0, 0}, []int{1, 1, 1}, 1)
+	d.midConv = core.NewConv3d[T](engine, ops, []int{1, 1, 1}, []int{1, 1, 1, 1, 1, 1}, []int{1, 1, 1}, 1)
+	d.outConv = core.NewConv3d[T](engine, ops, []int{1, 1, 1}, []int{1, 1, 1, 1, 1, 1}, []int{1, 1, 1}, 1)
+	d.up = core.NewConvTranspose3d[T](engine, ops, []int{2, 2, 2}, []int{0, 0, 0, 0, 0, 0}, []int{1, 1, 1}, []int{0, 0, 0}, 1)
+
+	// Weights: Conv3d [Cout,Cin,kD,kH,kW]; ConvTranspose3d [Cin,Cout,kD,kH,kW].
+	if d.inW, err = fixtureWeights[T]([]int{cfg.MidChannels, cfg.LatentChannels, 1, 1, 1}, 1); err != nil {
+		return nil, err
+	}
+	if d.midW, err = fixtureWeights[T]([]int{cfg.MidChannels, cfg.MidChannels, 3, 3, 3}, 2); err != nil {
+		return nil, err
+	}
+	if d.upW, err = fixtureWeights[T]([]int{cfg.MidChannels, cfg.MidChannels, 2, 2, 2}, 3); err != nil {
+		return nil, err
+	}
+	if d.outW, err = fixtureWeights[T]([]int{cfg.OutChannels, cfg.MidChannels, 3, 3, 3}, 4); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// Forward decodes a latent [N, LatentChannels, D, H, W] to [N, OutChannels, 2D, 2H, 2W].
+func (d *LTXVAEDecoderSkeleton[T]) Forward(ctx context.Context, latent *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
+	e := d.engine
+	h, err := d.inConv.Forward(ctx, latent, d.inW)
+	if err != nil {
+		return nil, fmt.Errorf("vae skeleton: in-conv: %w", err)
+	}
+	// Residual block: h = h + Conv3d(GELU(GroupNorm(h))).
+	r, err := d.gn1.Forward(ctx, h)
+	if err != nil {
+		return nil, fmt.Errorf("vae skeleton: gn1: %w", err)
+	}
+	if r, err = d.act.Forward(ctx, r); err != nil {
+		return nil, fmt.Errorf("vae skeleton: act1: %w", err)
+	}
+	if r, err = d.midConv.Forward(ctx, r, d.midW); err != nil {
+		return nil, fmt.Errorf("vae skeleton: mid-conv: %w", err)
+	}
+	if h, err = e.Add(ctx, h, r); err != nil {
+		return nil, fmt.Errorf("vae skeleton: residual add: %w", err)
+	}
+	// Upsample 2x in each spatial dim.
+	if h, err = d.up.Forward(ctx, h, d.upW); err != nil {
+		return nil, fmt.Errorf("vae skeleton: upsample: %w", err)
+	}
+	// Out head: GroupNorm -> GELU -> Conv3d -> OutChannels.
+	if h, err = d.gn2.Forward(ctx, h); err != nil {
+		return nil, fmt.Errorf("vae skeleton: gn2: %w", err)
+	}
+	if h, err = d.act.Forward(ctx, h); err != nil {
+		return nil, fmt.Errorf("vae skeleton: act2: %w", err)
+	}
+	out, err := d.outConv.Forward(ctx, h, d.outW)
+	if err != nil {
+		return nil, fmt.Errorf("vae skeleton: out-conv: %w", err)
+	}
+	d.outputShape = out.Shape()
+	return out, nil
+}
+
+// OutputShape returns the last forward output shape.
+func (d *LTXVAEDecoderSkeleton[T]) OutputShape() []int { return d.outputShape }

--- a/layers/vision/ltx_vae_decode_test.go
+++ b/layers/vision/ltx_vae_decode_test.go
@@ -1,0 +1,62 @@
+package vision
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// TestLTXVAEDecoderSkeleton_ForwardShape verifies the E127 conv/norm primitives
+// (Conv3d, ConvTranspose3d, GroupNormalization, GELU) compose end-to-end into a
+// running decode forward that 2x-upsamples each spatial dim and emits the
+// configured output channels, with a finite result.
+func TestLTXVAEDecoderSkeleton_ForwardShape(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine[float32](ops)
+
+	cfg := LTXVAEDecoderConfig{
+		LatentChannels: 16,
+		MidChannels:    8,
+		OutChannels:    3,
+		NumGroups:      4,
+		Epsilon:        1e-5,
+	}
+	dec, err := NewLTXVAEDecoderSkeleton[float32](engine, ops, cfg)
+	if err != nil {
+		t.Fatalf("NewLTXVAEDecoderSkeleton: %v", err)
+	}
+
+	// Fixture latent [N=1, C=16, D=2, H=3, W=3].
+	const n, d, h, w = 1, 2, 3, 3
+	size := n * cfg.LatentChannels * d * h * w
+	data := make([]float32, size)
+	for i := range data {
+		data[i] = float32(math.Sin(float64(i) * 0.1)) // deterministic, bounded
+	}
+	latent, _ := tensor.New[float32]([]int{n, cfg.LatentChannels, d, h, w}, data)
+
+	out, err := dec.Forward(context.Background(), latent)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+
+	want := []int{n, cfg.OutChannels, 2 * d, 2 * h, 2 * w}
+	got := out.Shape()
+	if len(got) != len(want) {
+		t.Fatalf("rank: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("shape: got %v want %v", got, want)
+		}
+	}
+	for i, v := range out.Data() {
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			t.Fatalf("non-finite output at %d: %v", i, v)
+		}
+	}
+}


### PR DESCRIPTION
Two CPU-verified increments toward the E127 video VAE.

## GroupNormalization production layer (`layers/normalization/group_norm.go`)
The zerfoo production GroupNorm that **T127.4.1 left pending** (only the ztensor oracle reference existed). Forward + backward over `[N,C,*spatial]` — per-group statistics + per-channel affine, all via Engine primitives, mirroring `BatchNormalization` conventions.
- **Verified:** forward vs an independent naive reference (2D / 4D-image / 5D-video), and a **finite-difference check** of dX, dScale, dBias.

## LTX-2 VAE decoder skeleton (`layers/vision/ltx_vae_decode.go`) — T127.4.4 scaffolding
Wires **Conv3d + ConvTranspose3d (#896) + GroupNormalization + GELU** into a representative residual + 2×-upsample decode forward, proving the E127 primitive set composes end-to-end.
- **Explicitly a SKELETON** — NOT the weight-accurate LTX-2 VAE (real `block_out_channels`, stacked ResNet3D, mid-block attention, and converted weights are the rest of T127.4.4). Weights are small deterministic fixtures.
- **Verified:** forward-shape (`[N,C,D,H,W]→[N,3,2D,2H,2W]`) + finiteness test.

`go vet` clean; full module builds; `layers/{normalization,vision,core}` suites green.

## Follow-ups (not this PR)
GroupNormalization registry wiring; the weight-accurate VAE decoder (real config + converted weights); torch-oracle on GB10.

Refs #886. Builds on #896 (Conv3d/ConvTranspose3d) and the T127.1.0a oracle ops.