### PR TITLE
fix(parity): build GPU parity container with CGO, no cuda tag (#902)

### DIFF
--- a/tests/parity/Containerfile
+++ b/tests/parity/Containerfile
@@ -1,14 +1,22 @@
 # GPU parity test container.
 #
-# Multi-stage build: compiles a static test binary in the builder stage,
+# Multi-stage build: compiles the parity test binary in the builder stage,
 # then copies it into a minimal Ubuntu 24.04 runtime image. CUDA libs are
 # mounted from the host at runtime (see gpu-parity.yaml manifest).
 #
 # Build:
 #   docker build --platform linux/arm64 -f tests/parity/Containerfile -t ghcr.io/zerfoo/zerfoo-parity:latest .
 #
-# The test binary is built with CGO_ENABLED=0 — GPU acceleration is loaded
-# at runtime via purego/dlopen from host-mounted /usr/local/cuda.
+# CGO is ENABLED but the build needs NO CUDA toolkit or cutlass headers
+# (issue #902). The binary is built WITHOUT the `cuda` build tag, so:
+#   - internal/cuda selects the cgo dlopen path (purego_linux_arm64_cgo.go),
+#     which resolves dlopen/dlsym at link time (the CGO-free !cgo path's
+#     //go:linkname runtime.dlopen is unresolvable in a static binary --
+#     the original `-tags cuda` + CGO_ENABLED=0 combination did not link).
+#   - ztensor selects its `!cuda` purego kernel bindings, which dlopen the
+#     real CUDA kernels at runtime from the host-mounted /usr/local/cuda and
+#     /opt/zerfoo/lib (see gpu-parity.yaml). No CUDA/cutlass at build time.
+# A plain gcc (already in golang:1.26-bookworm) satisfies CGO.
 
 # ── Build stage ──────────────────────────────────────────────────────────────
 FROM golang:1.26-bookworm AS build
@@ -21,9 +29,10 @@ RUN go mod download
 
 COPY . .
 
-# Compile the parity test binary for linux/arm64.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
-    go test -c -tags cuda -trimpath \
+# Compile the parity test binary for linux/arm64. CGO on, no `cuda` tag
+# (issue #902): cgo dlopen path links; CUDA kernels load at runtime via dlopen.
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=arm64 \
+    go test -c -trimpath \
     -o /out/parity-test ./tests/parity/
 
 # ── Runtime stage ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #902 — the GPU parity container would not build.

**Root cause (two dead ends):**
- The Containerfile used `CGO_ENABLED=0` + `-tags cuda`. The `cuda` tag selects ztensor's **cgo** CUDA kernels, which can't link without cgo → `undefined: kernels.GemmQ4F32 / Transpose2D / FusedRoPEF32 / ...`
- Dropping the tag under `CGO_ENABLED=0` falls through to the CGO-free dlopen path (`internal/cuda/purego_linux_arm64.go`), whose `//go:linkname runtime.dlopen` is unresolvable in a static binary → `relocation target runtime.dlopen not defined`. Verified on a **linux/arm64 native** build (not just a darwin cross-compile), so that path genuinely does not link.

**Fix:** build with `CGO_ENABLED=1` and **no** `cuda` tag.
- `internal/cuda` then selects the **cgo** dlopen path (`purego_linux_arm64_cgo.go`), which links.
- ztensor selects its `!cuda` **purego** kernel bindings, which dlopen the real CUDA kernels at runtime from host-mounted `/usr/local/cuda` + `/opt/zerfoo/lib` (already mounted by `docs/bench/manifests/gpu-parity.yaml`).
- No CUDA toolkit or cutlass headers are needed at build time — the gcc already in `golang:1.26-bookworm` satisfies CGO.

## Validation

- `go test -c` (CGO=1, no cuda tag) links and produces the binary on linux/arm64 (verified in a `golang:1.26-bookworm` arm64 container).
- Full multi-stage image builds (`podman build --platform linux/arm64`).
- Image pushed to the DGX registry and the parity suite **run on GB10 via Spark** — see PR comment for the live result (validates this fix end-to-end + the T11.8 `TestGPUParity_GradNormReduceAll` gate).

Unblocks GB10 GPU-gate validation for the speed-parity track.