### PR TITLE
feat: DGX arm64 one-command GPU validation job (T131.1)

### DIFF
--- a/docs/bench/manifests/validate-arm64.yaml
+++ b/docs/bench/manifests/validate-arm64.yaml
@@ -1,0 +1,159 @@
+# Native arm64 GPU-validation pod manifest for the DGX GB10 (via Spark).
+#
+# Why this exists: zerfoo's GPU bindings load CUDA + the custom kernels via
+# purego/dlopen, whose runtime.dlopen linknames need cgo. That makes a
+# darwin->linux/arm64 cross-compile impossible, so every GPU-touching build
+# and test MUST be produced NATIVELY on the GB10. This manifest institutionalizes
+# the workaround proven manually in E96: clone zerfoo at a ref inside an arm64
+# Go container on the host, build + vet + run the cuda-tagged tests there, and
+# emit a machine-readable pass/fail report.
+#
+# Submit via scripts/dgx-validate.sh, which fills in the pod name and git ref
+# before POSTing to Spark's /api/v1/pods endpoint. Do NOT submit by hand.
+#
+# Divergence from patchtst-train.yaml: that manifest runs a bench binary that
+# was pre-built on the host, so it uses a bare ubuntu:24.04 base. This job
+# builds from source in-pod, so it uses an arm64 golang image (which also
+# ships git). Everything else -- cgroup caps, the read-only CUDA + kernels
+# mounts, hostPath output persistence -- follows the same conventions.
+#
+# Resource caps are enforced by Podman cgroups on the DGX host:
+#   - memory 32Gi       (host RAM cap; NOT VRAM -- GB10 has unified memory, no MIG)
+#   - cpu "8"           (8 full cores out of the host's budget)
+#   - nvidia.com/gpu 1  (serialized via SPARK_GPU_MAX=1 on the host)
+#
+# Mounts (read-only unless noted):
+#   /usr/local/cuda        CUDA 13 runtime libs (loaded via purego/dlopen)
+#   /opt/zerfoo/lib        tanh-fixed sm_121 libkernels.so; resolved by
+#                          internal/cuda/purego.go kernelLibPaths[2]
+#   /var/lib/zerfoo/models GGUF model files for the parity subset (optional;
+#                          the job skips model parity cleanly when empty)
+#   /var/lib/zerfoo/go     writable Go build+module cache (speeds re-runs)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${POD_NAME}
+  labels:
+    app: validate
+    type: arm64-gpu-validation
+spec:
+  restartPolicy: Never
+  containers:
+    - name: validate
+      image: docker.io/library/golang:1.26-bookworm
+      command:
+        - /bin/bash
+        - -c
+      args:
+        - |
+          set -uo pipefail
+
+          REF="${REF:-main}"
+          REPO_URL="${REPO_URL:-https://github.com/zerfoo/zerfoo.git}"
+          MODELS_DIR="${MODELS_DIR:-/var/lib/zerfoo/models}"
+          CUDA_PKGS="${CUDA_PKGS:-./internal/cuda/... ./tabular/... ./tests/parity/...}"
+          SRC=/workspace/zerfoo
+
+          FAILS=""
+          add_fail() { FAILS="${FAILS:+$FAILS,}\"$1\""; }
+
+          # Emit the single-line JSON report as the final stdout line.
+          emit() {
+            printf '{"ref":"%s","build":"%s","vet":"%s","cuda_tests":"%s","parity":"%s","failures":[%s]}\n' \
+              "$REF" "$1" "$2" "$3" "$4" "$FAILS"
+          }
+
+          echo ">> zerfoo arm64 GPU validation: ref=$REF host=$(uname -m) go=$(go version)"
+
+          rm -rf "$SRC"
+          if ! git clone --quiet "$REPO_URL" "$SRC"; then
+            add_fail clone; emit fail skip skip skip; exit 1
+          fi
+          cd "$SRC" || { add_fail chdir; emit fail skip skip skip; exit 1; }
+          if ! git checkout --quiet "$REF"; then
+            add_fail checkout; emit fail skip skip skip; exit 1
+          fi
+          echo ">> HEAD $(git rev-parse HEAD)"
+
+          BUILD=pass
+          echo ">> go build ./..."
+          go build ./... || { BUILD=fail; add_fail build; }
+
+          VET=pass
+          echo ">> go vet ./..."
+          go vet ./... || { VET=fail; add_fail vet; }
+
+          CUDA=pass
+          echo ">> go test -tags cuda $CUDA_PKGS"
+          # shellcheck disable=SC2086
+          go test -tags cuda -count=1 -timeout 900s $CUDA_PKGS || { CUDA=fail; add_fail cuda_tests; }
+
+          # Model parity: only when GGUF files are mounted. Each model parity
+          # test skips itself when its ModelDirEnvVar is unset, so we discover
+          # those env-var names from the source and point them all at MODELS_DIR.
+          PARITY=skip
+          if [ -d "$MODELS_DIR" ] && [ -n "$(ls -A "$MODELS_DIR" 2>/dev/null)" ]; then
+            for v in $(grep -rhoE 'ModelDirEnvVar:[[:space:]]*"[A-Z0-9_]+"' tests/parity 2>/dev/null \
+                       | grep -oE '"[A-Z0-9_]+"' | tr -d '"' | sort -u); do
+              export "$v=$MODELS_DIR"
+            done
+            PARITY=pass
+            echo ">> go test -tags cuda ./tests/parity/... (models present)"
+            go test -tags cuda -count=1 -timeout 900s ./tests/parity/... || { PARITY=fail; add_fail parity; }
+          else
+            echo ">> model parity skipped (no files under $MODELS_DIR)"
+          fi
+
+          emit "$BUILD" "$VET" "$CUDA" "$PARITY"
+          [ -z "$FAILS" ] || exit 1
+      env:
+        - name: REF
+          value: "${REF}"
+        - name: REPO_URL
+          value: "https://github.com/zerfoo/zerfoo.git"
+        - name: MODELS_DIR
+          value: "/var/lib/zerfoo/models"
+        - name: CUDA_PKGS
+          value: "./internal/cuda/... ./tabular/... ./tests/parity/..."
+        - name: LD_LIBRARY_PATH
+          value: "/usr/local/cuda/lib64:/opt/zerfoo/lib"
+        - name: GOCACHE
+          value: "/var/lib/zerfoo/go/build"
+        - name: GOMODCACHE
+          value: "/var/lib/zerfoo/go/mod"
+        - name: GOFLAGS
+          value: "-mod=mod"
+      resources:
+        limits:
+          memory: 32Gi
+          cpu: "8"
+          nvidia.com/gpu: "1"
+      volumeMounts:
+        - name: zerfoo-lib
+          mountPath: /opt/zerfoo/lib
+          readOnly: true
+        - name: cuda
+          mountPath: /usr/local/cuda
+          readOnly: true
+        - name: models
+          mountPath: /var/lib/zerfoo/models
+          readOnly: true
+        - name: go-cache
+          mountPath: /var/lib/zerfoo/go
+  volumes:
+    - name: zerfoo-lib
+      hostPath:
+        path: /opt/zerfoo/lib
+        type: Directory
+    - name: cuda
+      hostPath:
+        path: /usr/local/cuda
+        type: Directory
+    - name: models
+      hostPath:
+        path: /var/lib/zerfoo/models
+        type: DirectoryOrCreate
+    - name: go-cache
+      hostPath:
+        path: /var/lib/zerfoo/go
+        type: DirectoryOrCreate

--- a/scripts/dgx-validate.sh
+++ b/scripts/dgx-validate.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# dgx-validate.sh -- one command to run zerfoo's GPU validation suite natively
+# on the DGX GB10 via Spark.
+#
+# purego GPU bindings cannot cross-compile darwin->linux/arm64 (runtime.dlopen
+# linknames need cgo), so all GPU-touching build+test must happen ON the DGX.
+# This wraps docs/bench/manifests/validate-arm64.yaml: it renders a unique pod,
+# POSTs it to Spark, polls to completion, streams logs, extracts the JSON
+# report, deletes the pod, and propagates a green/red exit code.
+#
+# Usage:
+#   scripts/dgx-validate.sh [-ref <git-ref>] [-timeout <seconds>] [-dry-run]
+#
+#   -ref <git-ref>     git ref (branch/tag/SHA) to validate. Default: the
+#                      current origin/main SHA.
+#   -timeout <seconds> max seconds to wait for the pod to terminate. Default 1800.
+#   -dry-run           render the manifest and print the API calls; submit nothing.
+#
+# Environment:
+#   SPARK        base URL of the Spark API. Default http://192.168.86.250:8080.
+#                (SPARK_HOST=host:port is also honored, for parity with
+#                 scripts/bench-spark.sh.)
+#   SPARK_TOKEN  optional; sent as "Authorization: Bearer <token>" on every call.
+#
+# Requires: bash, curl, git, sed, grep, date, mktemp. No third-party deps.
+#
+# GPU runs are serialized on the host (SPARK_GPU_MAX=1): only one GPU pod runs
+# at a time, so coordinate with any other DGX GPU work before submitting.
+
+set -euo pipefail
+
+# --- config ------------------------------------------------------------------
+
+SPARK="${SPARK:-}"
+if [ -z "$SPARK" ]; then
+  if [ -n "${SPARK_HOST:-}" ]; then
+    SPARK="http://${SPARK_HOST}"
+  else
+    SPARK="http://192.168.86.250:8080"
+  fi
+fi
+SPARK="${SPARK%/}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MANIFEST_TEMPLATE="${REPO_ROOT}/docs/bench/manifests/validate-arm64.yaml"
+
+REF=""
+DRY_RUN=0
+TIMEOUT=1800
+POLL_INTERVAL="${POLL_INTERVAL:-5}"
+
+usage() {
+  cat >&2 <<USAGE
+Usage: $0 [-ref <git-ref>] [-timeout <seconds>] [-dry-run]
+
+Submits docs/bench/manifests/validate-arm64.yaml to Spark at \${SPARK}
+(currently ${SPARK}), polls until the pod terminates, streams logs, extracts
+the JSON report, deletes the pod, and exits 0 only on Succeeded + a report
+with no failures.
+USAGE
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -ref)      [ $# -ge 2 ] || usage; REF="$2"; shift 2 ;;
+    -timeout)  [ $# -ge 2 ] || usage; TIMEOUT="$2"; shift 2 ;;
+    -dry-run)  DRY_RUN=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+case "$TIMEOUT" in
+  ''|*[!0-9]*) echo "dgx-validate: -timeout must be a positive integer" >&2; exit 2 ;;
+esac
+
+[ -f "$MANIFEST_TEMPLATE" ] || { echo "dgx-validate: missing manifest: $MANIFEST_TEMPLATE" >&2; exit 3; }
+
+if [ -z "$REF" ]; then
+  REF="$(git -C "$REPO_ROOT" rev-parse origin/main 2>/dev/null || true)"
+  if [ -z "$REF" ]; then
+    echo "dgx-validate: could not resolve origin/main; pass -ref explicitly" >&2
+    exit 3
+  fi
+fi
+
+# Unique pod name: zerfoo-validate-<shortref>-<epoch>. Strip anything that is
+# not alphanumeric from the ref so branch names with slashes stay DNS-safe.
+SHORT="$(printf '%s' "$REF" | tr -cd '[:alnum:]' | cut -c1-12)"
+[ -n "$SHORT" ] || SHORT="ref"
+EPOCH="$(date -u +%s)"
+POD_NAME="zerfoo-validate-${SHORT}-${EPOCH}"
+
+# Substitute only the two variables we own. Refs/SHAs cannot contain '|', so it
+# is a safe sed delimiter here.
+MANIFEST="$(
+  sed \
+    -e "s|\${POD_NAME}|${POD_NAME}|g" \
+    -e "s|\${REF}|${REF}|g" \
+    "$MANIFEST_TEMPLATE"
+)"
+
+# --- HTTP with retry ---------------------------------------------------------
+
+# Auth header as an array so it expands to zero args when unset (bash 3.2 safe).
+AUTH_HEADER=()
+if [ -n "${SPARK_TOKEN:-}" ]; then
+  AUTH_HEADER=(-H "Authorization: Bearer ${SPARK_TOKEN}")
+fi
+
+HTTP_BODY=""
+HTTP_CODE=""
+
+# http_req METHOD URL [extra curl args...]
+# Retries 3x with 2s/4s/8s backoff on 429, 5xx, and connection errors.
+# Never retries other 4xx. Sets HTTP_BODY and HTTP_CODE; returns 0 on 2xx.
+http_req() {
+  local method="$1" url="$2"
+  shift 2
+  local attempt=1 delay=2 code body tmp
+  while : ; do
+    tmp="$(mktemp)"
+    code="$(curl -sS -o "$tmp" -w '%{http_code}' -X "$method" \
+              "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}" "$@" "$url" 2>/dev/null)" || code=000
+    body="$(cat "$tmp")"; rm -f "$tmp"
+    [ -n "$code" ] || code=000
+    HTTP_BODY="$body"; HTTP_CODE="$code"
+
+    if [ "$code" -ge 200 ] 2>/dev/null && [ "$code" -lt 300 ] 2>/dev/null; then
+      return 0
+    fi
+    # Any 4xx other than 429 is a client error: do not retry.
+    if [ "$code" -ge 400 ] 2>/dev/null && [ "$code" -lt 500 ] 2>/dev/null && [ "$code" != "429" ]; then
+      return 1
+    fi
+    if [ "$attempt" -ge 3 ]; then
+      return 1
+    fi
+    echo "dgx-validate: ${method} ${url} -> HTTP ${code}; retry ${attempt}/3 in ${delay}s" >&2
+    sleep "$delay"
+    delay=$((delay * 2))
+    attempt=$((attempt + 1))
+  done
+}
+
+# Extract a terminal-ish phase from a pod JSON body. Handles both k8s-style
+# "phase":"Succeeded" and Spark's flat "status":"completed" without a JSON
+# parser (the values are simple string literals).
+extract_phase() {
+  printf '%s' "$1" \
+    | grep -oiE '"(phase|status)"[[:space:]]*:[[:space:]]*"[a-z]+"' \
+    | grep -oiE '"[a-z]+"$' \
+    | tr -d '"' \
+    | head -1
+}
+
+# --- dry-run -----------------------------------------------------------------
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "# dgx-validate DRY RUN -- nothing will be submitted"
+  echo "# SPARK=${SPARK}"
+  echo "# ref=${REF}"
+  echo "# pod=${POD_NAME}"
+  if [ -n "${SPARK_TOKEN:-}" ]; then
+    echo "# auth: Authorization: Bearer <SPARK_TOKEN> (set)"
+  else
+    echo "# auth: none (SPARK_TOKEN unset)"
+  fi
+  echo
+  echo "# --- rendered manifest ---"
+  printf '%s\n' "$MANIFEST"
+  echo
+  echo "# --- API calls that would be issued ---"
+  echo "POST   ${SPARK}/api/v1/pods            (Content-Type: application/yaml, body = manifest above)"
+  echo "GET    ${SPARK}/api/v1/pods/${POD_NAME}   (poll every ${POLL_INTERVAL}s until Succeeded/Failed, timeout ${TIMEOUT}s)"
+  echo "GET    ${SPARK}/api/v1/pods/${POD_NAME}/logs"
+  echo "DELETE ${SPARK}/api/v1/pods/${POD_NAME}"
+  exit 0
+fi
+
+# --- submit ------------------------------------------------------------------
+
+echo "dgx-validate: submitting ${POD_NAME} to ${SPARK} (ref=${REF})"
+if ! http_req POST "${SPARK}/api/v1/pods" \
+      -H 'Content-Type: application/yaml' --data-binary "$MANIFEST"; then
+  echo "dgx-validate: submit failed (HTTP ${HTTP_CODE})" >&2
+  printf '%s\n' "$HTTP_BODY" | head -c 800 >&2
+  echo >&2
+  exit 5
+fi
+echo "dgx-validate: submitted; polling for terminal phase"
+
+# --- poll --------------------------------------------------------------------
+
+DEADLINE=$(( $(date +%s) + TIMEOUT ))
+PHASE=""
+while : ; do
+  if http_req GET "${SPARK}/api/v1/pods/${POD_NAME}"; then
+    RAW_PHASE="$(extract_phase "$HTTP_BODY")"
+    case "$RAW_PHASE" in
+      [Ss]ucceeded|[Cc]ompleted) PHASE="Succeeded"; break ;;
+      [Ff]ailed)                 PHASE="Failed";    break ;;
+    esac
+  else
+    # 404 right after submit is normal until the pod registers; keep polling.
+    echo "dgx-validate: poll HTTP ${HTTP_CODE}; retrying" >&2
+  fi
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    PHASE="timeout"
+    break
+  fi
+  sleep "$POLL_INTERVAL"
+done
+
+# --- logs + report -----------------------------------------------------------
+
+echo "dgx-validate: phase=${PHASE}; fetching logs"
+if http_req GET "${SPARK}/api/v1/pods/${POD_NAME}/logs"; then
+  LOGS="$HTTP_BODY"
+else
+  LOGS="(log fetch failed: HTTP ${HTTP_CODE})"
+fi
+printf '%s\n' "$LOGS"
+
+# The in-pod script prints the report as the final line starting with {"ref":.
+REPORT="$(printf '%s\n' "$LOGS" | grep -E '\{"ref":' | tail -1 || true)"
+if [ -n "$REPORT" ]; then
+  echo "dgx-validate: report: ${REPORT}"
+else
+  echo "dgx-validate: no JSON report line found in logs" >&2
+fi
+
+# --- cleanup -----------------------------------------------------------------
+
+if [ "$PHASE" != "timeout" ]; then
+  if http_req DELETE "${SPARK}/api/v1/pods/${POD_NAME}"; then
+    echo "dgx-validate: deleted pod ${POD_NAME}"
+  else
+    echo "dgx-validate: warning: could not delete pod ${POD_NAME} (HTTP ${HTTP_CODE})" >&2
+  fi
+else
+  echo "dgx-validate: timed out after ${TIMEOUT}s; leaving pod ${POD_NAME} for inspection:" >&2
+  echo "  curl ${SPARK}/api/v1/pods/${POD_NAME}" >&2
+  echo "  curl ${SPARK}/api/v1/pods/${POD_NAME}/logs" >&2
+  echo "  curl -X DELETE ${SPARK}/api/v1/pods/${POD_NAME}" >&2
+fi
+
+# --- exit code ---------------------------------------------------------------
+
+if [ "$PHASE" = "Succeeded" ]; then
+  if [ -n "$REPORT" ] && printf '%s' "$REPORT" | grep -q '"failures":\[\]'; then
+    echo "dgx-validate: PASS"
+    exit 0
+  fi
+  echo "dgx-validate: pod Succeeded but report is missing or lists failures" >&2
+  exit 1
+fi
+
+echo "dgx-validate: FAIL (phase=${PHASE})" >&2
+exit 1


### PR DESCRIPTION
## T131.1 — Spark pod manifest + native arm64 GPU-validation script

Verifies **UC-H2-002** (one-command DGX arm64 validation run). Institutionalizes the E96 workaround: purego GPU bindings cannot cross-compile darwin→linux/arm64 (`runtime.dlopen` linknames need cgo), so all GPU validation must build **natively** on the GB10.

### Deliverables
- `docs/bench/manifests/validate-arm64.yaml` — Spark Pod: `restartPolicy: Never`, cgroup caps `memory 32Gi` / `cpu "8"` / `nvidia.com/gpu "1"`, arm64 `golang:1.26-bookworm` base. Clones zerfoo at `$REF`, runs `go build ./...`, `go vet ./...`, cuda-tagged unit tests, and the model-parity subset when GGUF files are mounted; emits a single-line JSON report and exits nonzero on any failure. Reuses patchtst-train.yaml conventions (read-only `/usr/local/cuda` + `/opt/zerfoo/lib` libkernels.so mounts, hostPath persistence).
- `scripts/dgx-validate.sh` — POSIX-ish bash, no third-party deps. Flags `-ref` (default: current `origin/main` SHA), `-timeout` (default 1800), `-dry-run`. Renders a unique pod `zerfoo-validate-<shortsha>-<epoch>`, POSTs to `$SPARK/api/v1/pods`, polls to Succeeded/Failed or timeout, streams logs, extracts the JSON report, DELETEs the pod, exits 0 only on Succeeded + empty `failures`. Every curl is retried 3× (2s/4s/8s) on 429/5xx/connection errors, never on other 4xx; honors `SPARK_TOKEN` as a Bearer header.

Two commits (top-level dirs kept separate per the pre-commit hook): docs/ then scripts/.

### JSON report shape (pod → logs, final line)
```
{"ref":..., "build":"pass|fail", "vet":"pass|fail", "cuda_tests":"pass|fail|skip", "parity":"pass|fail|skip", "failures":[...]}
```

### cuda test package set
`./internal/cuda/... ./tabular/... ./tests/parity/...` — the model-independent cuda-tagged unit packages. `distributed` / `internal/nccl` / `internal/tensorrt` are intentionally excluded (multi-GPU / NCCL / TensorRT — not applicable to the single GB10). Model parity tests in `tests/parity` skip themselves when their `ModelDirEnvVar` is unset; the pod discovers those env-var names from source and points them all at `MODELS_DIR` only when files are present.

### Validation (Tiers 0–1)
- `bash -n scripts/dgx-validate.sh` → syntax OK
- `shellcheck scripts/dgx-validate.sh` → **clean** (verified on bash 3.2, the macOS default; auth-header array uses the `${arr[@]+...}` guard for set -u safety)
- `go build ./...` → green (RC 0)
- `scripts/dgx-validate.sh -dry-run` → renders manifest + prints the four API calls, submits nothing (RC 0). Confirmed `${POD_NAME}`/`${REF}` substitution and that `-ref feature/foo` produces a DNS-safe pod name.

No pod was submitted (per task instructions — T131.3 does the first real run).

### Open verification points for T131.3 (first real run)
1. **Terminal-phase field.** CLAUDE.md documents `phase: Succeeded/Failed`; the existing `bench-spark.sh` parses a flat `status: completed/failed`. The poller accepts **both** (`Succeeded|completed` → success, `Failed`). Confirm which Spark actually returns.
2. **Literal-block-scalar (`|`) parsing.** The in-pod script is an inline YAML block scalar under `args`. Spark's indent-based parser should handle it; confirm it isn't flattened/mangled. Fallback if it is: move the in-pod logic to a committed `scripts/` helper and have the pod `exec` it after clone.
3. **`golang:1.26-bookworm` arm64 pullable** on the DGX, and module fetch of `github.com/zerfoo/{ztensor,ztoken}` succeeds in-pod (public vs. private — may need GOPRIVATE + netrc; a private-module failure surfaces as `build:fail`).
4. **libkernels.so resolution.** Pod sets `LD_LIBRARY_PATH=/usr/local/cuda/lib64:/opt/zerfoo/lib`; runtime also probes `/opt/zerfoo/lib/libkernels.so` directly. Confirm the tanh-fixed sm_121 build is present at that host path.
5. **Model-parity layout.** Pointing every `ModelDirEnvVar` at a single `MODELS_DIR` assumes a flat layout; if models live in per-model subdirs, adjust the mapping. Reports `skip` cleanly when `MODELS_DIR` is empty.
6. **Poll timeout on cold builds.** A cold in-pod `go build ./...` took >2 min locally; default `-timeout 1800` should cover build+vet+cuda tests, but confirm and bump if the parity subset runs long.
