### PR TITLE
feat(training): loud-fail gate on capture-replay training pending zerfoo#878 (T129.2)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1701,6 +1701,25 @@ Two upstream ztensor contracts make both paths safe:
   registered sync hooks (`tensor.RegisterHostAccessSync`), so a host read can
   never observe bytes from before a still-asynchronous kernel write.
 
+### 21.5 Capture-Replay Training (gated off)
+
+`training/capture_replay.go` provides a `CaptureReplayRunner` that records a
+training step's forward + loss + backward + gradient-accumulation walk into a
+CUDA graph (on engines implementing `compute.GraphCapturer`) and replays it,
+replacing the per-step kernel-launch sequence with a single graph launch.
+
+This path is currently **gated off**. Enabling CUDA-graph capture on the
+training walk silently produces wrong gradients (losses ascend while the
+identical eager configuration converges), tracked as zerfoo#878. Until the
+root-cause fix lands, `NewCaptureReplayRunner` refuses to construct a
+capture-enabled runner: when the engine is a `GraphCapturer` and capture is not
+disabled via `ZERFOO_DISABLE_CUDA_GRAPH`, construction returns an error unless
+`ZERFOO_UNSAFE_CAPTURE_TRAINING=1` is set to acknowledge the hazard. The gate is
+containment only, decided once at construction (not per-step). Eager/passthrough
+construction (no `GraphCapturer` engine, or capture disabled) is unaffected and
+needs no override. Inference-side CUDA-graph capture (see 10.3) is a separate,
+unaffected path.
+
 ---
 
 ## 22. Time-Series ML Platform

--- a/tests/training/capture_replay_divergence_878_test.go
+++ b/tests/training/capture_replay_divergence_878_test.go
@@ -232,7 +232,10 @@ func run878Trajectory(
 	} else {
 		t.Setenv(training.DisableCUDAGraphEnv, "1")
 	}
-	runner := training.NewCaptureReplayRunner[float32](strategy, engine, warmup)
+	runner, rerr := training.NewCaptureReplayRunner[float32](strategy, engine, warmup)
+	if rerr != nil {
+		t.Fatalf("NewCaptureReplayRunner (captureEnabled=%v): %v", captureEnabled, rerr)
+	}
 
 	batch := training.Batch[float32]{
 		Inputs:  map[graph.Node[float32]]*tensor.TensorNumeric[float32]{input: inputT},

--- a/training/capture_replay.go
+++ b/training/capture_replay.go
@@ -1,9 +1,21 @@
 // Package training: CUDA-graph capture-replay for repeated identical
 // training steps.
+//
+// Capture-replay TRAINING is currently gated off. zerfoo#878 showed that
+// enabling CUDA-graph capture on the training walk silently produces wrong
+// gradients (losses ascend 10-20x while the identical eager config
+// converges), so NewCaptureReplayRunner refuses to build a capture-enabled
+// runner unless ZERFOO_UNSAFE_CAPTURE_TRAINING=1 is set to acknowledge the
+// hazard. Eager/passthrough construction (no GraphCapturer engine, or
+// capture disabled via ZERFOO_DISABLE_CUDA_GRAPH) is unaffected and needs no
+// override. This gate is containment only; the root-cause fix is tracked in
+// zerfoo#878. It does not touch inference-side capture (generate/,
+// inference/), which is a separate, unaffected path.
 package training
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -16,6 +28,20 @@ import (
 // capture-replay when set to a non-empty value. It is read ONCE, at
 // NewCaptureReplayRunner time -- a debug toggle, not a hot-path read.
 const DisableCUDAGraphEnv = "ZERFOO_DISABLE_CUDA_GRAPH"
+
+// UnsafeCaptureTrainingEnv is the environment variable that overrides the
+// zerfoo#878 loud-fail gate. Constructing a capture-ENABLED training runner
+// returns ErrCaptureTrainingDisabled unless this is set to "1". It is read
+// ONCE, at NewCaptureReplayRunner time.
+const UnsafeCaptureTrainingEnv = "ZERFOO_UNSAFE_CAPTURE_TRAINING"
+
+// ErrCaptureTrainingDisabled is returned by NewCaptureReplayRunner when the
+// runner would enable CUDA-graph capture on the training walk but the
+// ZERFOO_UNSAFE_CAPTURE_TRAINING=1 override is not set. Capture-replay
+// training is disabled pending the zerfoo#878 silent-gradient-divergence fix.
+var ErrCaptureTrainingDisabled = errors.New(
+	"capture-replay training is disabled pending zerfoo#878 (silent gradient divergence); " +
+		"set ZERFOO_UNSAFE_CAPTURE_TRAINING=1 to override at your own risk")
 
 // CaptureReplayRunner drives a per-step training loop (forward + loss +
 // backward + gradient accumulation) through CUDA-graph capture-replay on
@@ -84,12 +110,21 @@ type CaptureReplayRunner[T tensor.Numeric] struct {
 // to allocate persistent gradient accumulators and lazy workspaces).
 //
 // When capture is disabled the runner is a transparent passthrough to
-// strategy.ComputeGradients and the counters stay at zero.
+// strategy.ComputeGradients and the counters stay at zero; that construction
+// path always succeeds.
+//
+// Loud-fail gate (zerfoo#878): capture-enabled TRAINING silently produces
+// wrong gradients, so when this constructor would enable capture (a
+// GraphCapturer engine and ZERFOO_DISABLE_CUDA_GRAPH unset) it returns
+// ErrCaptureTrainingDisabled unless ZERFOO_UNSAFE_CAPTURE_TRAINING=1 is set.
+// Enablement is fully decided here (the env reads and the interface assertion
+// all happen at construction), so this is the correct and only gate point --
+// Step never re-checks, keeping the hot path clean.
 func NewCaptureReplayRunner[T tensor.Numeric](
 	strategy *DefaultBackpropStrategy[T],
 	engine compute.Engine[T],
 	warmupSteps int,
-) *CaptureReplayRunner[T] {
+) (*CaptureReplayRunner[T], error) {
 	if warmupSteps < 1 {
 		warmupSteps = 1
 	}
@@ -99,14 +134,19 @@ func NewCaptureReplayRunner[T tensor.Numeric](
 	}
 	gc, ok := engine.(compute.GraphCapturer)
 	if !ok {
-		return r
+		return r, nil
 	}
 	if os.Getenv(DisableCUDAGraphEnv) != "" {
-		return r
+		return r, nil
+	}
+	// Capture would be ENABLED from here: gate it behind the zerfoo#878
+	// override before wiring up the capturer.
+	if os.Getenv(UnsafeCaptureTrainingEnv) != "1" {
+		return nil, ErrCaptureTrainingDisabled
 	}
 	r.gc = gc
 	r.enabled = true
-	return r
+	return r, nil
 }
 
 // Enabled reports whether capture-replay is active (GraphCapturer engine

--- a/training/capture_replay_test.go
+++ b/training/capture_replay_test.go
@@ -2,6 +2,8 @@ package training
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/zerfoo/ztensor/compute"
@@ -93,9 +95,13 @@ func TestCaptureReplayRunner_CounterSchedule(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(UnsafeCaptureTrainingEnv, "1")
 			eng := newFakeCaptureEngine()
 			strategy := NewDefaultBackpropStrategy[float32]()
-			runner := NewCaptureReplayRunner(strategy, eng, tt.warmup)
+			runner, err := NewCaptureReplayRunner(strategy, eng, tt.warmup)
+			if err != nil {
+				t.Fatalf("NewCaptureReplayRunner: %v", err)
+			}
 			if !runner.Enabled() {
 				t.Fatal("runner should be enabled with a GraphCapturer engine")
 			}
@@ -139,7 +145,10 @@ func TestCaptureReplayRunner_DisabledByEnv(t *testing.T) {
 
 	eng := newFakeCaptureEngine()
 	strategy := NewDefaultBackpropStrategy[float32]()
-	runner := NewCaptureReplayRunner(strategy, eng, 1)
+	runner, err := NewCaptureReplayRunner(strategy, eng, 1)
+	if err != nil {
+		t.Fatalf("NewCaptureReplayRunner: %v", err)
+	}
 	if runner.Enabled() {
 		t.Fatal("runner must be disabled when ZERFOO_DISABLE_CUDA_GRAPH is set")
 	}
@@ -166,7 +175,10 @@ func TestCaptureReplayRunner_DisabledByEnv(t *testing.T) {
 func TestCaptureReplayRunner_NonCapturerEngine(t *testing.T) {
 	cpu := compute.NewCPUEngine[float32](numeric.Float32Ops{})
 	strategy := NewDefaultBackpropStrategy[float32]()
-	runner := NewCaptureReplayRunner[float32](strategy, cpu, 1)
+	runner, err := NewCaptureReplayRunner[float32](strategy, cpu, 1)
+	if err != nil {
+		t.Fatalf("NewCaptureReplayRunner: %v", err)
+	}
 	if runner.Enabled() {
 		t.Fatal("runner must be disabled for engines without GraphCapturer")
 	}
@@ -183,9 +195,13 @@ func TestCaptureReplayRunner_NonCapturerEngine(t *testing.T) {
 
 // TestCaptureReplayRunner_Close destroys the captured graph exactly once.
 func TestCaptureReplayRunner_Close(t *testing.T) {
+	t.Setenv(UnsafeCaptureTrainingEnv, "1")
 	eng := newFakeCaptureEngine()
 	strategy := NewDefaultBackpropStrategy[float32]()
-	runner := NewCaptureReplayRunner(strategy, eng, 1)
+	runner, err := NewCaptureReplayRunner(strategy, eng, 1)
+	if err != nil {
+		t.Fatalf("NewCaptureReplayRunner: %v", err)
+	}
 
 	g, _, batch := captureFixture(t)
 	ctx := context.Background()
@@ -202,5 +218,91 @@ func TestCaptureReplayRunner_Close(t *testing.T) {
 	}
 	if eng.destroyCalls != 1 {
 		t.Errorf("DestroyGraph calls = %d, want 1 (Close must be idempotent)", eng.destroyCalls)
+	}
+}
+
+// TestCaptureReplayRunner_GateBlocksCaptureWithoutOverride is the S129.2.1
+// containment test: a GraphCapturer engine WITHOUT ZERFOO_UNSAFE_CAPTURE_TRAINING
+// must make construction fail loudly (zerfoo#878), returning a nil runner and an
+// error that names the issue and the override knob.
+func TestCaptureReplayRunner_GateBlocksCaptureWithoutOverride(t *testing.T) {
+	// Set to a non-"1" value (t.Setenv restores after the test) so the gate
+	// fires regardless of any inherited environment.
+	t.Setenv(UnsafeCaptureTrainingEnv, "")
+
+	eng := newFakeCaptureEngine()
+	strategy := NewDefaultBackpropStrategy[float32]()
+	runner, err := NewCaptureReplayRunner(strategy, eng, 1)
+	if err == nil {
+		t.Fatal("capture-enabled construction must fail without ZERFOO_UNSAFE_CAPTURE_TRAINING=1")
+	}
+	if runner != nil {
+		t.Errorf("runner must be nil on gate failure, got %v", runner)
+	}
+	if !errors.Is(err, ErrCaptureTrainingDisabled) {
+		t.Errorf("error should wrap ErrCaptureTrainingDisabled, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "zerfoo#878") {
+		t.Errorf("error must cite zerfoo#878, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "ZERFOO_UNSAFE_CAPTURE_TRAINING") {
+		t.Errorf("error must name the override knob, got %q", err.Error())
+	}
+	// The gate must not have touched the capture API.
+	if eng.beginCalls != 0 || eng.replayCalls != 0 {
+		t.Errorf("capture API touched while gated: begin=%d replay=%d", eng.beginCalls, eng.replayCalls)
+	}
+}
+
+// TestCaptureReplayRunner_GateOverrideRestoresCapture is the S129.2.1 override
+// test: with ZERFOO_UNSAFE_CAPTURE_TRAINING=1 the same construction succeeds,
+// the runner is capture-enabled, and its behavior is unchanged (a normal
+// warmup -> capture -> replay schedule runs to completion).
+func TestCaptureReplayRunner_GateOverrideRestoresCapture(t *testing.T) {
+	t.Setenv(UnsafeCaptureTrainingEnv, "1")
+
+	eng := newFakeCaptureEngine()
+	strategy := NewDefaultBackpropStrategy[float32]()
+	runner, err := NewCaptureReplayRunner(strategy, eng, 1)
+	if err != nil {
+		t.Fatalf("NewCaptureReplayRunner with override set: %v", err)
+	}
+	if !runner.Enabled() {
+		t.Fatal("runner must be capture-enabled when the override is set")
+	}
+
+	g, _, batch := captureFixture(t)
+	ctx := context.Background()
+	const steps = 4
+	for i := 0; i < steps; i++ {
+		if _, serr := runner.Step(ctx, g, &passthroughLoss{}, batch); serr != nil {
+			t.Fatalf("Step %d: %v", i, serr)
+		}
+	}
+	// warmup=1 -> one capture, steps-warmup replays: behavior unchanged by the gate.
+	if got := runner.CapturesPerformed(); got != 1 {
+		t.Errorf("CapturesPerformed = %d, want 1", got)
+	}
+	if got := runner.ReplaysPerformed(); got != uint64(steps-1) {
+		t.Errorf("ReplaysPerformed = %d, want %d", got, steps-1)
+	}
+}
+
+// TestCaptureReplayRunner_GateIgnoresEagerConstruction is the S129.2.1 no-op
+// test: eager/passthrough construction (engine without GraphCapturer) succeeds
+// with NO override env var -- the gate only ever fires for capture-enabled
+// runners.
+func TestCaptureReplayRunner_GateIgnoresEagerConstruction(t *testing.T) {
+	// Ensure the override is not "1"; the gate must not depend on it here.
+	t.Setenv(UnsafeCaptureTrainingEnv, "")
+
+	cpu := compute.NewCPUEngine[float32](numeric.Float32Ops{})
+	strategy := NewDefaultBackpropStrategy[float32]()
+	runner, err := NewCaptureReplayRunner[float32](strategy, cpu, 1)
+	if err != nil {
+		t.Fatalf("eager construction must succeed without the override: %v", err)
+	}
+	if runner == nil || runner.Enabled() {
+		t.Fatal("eager runner must be non-nil and capture-disabled")
 	}
 }


### PR DESCRIPTION
## Summary

Containment for **zerfoo#878** (CUDA-graph capture-replay TRAINING silently produces wrong gradients — losses ascend 10–20x while the identical eager config converges). Until the Phase 1 root-cause fix lands, constructing a **capture-enabled** training runner now **fails loudly**.

Tasks: **T129.2** + **S129.2.1**. Verifies use case **UC-H2-001** (capture-replay training fails loudly when unsafe).

## Gate semantics

`training/capture_replay.go` — `NewCaptureReplayRunner` now returns `(*CaptureReplayRunner[T], error)`:

- Engine is a `compute.GraphCapturer` **and** `ZERFOO_DISABLE_CUDA_GRAPH` is unset ⇒ capture would be enabled ⇒ return `ErrCaptureTrainingDisabled` **unless** `ZERFOO_UNSAFE_CAPTURE_TRAINING=1`.
- Error message (exact): `capture-replay training is disabled pending zerfoo#878 (silent gradient divergence); set ZERFOO_UNSAFE_CAPTURE_TRAINING=1 to override at your own risk`.
- **Eager/passthrough construction is completely unaffected** — no `GraphCapturer` engine, or capture disabled via `ZERFOO_DISABLE_CUDA_GRAPH` ⇒ succeeds, no env var needed.
- Gate is decided **once at construction** (where enablement is already fully decided: the env reads and the interface assertion all happen there), so `Step` never re-checks — the hot path is untouched.
- **Inference-side CUDA-graph capture (`generate/`, `inference/`) is not touched** — separate, unaffected path.

## Test matrix (S129.2.1, `training/capture_replay_test.go`)

| Test | Scenario | Expectation |
|---|---|---|
| `GateBlocksCaptureWithoutOverride` | fake `GraphCapturer`, no override | error wraps `ErrCaptureTrainingDisabled`, message contains `zerfoo#878` and `ZERFOO_UNSAFE_CAPTURE_TRAINING`, runner nil, capture API untouched |
| `GateOverrideRestoresCapture` | override `=1` | construction succeeds, `Enabled()==true`, warmup→capture→replay schedule unchanged |
| `GateIgnoresEagerConstruction` | CPU engine (no capturer), no override | succeeds, disabled passthrough |

Existing capture tests updated to set the override and consume the new error return. Fixture `tests/training/capture_replay_divergence_878_test.go` updated to consume the error return (it already sets `ZERFOO_UNSAFE_CAPTURE_TRAINING=1`).

Mocks/fakes are confined to test files.

## Docs

`docs/design.md` §21.5 (new, Tier-1) describes the gate + override and cites zerfoo#878. Separate commit from `training/`.

## Validation

- `go build ./...` — green
- `go vet ./training/ ./tests/training/` — green
- `gofmt -l` on changed files — clean
- `go test ./training/` — **could not run locally**: the test binary compiles but crashes at process startup in `ztensor/device.init.0` → `cuda.GetDeviceCount` → `dlopenImpl` SIGSEGV on this darwin host. This is the pre-existing **ztensor#171** dlopen bug, fires on import before any test function, independent of this change. Compilation of the tests is proven (the binary built and only faulted at package-init).

## Commits

- `feat(training):` gate + S129.2.1 unit tests
- `test(training):` fixture error-return handling
- `docs(design):` §21.5 gate documentation
