### PR TITLE
fix(training): reserve captured-graph arena footprint under capture-replay (ztensor#167)

### DIFF
--- a/training/capture_replay.go
+++ b/training/capture_replay.go
@@ -175,6 +175,24 @@ func (r *CaptureReplayRunner[T]) Step(
 	r.captured = true
 	r.capturesPerformed++
 
+	// ztensor#167 / ADR 007: the captured graph's kernels reference frozen
+	// device addresses for every buffer the step touches, including the
+	// save-for-backward intermediates that this capture step's own Backward
+	// already unpinned (ADR 006 pins are released when the node's Backward
+	// returns). Those addresses are then reissued by a later per-epoch
+	// ResetPool + arena free-list reuse, and the replayed graph reads the
+	// corrupted memory -- gradients collapse toward zero from the next step
+	// (GB10 CrossAsset fold-0 0.6047 vs the CPU baseline 0.7257). Reserve the
+	// captured graph's whole arena footprint for its replay lifetime by raising
+	// the arena reset floor to the capture high-water. This mirrors the proven
+	// decode-loop capture path (generate/generator.go onCaptured), which has
+	// always done this and is therefore correct under capture-replay.
+	if ap, ok := any(r.gc).(interface{ ArenaUsedBytes() int }); ok {
+		if asf, ok2 := any(r.gc).(interface{ SetArenaResetFloor(int) }); ok2 {
+			asf.SetArenaResetFloor(ap.ArenaUsedBytes())
+		}
+	}
+
 	// The capture recorded this step but did not execute it: launch the
 	// graph once so step `warmup` actually happens.
 	if err := r.gc.ReplayGraph(r.handle); err != nil {


### PR DESCRIPTION
## Summary
Fixes the GPU capture-on training correctness regression (ztensor#167): GB10 CrossAsset trains to fold-0 **0.6047** instead of the CPU baseline **0.7257** at a byte-identical config, because the captured graph's kernels read arena memory that gets reused across replays.

## Root cause
`CaptureReplayRunner` captures one training step and replays it ~2559x across all epochs. The captured graph executable freezes the device addresses of every buffer the step touches — including **save-for-backward intermediates** whose ADR 006 pins are released the moment the capture step's own `Backward` returns (`graph.releaseSaved`). After capture those addresses are unpinned, so a later per-epoch `ResetPool()` + arena free-list reuse reissue them to unrelated tensors. The replayed graph then reads contaminated memory → gradients collapse toward ~0 from the next step → loss plateaus → 0.6047. Dropout-independent; this is why production training stayed on CPU.

## Fix
After `EndCapture`, raise the arena reset floor to the capture high-water (`ArenaUsedBytes`), reserving the captured graph's whole footprint for its replay lifetime so no address it uses is ever reissued:

```go
if ap, ok := any(r.gc).(interface{ ArenaUsedBytes() int }); ok {
    if asf, ok2 := any(r.gc).(interface{ SetArenaResetFloor(int) }); ok2 {
        asf.SetArenaResetFloor(ap.ArenaUsedBytes())
    }
}
```

This **mirrors the decode-loop capture path** (`generate/generator.go` `onCaptured`), which has always done exactly this and is correct under capture-replay. No allocation occurs during the replay phase (inputs are staged by copying into pre-existing stable tensors), so the reserved span is never reused mid-run. Pure consumer-side change using ztensor's existing `SetResetFloor`.

## Validation
- `go build/vet/test ./training/...` green (the capture-replay path itself is GPU-only).
- **Pending GB10 acceptance:** Wolf CrossAsset GPU capture-on (dropout=0, 40ep/2fold) must reproduce fold-0 ~0.7257 with capture still engaged. Will validate on the GB10 via Spark with a `replace` directive before relying on a tagged release.

## Refs
- ztensor#167 (root-caused + current repro evidence in the issue thread)
- ztensor `docs/adr/007-capture-lifetime-arena-reservation.md`
- Plan: ztensor `docs/plan-167-capture-arena-savefb.md`