### PR TITLE
feat(regularization): optional seeded RNG for reproducible Dropout masks

### DIFF
--- a/layers/regularization/dropout.go
+++ b/layers/regularization/dropout.go
@@ -25,6 +25,12 @@ type Dropout[T tensor.Float] struct {
 	rate     T
 	training bool
 
+	// rng, when non-nil, is a seeded source used to draw the dropout mask so
+	// that training is reproducible. When nil (the default) the package-global
+	// unseeded math/rand/v2 source is used, preserving the historical
+	// non-deterministic behavior. See WithDropoutSeed / WithDropoutSource.
+	rng *rand.Rand
+
 	// Cache for backward pass. The mask is registered with the
 	// save-for-backward contract (ztensor ADR 006) every training-mode
 	// Forward: it cannot be recomputed (it is random), so arena-backed
@@ -34,6 +40,33 @@ type Dropout[T tensor.Float] struct {
 	saver       graph.Saver[T] // wired by graph Builder (graph.SaverAware); nil outside a Graph
 }
 
+// DropoutOption configures optional behavior of a Dropout layer.
+type DropoutOption[T tensor.Float] func(*Dropout[T])
+
+// WithDropoutSeed returns a DropoutOption that makes the dropout mask
+// reproducible by drawing it from a deterministic source seeded with the
+// given value. Two layers constructed with the same seed produce identical
+// masks for identical inputs and call sequences. Without this option (the
+// default) masks are drawn from the unseeded package-global source and are
+// not reproducible.
+func WithDropoutSeed[T tensor.Float](seed uint64) DropoutOption[T] {
+	return func(d *Dropout[T]) {
+		d.rng = rand.New(rand.NewPCG(seed, seed^0x9E3779B97F4A7C15)) //#nosec G404
+	}
+}
+
+// WithDropoutSource returns a DropoutOption that draws the dropout mask from
+// the provided source, allowing callers to supply their own seeded or shared
+// rand.Source for reproducible training. A nil source is ignored, leaving the
+// default unseeded behavior in place.
+func WithDropoutSource[T tensor.Float](src rand.Source) DropoutOption[T] {
+	return func(d *Dropout[T]) {
+		if src != nil {
+			d.rng = rand.New(src) //#nosec G404
+		}
+	}
+}
+
 // SetSaver implements graph.SaverAware.
 func (d *Dropout[T]) SetSaver(sv graph.Saver[T]) {
 	d.saver = sv
@@ -41,12 +74,31 @@ func (d *Dropout[T]) SetSaver(sv graph.Saver[T]) {
 
 // NewDropout creates a new Dropout layer with the given drop rate.
 // The rate must be in [0, 1). A rate of 0 disables dropout entirely.
-func NewDropout[T tensor.Float](engine compute.Engine[T], ops numeric.Arithmetic[T], rate T) *Dropout[T] {
-	return &Dropout[T]{
+//
+// By default the dropout mask is drawn from the unseeded package-global
+// math/rand/v2 source, so masks are not reproducible across runs. Pass
+// WithDropoutSeed or WithDropoutSource to make the mask deterministic.
+func NewDropout[T tensor.Float](engine compute.Engine[T], ops numeric.Arithmetic[T], rate T, opts ...DropoutOption[T]) *Dropout[T] {
+	d := &Dropout[T]{
 		engine: engine,
 		ops:    ops,
 		rate:   rate,
 	}
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
+}
+
+// randFloat64 returns the next mask draw, using the layer's seeded source when
+// configured and falling back to the unseeded package-global source otherwise.
+func (d *Dropout[T]) randFloat64() float64 {
+	if d.rng != nil {
+		return d.rng.Float64()
+	}
+
+	return rand.Float64() //#nosec G404
 }
 
 // OpType returns the operation type.
@@ -101,7 +153,7 @@ func (d *Dropout[T]) Forward(ctx context.Context, inputs ...*tensor.TensorNumeri
 
 	maskData := make([]T, size)
 	for i := range maskData {
-		if rand.Float64() >= rate64 { //#nosec G404
+		if d.randFloat64() >= rate64 {
 			maskData[i] = scale
 		} else {
 			maskData[i] = zero

--- a/layers/regularization/dropout_seed_test.go
+++ b/layers/regularization/dropout_seed_test.go
@@ -1,0 +1,245 @@
+package regularization
+
+import (
+	"context"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// newSeededDropout builds a training-mode Dropout seeded with the given value.
+func newSeededDropout(rate float32, seed uint64) *Dropout[float32] {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine(ops)
+	d := NewDropout(engine, ops, rate, WithDropoutSeed[float32](seed))
+	d.SetTraining(true)
+
+	return d
+}
+
+// runDropoutForward runs a single training-mode Forward over a constant-ones
+// input and returns the resulting mask (recovered from the cached mask tensor).
+func runDropoutForward(t *testing.T, d *Dropout[float32], size int) []float32 {
+	t.Helper()
+	ctx := context.Background()
+
+	inputData := make([]float32, size)
+	for i := range inputData {
+		inputData[i] = 1.0
+	}
+	input, err := tensor.New([]int{size}, inputData)
+	if err != nil {
+		t.Fatalf("failed to create input tensor: %v", err)
+	}
+
+	if _, err := d.Forward(ctx, input); err != nil {
+		t.Fatalf("Forward returned error: %v", err)
+	}
+	if d.mask == nil {
+		t.Fatal("expected a cached mask after training-mode Forward")
+	}
+
+	out := make([]float32, size)
+	copy(out, d.mask.Data())
+
+	return out
+}
+
+func maskEqual(a, b []float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// TestDropout_SeededReproducible verifies the core reproducibility contract:
+// two layers seeded identically produce byte-identical masks for the same
+// input and call sequence.
+func TestDropout_SeededReproducible(t *testing.T) {
+	const (
+		size = 256
+		seed = uint64(0xC0FFEE)
+	)
+
+	maskA := runDropoutForward(t, newSeededDropout(0.5, seed), size)
+	maskB := runDropoutForward(t, newSeededDropout(0.5, seed), size)
+
+	if !maskEqual(maskA, maskB) {
+		t.Fatal("same seed must produce identical dropout masks")
+	}
+
+	// Sanity: the mask is a real dropout mask (mix of zeros and scaled survivors).
+	zeros := 0
+	for _, v := range maskA {
+		if v == 0 {
+			zeros++
+		}
+	}
+	if zeros == 0 || zeros == size {
+		t.Fatalf("seeded mask is degenerate: %d zeros of %d", zeros, size)
+	}
+}
+
+// TestDropout_SeededDiffersBySeed verifies that different seeds yield different
+// masks (so the seed actually drives the draw).
+func TestDropout_SeededDiffersBySeed(t *testing.T) {
+	const size = 256
+
+	maskA := runDropoutForward(t, newSeededDropout(0.5, 1), size)
+	maskB := runDropoutForward(t, newSeededDropout(0.5, 2), size)
+
+	if maskEqual(maskA, maskB) {
+		t.Fatal("different seeds should (with overwhelming probability) produce different masks")
+	}
+}
+
+// TestDropout_SeededSequenceAdvances verifies that successive Forward calls on
+// the same seeded layer advance the source (masks differ batch-to-batch) and
+// that the full sequence is reproducible across two identically seeded layers.
+func TestDropout_SeededSequenceAdvances(t *testing.T) {
+	const (
+		size = 128
+		seed = uint64(7)
+	)
+
+	d1 := newSeededDropout(0.5, seed)
+	d2 := newSeededDropout(0.5, seed)
+
+	var seq1, seq2 [][]float32
+	for i := 0; i < 4; i++ {
+		seq1 = append(seq1, runDropoutForward(t, d1, size))
+		seq2 = append(seq2, runDropoutForward(t, d2, size))
+	}
+
+	// Each step of the two identically seeded layers must match.
+	for i := range seq1 {
+		if !maskEqual(seq1[i], seq2[i]) {
+			t.Fatalf("step %d: identically seeded layers diverged", i)
+		}
+	}
+
+	// Consecutive steps should differ (the source advances; not the same mask).
+	if maskEqual(seq1[0], seq1[1]) {
+		t.Fatal("consecutive seeded Forward calls produced an identical mask; source did not advance")
+	}
+}
+
+// TestDropout_WithSourceReproducible verifies the WithDropoutSource option is
+// honored and reproducible when fed an identically seeded rand.Source.
+func TestDropout_WithSourceReproducible(t *testing.T) {
+	const size = 200
+
+	build := func() *Dropout[float32] {
+		ops := numeric.Float32Ops{}
+		engine := compute.NewCPUEngine(ops)
+		src := rand.NewPCG(11, 22)
+		d := NewDropout(engine, ops, float32(0.4), WithDropoutSource[float32](src))
+		d.SetTraining(true)
+
+		return d
+	}
+
+	maskA := runDropoutForward(t, build(), size)
+	maskB := runDropoutForward(t, build(), size)
+
+	if !maskEqual(maskA, maskB) {
+		t.Fatal("identically seeded rand.Source must produce identical masks")
+	}
+}
+
+// TestDropout_WithSourceNilIgnored verifies a nil source leaves the default
+// (unseeded) behavior in place rather than panicking.
+func TestDropout_WithSourceNilIgnored(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine(ops)
+	d := NewDropout(engine, ops, float32(0.5), WithDropoutSource[float32](nil))
+	if d.rng != nil {
+		t.Fatal("nil source should leave rng unset (default unseeded behavior)")
+	}
+	d.SetTraining(true)
+	// Should still run without panic.
+	_ = runDropoutForward(t, d, 64)
+}
+
+// TestDropout_DefaultUnseeded verifies the default constructor preserves the
+// historical unseeded behavior: no seeded source is installed.
+func TestDropout_DefaultUnseeded(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine(ops)
+	d := NewDropout(engine, ops, float32(0.5))
+	if d.rng != nil {
+		t.Fatal("default NewDropout must not install a seeded source (backward compatible)")
+	}
+}
+
+// TestDropout_SeededEvalModeUnaffected verifies the seed has no effect in eval
+// mode: the input is returned unchanged (the eval-mode parity contract holds
+// regardless of seeding).
+func TestDropout_SeededEvalModeUnaffected(t *testing.T) {
+	ctx := context.Background()
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine(ops)
+	d := NewDropout(engine, ops, float32(0.5), WithDropoutSeed[float32](99))
+	// Default mode is eval (training=false); do not enable training.
+
+	inputData := []float32{1, 2, 3, 4, 5, 6}
+	input, err := tensor.New([]int{2, 3}, inputData)
+	if err != nil {
+		t.Fatalf("failed to create input tensor: %v", err)
+	}
+
+	output, err := d.Forward(ctx, input)
+	if err != nil {
+		t.Fatalf("Forward returned error: %v", err)
+	}
+	if output != input {
+		t.Error("eval mode must return the same pointer as input regardless of seeding")
+	}
+	for i, v := range output.Data() {
+		if v != inputData[i] {
+			t.Errorf("element %d: got %v, want %v", i, v, inputData[i])
+		}
+	}
+}
+
+// TestDropout_SeededBackwardConsistent verifies the seeded forward mask is the
+// same one applied in Backward (no gradient w.r.t. the mask; the gate here is
+// forward/backward determinism, not gradcheck of the random mask).
+func TestDropout_SeededBackwardConsistent(t *testing.T) {
+	ctx := context.Background()
+	d := newSeededDropout(0.5, 5)
+
+	size := 64
+	mask := runDropoutForward(t, d, size)
+
+	dOutData := make([]float32, size)
+	for i := range dOutData {
+		dOutData[i] = 1.0
+	}
+	dOut, err := tensor.New([]int{size}, dOutData)
+	if err != nil {
+		t.Fatalf("failed to create dOut tensor: %v", err)
+	}
+
+	input, _ := tensor.New([]int{size}, make([]float32, size))
+	grads, err := d.Backward(ctx, types.FullBackprop, dOut, input)
+	if err != nil {
+		t.Fatalf("Backward returned error: %v", err)
+	}
+
+	for i, g := range grads[0].Data() {
+		if g != mask[i] {
+			t.Errorf("element %d: backward grad %v != forward mask %v", i, g, mask[i])
+		}
+	}
+}

--- a/layers/regularization/feature_dropout.go
+++ b/layers/regularization/feature_dropout.go
@@ -24,6 +24,13 @@ type FeatureDropout[T tensor.Float] struct {
 	rate     T
 	training bool
 
+	// rng, when non-nil, is a seeded source used to draw the per-feature mask
+	// so that training is reproducible. When nil (the default) the
+	// package-global unseeded math/rand/v2 source is used, preserving the
+	// historical non-deterministic behavior. See WithFeatureDropoutSeed /
+	// WithFeatureDropoutSource.
+	rng *rand.Rand
+
 	// Cache for backward pass. The mask is registered with the
 	// save-for-backward contract (ztensor ADR 006) every training-mode
 	// Forward: it cannot be recomputed (it is random), so arena-backed
@@ -33,6 +40,31 @@ type FeatureDropout[T tensor.Float] struct {
 	saver       graph.Saver[T] // wired by graph Builder (graph.SaverAware); nil outside a Graph
 }
 
+// FeatureDropoutOption configures optional behavior of a FeatureDropout layer.
+type FeatureDropoutOption[T tensor.Float] func(*FeatureDropout[T])
+
+// WithFeatureDropoutSeed returns a FeatureDropoutOption that makes the
+// per-feature dropout mask reproducible by drawing it from a deterministic
+// source seeded with the given value. Without this option (the default) masks
+// are drawn from the unseeded package-global source and are not reproducible.
+func WithFeatureDropoutSeed[T tensor.Float](seed uint64) FeatureDropoutOption[T] {
+	return func(d *FeatureDropout[T]) {
+		d.rng = rand.New(rand.NewPCG(seed, seed^0x9E3779B97F4A7C15)) //#nosec G404
+	}
+}
+
+// WithFeatureDropoutSource returns a FeatureDropoutOption that draws the mask
+// from the provided source, allowing callers to supply their own seeded or
+// shared rand.Source for reproducible training. A nil source is ignored,
+// leaving the default unseeded behavior in place.
+func WithFeatureDropoutSource[T tensor.Float](src rand.Source) FeatureDropoutOption[T] {
+	return func(d *FeatureDropout[T]) {
+		if src != nil {
+			d.rng = rand.New(src) //#nosec G404
+		}
+	}
+}
+
 // SetSaver implements graph.SaverAware.
 func (d *FeatureDropout[T]) SetSaver(sv graph.Saver[T]) {
 	d.saver = sv
@@ -40,12 +72,32 @@ func (d *FeatureDropout[T]) SetSaver(sv graph.Saver[T]) {
 
 // NewFeatureDropout creates a new FeatureDropout layer with the given drop rate.
 // The rate must be in [0, 1). A rate of 0 disables dropout entirely.
-func NewFeatureDropout[T tensor.Float](engine compute.Engine[T], ops numeric.Arithmetic[T], rate T) *FeatureDropout[T] {
-	return &FeatureDropout[T]{
+//
+// By default the per-feature mask is drawn from the unseeded package-global
+// math/rand/v2 source, so masks are not reproducible across runs. Pass
+// WithFeatureDropoutSeed or WithFeatureDropoutSource to make the mask
+// deterministic.
+func NewFeatureDropout[T tensor.Float](engine compute.Engine[T], ops numeric.Arithmetic[T], rate T, opts ...FeatureDropoutOption[T]) *FeatureDropout[T] {
+	d := &FeatureDropout[T]{
 		engine: engine,
 		ops:    ops,
 		rate:   rate,
 	}
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
+}
+
+// randFloat64 returns the next mask draw, using the layer's seeded source when
+// configured and falling back to the unseeded package-global source otherwise.
+func (d *FeatureDropout[T]) randFloat64() float64 {
+	if d.rng != nil {
+		return d.rng.Float64()
+	}
+
+	return rand.Float64() //#nosec G404
 }
 
 // OpType returns the operation type.
@@ -105,7 +157,7 @@ func (d *FeatureDropout[T]) Forward(ctx context.Context, inputs ...*tensor.Tenso
 	// Generate a per-feature mask.
 	featureMask := make([]T, numFeatures)
 	for j := range featureMask {
-		if rand.Float64() >= rate64 { //#nosec G404
+		if d.randFloat64() >= rate64 {
 			featureMask[j] = scale
 		} else {
 			featureMask[j] = zero

--- a/layers/regularization/feature_dropout_seed_test.go
+++ b/layers/regularization/feature_dropout_seed_test.go
@@ -1,0 +1,160 @@
+package regularization
+
+import (
+	"context"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// runFeatureDropoutForward runs a single training-mode Forward over a constant
+// input of shape [rows, cols] and returns the cached broadcast mask.
+func runFeatureDropoutForward(t *testing.T, d *FeatureDropout[float32], rows, cols int) []float32 {
+	t.Helper()
+	ctx := context.Background()
+
+	size := rows * cols
+	inputData := make([]float32, size)
+	for i := range inputData {
+		inputData[i] = 1.0
+	}
+	input, err := tensor.New([]int{rows, cols}, inputData)
+	if err != nil {
+		t.Fatalf("failed to create input tensor: %v", err)
+	}
+
+	if _, err := d.Forward(ctx, input); err != nil {
+		t.Fatalf("Forward returned error: %v", err)
+	}
+	if d.mask == nil {
+		t.Fatal("expected a cached mask after training-mode Forward")
+	}
+
+	out := make([]float32, size)
+	copy(out, d.mask.Data())
+
+	return out
+}
+
+func newSeededFeatureDropout(rate float32, seed uint64) *FeatureDropout[float32] {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine(ops)
+	d := NewFeatureDropout(engine, ops, rate, WithFeatureDropoutSeed[float32](seed))
+	d.SetTraining(true)
+
+	return d
+}
+
+// TestFeatureDropout_SeededReproducible verifies same seed -> identical masks.
+func TestFeatureDropout_SeededReproducible(t *testing.T) {
+	const (
+		rows = 4
+		cols = 64
+		seed = uint64(0xBEEF)
+	)
+
+	maskA := runFeatureDropoutForward(t, newSeededFeatureDropout(0.5, seed), rows, cols)
+	maskB := runFeatureDropoutForward(t, newSeededFeatureDropout(0.5, seed), rows, cols)
+
+	if !maskEqual(maskA, maskB) {
+		t.Fatal("same seed must produce identical feature-dropout masks")
+	}
+
+	// Sanity: at least one column dropped and one retained.
+	zeros := 0
+	for _, v := range maskA {
+		if v == 0 {
+			zeros++
+		}
+	}
+	if zeros == 0 || zeros == len(maskA) {
+		t.Fatalf("seeded feature mask is degenerate: %d zeros of %d", zeros, len(maskA))
+	}
+}
+
+// TestFeatureDropout_SeededDiffersBySeed verifies different seeds -> different masks.
+func TestFeatureDropout_SeededDiffersBySeed(t *testing.T) {
+	const (
+		rows = 4
+		cols = 64
+	)
+
+	maskA := runFeatureDropoutForward(t, newSeededFeatureDropout(0.5, 1), rows, cols)
+	maskB := runFeatureDropoutForward(t, newSeededFeatureDropout(0.5, 2), rows, cols)
+
+	if maskEqual(maskA, maskB) {
+		t.Fatal("different seeds should produce different feature-dropout masks")
+	}
+}
+
+// TestFeatureDropout_WithSourceReproducible verifies WithFeatureDropoutSource.
+func TestFeatureDropout_WithSourceReproducible(t *testing.T) {
+	const (
+		rows = 3
+		cols = 50
+	)
+
+	build := func() *FeatureDropout[float32] {
+		ops := numeric.Float32Ops{}
+		engine := compute.NewCPUEngine(ops)
+		src := rand.NewPCG(101, 202)
+		d := NewFeatureDropout(engine, ops, float32(0.4), WithFeatureDropoutSource[float32](src))
+		d.SetTraining(true)
+
+		return d
+	}
+
+	maskA := runFeatureDropoutForward(t, build(), rows, cols)
+	maskB := runFeatureDropoutForward(t, build(), rows, cols)
+
+	if !maskEqual(maskA, maskB) {
+		t.Fatal("identically seeded rand.Source must produce identical feature masks")
+	}
+}
+
+// TestFeatureDropout_DefaultUnseeded verifies the default constructor is unseeded.
+func TestFeatureDropout_DefaultUnseeded(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine(ops)
+	d := NewFeatureDropout(engine, ops, float32(0.5))
+	if d.rng != nil {
+		t.Fatal("default NewFeatureDropout must not install a seeded source (backward compatible)")
+	}
+}
+
+// TestFeatureDropout_SeededEvalModeUnaffected verifies eval mode passes input
+// through unchanged regardless of seeding.
+func TestFeatureDropout_SeededEvalModeUnaffected(t *testing.T) {
+	ctx := context.Background()
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine(ops)
+	d := NewFeatureDropout(engine, ops, float32(0.5), WithFeatureDropoutSeed[float32](42))
+	// Eval mode (training=false) by default.
+
+	inputData := []float32{1, 2, 3, 4, 5, 6}
+	input, err := tensor.New([]int{2, 3}, inputData)
+	if err != nil {
+		t.Fatalf("failed to create input tensor: %v", err)
+	}
+
+	output, err := d.Forward(ctx, input)
+	if err != nil {
+		t.Fatalf("Forward returned error: %v", err)
+	}
+	if output != input {
+		t.Error("eval mode must return the same pointer as input regardless of seeding")
+	}
+}
+
+// TestFeatureDropout_WithSourceNilIgnored verifies nil source is a no-op.
+func TestFeatureDropout_WithSourceNilIgnored(t *testing.T) {
+	ops := numeric.Float32Ops{}
+	engine := compute.NewCPUEngine(ops)
+	d := NewFeatureDropout(engine, ops, float32(0.5), WithFeatureDropoutSource[float32](nil))
+	if d.rng != nil {
+		t.Fatal("nil source should leave rng unset (default unseeded behavior)")
+	}
+}


### PR DESCRIPTION
Closes #905.

## The gap

`Dropout` and `FeatureDropout` drew their masks from the **unseeded package-global** `math/rand/v2` source, so any training run using dropout was **non-reproducible** even with all other inputs fixed.

## The change (backward-compatible)

Add optional functional options that install a deterministic source:

- `WithDropoutSeed(seed uint64)` / `WithDropoutSource(rand.Source)`
- `WithFeatureDropoutSeed(seed uint64)` / `WithFeatureDropoutSource(rand.Source)`

`NewDropout`/`NewFeatureDropout` gain a trailing variadic `opts ...Option` (source-compatible — existing call sites compile and behave unchanged). **Default = unseeded global source**, preserving historical behavior. When seeded, a PCG source is used and `randFloat64()` draws from it; otherwise it falls back to `rand.Float64()`.

## Quality gate

Dropout has no gradient w.r.t. the random mask, so the gate is **forward/backward determinism + eval-mode passthrough parity**, not gradcheck of the mask. Table-driven, no-testify tests (`dropout_seed_test.go`, `feature_dropout_seed_test.go`) cover:

- same seed -> byte-identical masks
- different seed -> different masks
- source advances across successive Forward calls; full sequence reproducible across two identically-seeded layers
- `WithSource` reproducibility with an identically-seeded `rand.Source`
- nil source is a no-op (default unseeded)
- default constructor installs no seeded source (backward compatible)
- **eval-mode passthrough unaffected by seeding** (input returned unchanged)
- seeded forward mask == mask applied in Backward

## Gates run locally

`go build ./...`, `go vet`, `gofmt -l` (clean), `golangci-lint run` (0 issues), `go test ./layers/regularization/... -race` (pass).