### PR TITLE
fix(optimizer): keep AdamW grad-norm reduction on-device (T11.8)

### DIFF
--- a/tests/parity/gpu_parity_ops_test.go
+++ b/tests/parity/gpu_parity_ops_test.go
@@ -111,6 +111,68 @@ func TestGPUParity_Linear(t *testing.T) {
 	assertGPUClose(t, "linear_forward", cpuOut.Data(), gpuOut.Data(), 1e-3)
 }
 
+// TestGPUParity_GradNormReduceAll pins the T11.8 fix: AdamW's gradient-norm
+// guard sums a whole (possibly multi-dimensional) gradient to a scalar. The fix
+// reshapes the gradient to rank-1 and reduces axis 0 so the reduction runs
+// on-device (the negative-axis "reduce all" sentinel falls back to a host copy
+// in ztensor's gpuSum). This asserts the on-device path -- reshape-to-rank-1 +
+// ReduceSum(axis 0), for both the raw sum (NaN/Inf probe) and the sum-of-squares
+// (global norm) -- produces the IDENTICAL scalar on the CPU and GPU engines.
+// The reshape is a storage-sharing view, so the GPU operand stays device-resident.
+func TestGPUParity_GradNormReduceAll(t *testing.T) {
+	cpuEng, gpuEng, gpuRaw, _ := gpuOpsSetup(t)
+	ctx := context.Background()
+
+	// Multi-dim gradient: a single-axis reduction would NOT collapse this to a
+	// scalar, so this also guards the all-axes semantics on the device.
+	gradData := deterministicData(4 * 16)
+	shape := []int{4, 16}
+
+	// CPU: reshape -> ReduceSum(axis 0); square -> ReduceSum(axis 0).
+	cpuGrad := testutil.MakeTensor(t, gradData, shape)
+	cpuFlat, err := cpuGrad.Reshape([]int{-1})
+	if err != nil {
+		t.Fatalf("CPU reshape: %v", err)
+	}
+	cpuSum, err := cpuEng.ReduceSum(ctx, cpuFlat, 0, false)
+	if err != nil {
+		t.Fatalf("CPU ReduceSum: %v", err)
+	}
+	cpuSq, err := cpuEng.Mul(ctx, cpuFlat, cpuFlat, nil)
+	if err != nil {
+		t.Fatalf("CPU Mul: %v", err)
+	}
+	cpuSqSum, err := cpuEng.ReduceSum(ctx, cpuSq, 0, false)
+	if err != nil {
+		t.Fatalf("CPU ReduceSum sq: %v", err)
+	}
+
+	// GPU: same operations, on-device (operand uploaded; reshape keeps residency).
+	gpuGrad := testutil.MakeTensor(t, cloneF32(gradData), shape)
+	if err := gpuRaw.UploadWeights([]*tensor.TensorNumeric[float32]{gpuGrad}); err != nil {
+		t.Fatalf("UploadWeights: %v", err)
+	}
+	gpuFlat, err := gpuGrad.Reshape([]int{-1})
+	if err != nil {
+		t.Fatalf("GPU reshape: %v", err)
+	}
+	gpuSum, err := gpuEng.ReduceSum(ctx, gpuFlat, 0, false)
+	if err != nil {
+		t.Fatalf("GPU ReduceSum: %v", err)
+	}
+	gpuSq, err := gpuEng.Mul(ctx, gpuFlat, gpuFlat, nil)
+	if err != nil {
+		t.Fatalf("GPU Mul: %v", err)
+	}
+	gpuSqSum, err := gpuEng.ReduceSum(ctx, gpuSq, 0, false)
+	if err != nil {
+		t.Fatalf("GPU ReduceSum sq: %v", err)
+	}
+
+	assertGPUClose(t, "gradnorm_sum_all_axes", cpuSum.Data(), gpuSum.Data(), 1e-3)
+	assertGPUClose(t, "gradnorm_sqsum_all_axes", cpuSqSum.Data(), gpuSqSum.Data(), 1e-2)
+}
+
 func TestGPUParity_MatMul(t *testing.T) {
 	cpuEng, gpuEng, gpuRaw, _ := gpuOpsSetup(t)
 	ctx := context.Background()

--- a/training/optimizer/adamw.go
+++ b/training/optimizer/adamw.go
@@ -533,7 +533,20 @@ func (a *AdamW[T]) guardAndClipGradients(ctx context.Context, params []*graph.Pa
 			continue
 		}
 
-		sumTensor, err := a.engine.ReduceSum(ctx, grad, -1, false)
+		// T11.8: reduce over the whole gradient ON-DEVICE. The negative-axis
+		// "reduce over all axes" sentinel (ReduceSum(grad, -1, ...)) hits ztensor
+		// gpuSum's axis<0 CPU fallback, which copies the entire gradient host-side
+		// (a per-parameter D2H of the full tensor) just to produce one scalar.
+		// Reshaping to rank-1 and reducing axis 0 runs the on-device SumAxis
+		// kernel instead, so only the 4-byte scalar result is copied back. Reshape
+		// shares the underlying storage (it is a view), so a GPU-resident gradient
+		// stays resident; the reduced scalar is identical to the all-axes sum.
+		gradFlat, err := grad.Reshape([]int{-1})
+		if err != nil {
+			return fmt.Errorf("adamw: reshape gradient of parameter %q: %w", param.Name, err)
+		}
+
+		sumTensor, err := a.engine.ReduceSum(ctx, gradFlat, 0, false)
 		if err != nil {
 			return fmt.Errorf("adamw: ReduceSum failed for parameter %q: %w", param.Name, err)
 		}
@@ -548,12 +561,12 @@ func (a *AdamW[T]) guardAndClipGradients(ctx context.Context, params []*graph.Pa
 			return fmt.Errorf("adamw: Inf detected in gradient of parameter %q", param.Name)
 		}
 
-		gradSquared, err := a.engine.Mul(ctx, grad, grad, nil)
+		gradSquared, err := a.engine.Mul(ctx, gradFlat, gradFlat, nil)
 		if err != nil {
 			return fmt.Errorf("adamw: Mul failed for parameter %q: %w", param.Name, err)
 		}
 
-		sqSumTensor, err := a.engine.ReduceSum(ctx, gradSquared, -1, false)
+		sqSumTensor, err := a.engine.ReduceSum(ctx, gradSquared, 0, false)
 		if err != nil {
 			return fmt.Errorf("adamw: ReduceSum failed for parameter %q: %w", param.Name, err)
 		}

--- a/training/optimizer/adamw_test.go
+++ b/training/optimizer/adamw_test.go
@@ -525,6 +525,75 @@ func TestAdamW_Step_GradientClippingActuallyClips(t *testing.T) {
 	testutils.AssertFloatEqual(t, 1.0, clippedNorm, 1e-5, "Clipped gradient norm should be 1.0")
 }
 
+// TestAdamW_GuardClip_MultiDimReducesAllAxes pins the T11.8 invariant: the
+// gradient-norm reduction must sum over EVERY element of a multi-dimensional
+// gradient, not just one axis/stripe. The fix reshapes each gradient to rank-1
+// and reduces axis 0 (on-device when GPU-resident); this test proves that the
+// reshape-then-reduce path still computes the global norm over all axes on a
+// 2-D gradient, where a single-last-axis reduction (or a stale .Data()[0] of a
+// non-scalar result) would silently use only the first row and clip wrongly.
+func TestAdamW_GuardClip_MultiDimReducesAllAxes(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine[float32](ops)
+
+	adamw := NewAdamW[float32](engine, 0.01, 0.9, 0.999, 1e-8, 0.0)
+	adamw.SetMaxGradNorm(1.0)
+
+	// 2-D gradient: global norm over ALL elements = sqrt(3^2+0+0+4^2) = 5.0.
+	// A last-axis-only reduction would see row sums [3,4] and mis-scale.
+	value, err := tensor.New[float32]([]int{2, 2}, []float32{1, 2, 3, 4})
+	testutils.AssertNoError(t, err, "Failed to create value tensor")
+	gradient, err := tensor.New[float32]([]int{2, 2}, []float32{3, 0, 0, 4})
+	testutils.AssertNoError(t, err, "Failed to create gradient tensor")
+
+	param, err := graph.NewParameter("w", value, tensor.New[float32])
+	testutils.AssertNoError(t, err, "Failed to create parameter")
+	param.Gradient = gradient
+
+	err = adamw.guardAndClipGradients(context.Background(), []*graph.Parameter[float32]{param})
+	testutils.AssertNoError(t, err, "guardAndClipGradients should not error")
+
+	// scale = MaxGradNorm/globalNorm = 1/5 = 0.2 applied to every element.
+	clipped := param.Gradient.Data()
+	want := []float32{0.6, 0.0, 0.0, 0.8}
+	for i, w := range want {
+		testutils.AssertFloatEqual(t, float64(w), float64(clipped[i]), 1e-5,
+			"clipped gradient element should use the all-axes global norm")
+	}
+	clippedNorm := 0.0
+	for _, v := range clipped {
+		clippedNorm += float64(v) * float64(v)
+	}
+	testutils.AssertFloatEqual(t, 1.0, math.Sqrt(clippedNorm), 1e-5,
+		"clipped global norm should be 1.0")
+}
+
+// TestAdamW_GuardClip_MultiDimDetectsNaNAnyAxis ensures NaN/Inf detection still
+// inspects the whole gradient after the T11.8 reshape: a non-finite value in a
+// LATER row (not the first stripe) must still be detected. A reduction that
+// collapsed only one axis and read .Data()[0] would miss it.
+func TestAdamW_GuardClip_MultiDimDetectsNaNAnyAxis(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine[float32](ops)
+	adamw := NewAdamW[float32](engine, 0.01, 0.9, 0.999, 1e-8, 0.0)
+	adamw.SetMaxGradNorm(1.0)
+
+	value, err := tensor.New[float32]([]int{2, 2}, []float32{1, 2, 3, 4})
+	testutils.AssertNoError(t, err, "Failed to create value tensor")
+	// NaN sits at [1,1] -- the last element, deep past the first stripe.
+	gradient, err := tensor.New[float32]([]int{2, 2}, []float32{0.1, 0.2, 0.3, float32(math.NaN())})
+	testutils.AssertNoError(t, err, "Failed to create gradient tensor")
+
+	param, err := graph.NewParameter("w", value, tensor.New[float32])
+	testutils.AssertNoError(t, err, "Failed to create parameter")
+	param.Gradient = gradient
+
+	err = adamw.guardAndClipGradients(context.Background(), []*graph.Parameter[float32]{param})
+	if err == nil {
+		t.Fatal("expected NaN in a later gradient row to be detected, got nil error")
+	}
+}
+
 func TestAdamW_Step_NormalGradientUnchanged(t *testing.T) {
 	ops := numeric.Float32Ops{}
 	engine := compute.NewCPUEngine[float32](ops)


### PR DESCRIPTION
## Summary

`AdamW.guardAndClipGradients` reduced each gradient to a scalar via `ReduceSum(grad, -1, false)`. The negative axis is the *"reduce over all axes"* sentinel, and ztensor's `gpuSum` falls back to CPU for `axis < 0` (`compute/gpu_kernels.go`). On the GPU that meant copying the **entire gradient host-side, per parameter, every step**, just to produce one scalar — part of the H2D/D2H firehose scoped in Wolf's T11.0b.

**Fix:** reshape each gradient to rank-1 and reduce **axis 0**. `Reshape` returns a storage-sharing view (`isView: true`), so a GPU-resident gradient stays resident; reducing a non-negative axis runs ztensor's on-device `SumAxis` kernel and only the 4-byte scalar is copied back. A rank-1 tensor's axis-0 reduction **is** the sum over every element, so the global norm and NaN/Inf detection are unchanged.

General-purpose: any `T`, any engine. Self-contained in zerfoo — no ztensor change or release needed.

## Why this is the right layer

The reduction's result is identical; only its *location* changes (device vs host). The negative-axis "reduce all" CPU fallback in `gpuSum` stays correct for other callers; this fix simply expresses the AdamW grad-norm as an on-device positive-axis reduction so the optimizer stops round-tripping whole gradients.

## Tests

- **`training/optimizer/adamw_test.go`** (CPU, run in CI):
  - `TestAdamW_GuardClip_MultiDimReducesAllAxes` — a 2-D gradient `[[3,0],[0,4]]` must clip by the **all-axes** global norm (5.0 → scale 0.2). A last-axis-only reduction would use row sums and mis-scale.
  - `TestAdamW_GuardClip_MultiDimDetectsNaNAnyAxis` — a NaN in the **last** element (not the first stripe) is still detected.
  - Existing guard/clip tests still pass.
- **`tests/parity/gpu_parity_ops_test.go`**: `TestGPUParity_GradNormReduceAll` asserts the `reshape → ReduceSum(axis 0)` path (raw sum + sum-of-squares) yields **identical scalars on the CPU and GPU engines**. Skips without a GPU; runs on GB10 via `scripts/dgx-spark-parity.sh`.

## Validation

- `go build ./...` — OK
- `go vet ./training/... ./tests/parity/` — OK
- `go test ./training/...` — PASS (optimizer incl. new tests)
- `gofmt -l` — clean
- GPU parity (`TestGPUParity_GradNormReduceAll`) — skips locally (no CUDA); **GB10 run pending** via the DGX parity suite.

Tracked as **T11.8 (G4)** in Wolf's `docs/plan-pytorch-speed-parity.md`.