### PR TITLE
fix(cuda): #922 kernels-package CUDA-context poison (T135.1)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1155,6 +1155,15 @@ mounted; it exits 0 only on a clean JSON report. One GPU pod runs at a time
 on the host; interactive SSH remains debugging-only. Results are recorded in
 docs/devlog.md per run.
 
+Targeted debugging narrows the GPU test scope with
+`-pkgs "<go test args>"` (e.g. `-pkgs "-v -run TestKernelAdd ./internal/cuda/kernels/"`),
+which the pod passes verbatim to `go test`. The in-pod stage
+(`scripts/dgx-validate-inpod.sh`) enforces a zero-match guard: if a `-run`
+regex matches no tests, `go test` still exits 0 with "no tests to run", so the
+guard treats that output as a FAILURE rather than a silent pass. Note the sed
+substitution in `dgx-validate.sh` uses `|` as its delimiter, so a `-run` regex
+must not contain `|` (regex alternation).
+
 ---
 
 ## 9. Troubleshooting

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,73 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-07-02: #922 bisected + fixed -- a null-pointer FP16 kernel launch poisoned the CUDA context (T135.1)
+
+**Type:** finding + bugfix
+**Tags:** dgx, spark, validation, gb10, purego, kernels, cuda-context, T135.1, #922, #847, M-P1-1
+
+**Problem:** `go test ./internal/cuda/kernels/` failed package-wide on the GB10:
+every visible test failed at its first cudaMalloc/cudaStreamCreate with
+"an illegal memory access was encountered" (sticky cuda error 700), yet
+`TestKernelSoftmax` passed in isolation. One early test poisoned the context.
+
+**Bisection (GB10 via `scripts/dgx-validate.sh -ref wave-1-task-T135.1 -pkgs ...`):**
+Spark returns only the log TAIL, so a full `-v` run showed the cascade already
+underway (pod `...T13-1783046310`, first visible fail `TestGatherI32Parity`).
+Re-running with `-v -failfast` puts the first failure AT the tail where
+truncation cannot hide it (pod `...T13-1783046501`): tests ran in source order
+counter -> elementwise_fp16 -> ... and stopped at the FIRST fail --
+`TestFP16GracefulWithoutCUDA/AddFP16` (elementwise_fp16_test.go:53,
+"AddFP16 should return error without CUDA").
+
+**Root cause:** `TestFP16GracefulWithoutCUDA` was the ONLY `*GracefulWithoutCUDA`
+test missing the `if cuda.Available() { t.Skip() }` guard its six siblings all
+have. On the live GB10, `klib()` is non-nil, so `AddFP16(nil,nil,nil,1,nil)`
+(and the other five FP16 wrappers) launched the real FP16 kernels with NULL
+device pointers. The null-pointer kernel dereference is an illegal memory access
+that poisons the CUDA context for the rest of the package; the launch is async
+so the wrapper returned nil (also failing the test's own "should return error"
+assertion). This is a test bug, not a kernel/launcher bug -- the wrappers do
+exactly what every other wrapper does (launch what they are given), and the
+graceful path is only meaningful when CUDA is absent.
+
+**Fix:** add the missing `cuda.Available()` skip guard (commit on branch
+wave-1-task-T135.1). Post-fix full-package run (pod `...T13-1783046820`,
+ref 27026e73) confirmed the IMA cascade is GONE: gather, gemm_q4, offset_memcpy,
+rope_select, and the sgemv/gemv parity cases now PASS where they all previously
+IMA'd. See [[L-0013]].
+
+**Also (T135.1 deliverable):** the standing gate treated a `-run` regex that
+matched zero tests as PASS (go prints "no tests to run" and exits 0) -- the
+footgun recorded in the T131.3 entry that silently invalidated targeted `-pkgs`
+bisection. `scripts/dgx-validate-inpod.sh` now captures test output and fails
+loudly on that signature; `[no test files]` (a package with no tests, normal
+under `./...`) stays allowed. Note `dgx-validate.sh` uses `|` as its sed
+substitution delimiter, so a `-run` regex must not contain `|`.
+
+**Residual (NOT #922; unmasked by removing the poison) -> T135.2 / T135.3:**
+the post-fix run surfaced pre-existing kernel failures the poison had hidden:
+1. `TestSgemvM1_MultipleSizes/odd_N_127x255` -> `cudaStreamSynchronize failed:
+   misaligned address`, which re-poisons the context (next subtest
+   `large_4096x4096` then fails cudaStreamCreate). Root cause: sgemv_m1.cu casts
+   `A + row*N` to `float4*` (line 45) -- for N not a multiple of 4 an odd row's
+   pointer is not 16-byte aligned, so the vectorized `__ldg` float4 load faults.
+   A kernel (.cu) bug -> #847 tail / T3.3 oracle-gate.
+2. FP32 reduction-order tolerance failures (rel err ~1e-4 to 7.5e-4 vs the
+   test's 1e-4 bar) in `TestGemvQ4KF32_LargerMatrix/MultipleSizes` and
+   `TestSgemvM1_MultipleSizes` (medium/gemma3 sizes). This is exactly the
+   fixed-order fp32 tree-reduction work (T135.2, lands in ztensor) and the
+   per-op oracle tolerance table (T135.3).
+The gate mounts a PREBUILT libkernels.so (read-only, from /opt/zerfoo/lib) and
+never recompiles .cu in-pod, so neither residual is fixable/verifiable in this
+gate -- both require a .so rebuild + oracle-gating and belong to T135.2/T135.3.
+
+**Impact on M-P1-1 (standing gate full-scope green):** NOT achievable by T135.1
+alone. Removing the #922 poison unmasks T135.2 (reductions) and T135.3
+(misalignment + oracle) failures, so the default-scope gate stays red on
+`./internal/cuda/kernels/` until those land. The plan attributes M-P1-1 to
+T135.1 only; it in fact depends on T135.2 + T135.3.
+
 ## 2026-07-02: Standing DGX arm64 validation gate operational -- first honest run catches a real kernel bug (T131.3)
 
 **Type:** finding + infrastructure

--- a/docs/lore.md
+++ b/docs/lore.md
@@ -148,3 +148,14 @@ the next `L-NNNN` ID; never renumber. See `~/.claude/skills/lore/SKILL.md`
 **Why:** The repo's commit convention — reflected in the `/apply`, `/journal`, and `/lore` workflows, which each stage a single path (`git add docs/lore.md`) — is one directory per commit, so history stays bisectable and PRs stay reviewable per subsystem. NOTE / discrepancy with the seed summary: this could not be verified as an *installed* pre-commit hook in this worktree — there is no `.git/hooks/pre-commit`, no `.githooks/`, no `core.hooksPath`, and the rule is not stated in the project `CLAUDE.md`. Treat it as a documented convention (and honor it) until the enforcing hook is located; if you add such a hook, update this entry with its path.
 **Trigger:** A `git add` / commit spanning two top-level directories at once.
 **Source:** CLAUDE.md / repo commit hooks (convention; installed hook not located as of 2026-07-02).
+
+## L-0013: A null-pointer kernel launch poisons the whole CUDA context; graceful-degradation tests must skip when CUDA is available
+
+**Tags:** #gb10 #kernel #cuda-context #purego #gotcha
+**Date:** 2026-07-02
+**Repo:** zerfoo/zerfoo
+
+**Rule:** Never launch a real kernel with NULL device pointers on a live CUDA context. The `*GracefulWithoutCUDA` tests (which pass nil pointers to assert the wrappers error out) MUST guard with `if cuda.Available() { t.Skip("CUDA available, skipping graceful-failure test") }` -- the graceful path is only meaningful when CUDA is absent (klib() nil -> early error return before any launch).
+**Why:** With CUDA available, `klib()` is non-nil and a wrapper like `AddFP16(nil,nil,nil,1,nil)` calls `cuda.Ccall(k.launchAddFP16, 0,0,0,1,0)`, launching the FP16 kernel with null device pointers. The on-device null dereference is an illegal memory access that leaves a STICKY error (cuda 700) on the context, so every subsequent test in the package fails at its first cudaMalloc/cudaStreamCreate -- a package-wide IMA cascade that looks like many broken kernels but is one poisoning test. The launch is async, so the wrapper's `checkKernel` sees launch-success and returns nil, which also silently fails the test's own "should return error" assertion. `TestFP16GracefulWithoutCUDA` was the sole graceful test missing the guard (zerfoo#922); its six siblings (counter, elementwise_parity, fp8_ops, gather, offset_memcpy, rope_select) all had it. Corollary: to find the first-faulting test when Spark truncates logs to the tail, run `-v -failfast` so the first failure lands at the tail where truncation cannot hide it.
+**Trigger:** A new `*GracefulWithoutCUDA` (or any nil-device-pointer) test without the `cuda.Available()` skip guard; more generally, any code path that can reach a kernel launch with a null/unallocated device pointer on a live context.
+**Source:** zerfoo#922; devlog 2026-07-02 (T135.1).

--- a/internal/cuda/kernels/elementwise_fp16_test.go
+++ b/internal/cuda/kernels/elementwise_fp16_test.go
@@ -3,6 +3,8 @@ package kernels
 import (
 	"testing"
 	"unsafe"
+
+	"github.com/zerfoo/zerfoo/internal/cuda"
 )
 
 // TestFP16SignaturesCompile verifies that the FP16 purego wrappers have
@@ -34,6 +36,17 @@ func TestFP16SignaturesCompile(t *testing.T) {
 // TestFP16GracefulWithoutCUDA verifies that all FP16 kernel functions
 // return an error (not panic) when CUDA is not available.
 func TestFP16GracefulWithoutCUDA(t *testing.T) {
+	// When CUDA IS available, klib() is non-nil and these wrappers launch the
+	// real FP16 kernels with the nil device pointers below -- a null-pointer
+	// kernel launch that triggers an illegal memory access and poisons the
+	// CUDA context for every subsequent test in the package (zerfoo#922).
+	// Every other *GracefulWithoutCUDA test guards on this for the same reason;
+	// this one must too. The graceful path is only meaningful when CUDA is
+	// absent.
+	if cuda.Available() {
+		t.Skip("CUDA available, skipping graceful-failure test")
+	}
+
 	tests := []struct {
 		name string
 		fn   func() error

--- a/scripts/dgx-validate-inpod.sh
+++ b/scripts/dgx-validate-inpod.sh
@@ -60,8 +60,22 @@ fi
 
 CUDA=pass
 echo ">> go test $CUDA_PKGS (purego GPU path)"
+# Capture output (still streamed via tee) so we can enforce a zero-match guard.
+# Footgun (devlog 2026-07-02): when CUDA_PKGS carries a `-run <regex>` filter
+# that matches NO tests, `go test` prints "no tests to run", exits 0, and the
+# gate reports a false PASS. That silently invalidated targeted -pkgs bisection
+# runs. Detect that signature and fail loudly. NOTE: "[no test files]" (a
+# package that simply ships no tests, normal under the ./... default scope) is
+# a DIFFERENT string and must stay allowed.
+CUDA_LOG="$(mktemp)"
 # shellcheck disable=SC2086
-go test -count=1 -timeout 900s $CUDA_PKGS || { CUDA=fail; add_fail cuda_tests; }
+go test -count=1 -timeout 900s $CUDA_PKGS 2>&1 | tee "$CUDA_LOG"
+[ "${PIPESTATUS[0]}" -eq 0 ] || { CUDA=fail; add_fail cuda_tests; }
+if grep -q 'no tests to run' "$CUDA_LOG"; then
+  echo ">> ERROR: a -run filter matched zero tests; refusing to count this as a pass" >&2
+  CUDA=fail; add_fail cuda_tests_zero_match
+fi
+rm -f "$CUDA_LOG"
 
 # Model parity: only when GGUF files are mounted. Each model parity test skips
 # itself when its ModelDirEnvVar is unset, so we discover those env-var names


### PR DESCRIPTION
## T135.1 -- Bisect + fix #922 (kernels-package CUDA-context poison)

`verifies: UC-H2-003, infrastructure` · `fixes #922`

### Root cause
`go test ./internal/cuda/kernels/` failed package-wide on the GB10 (every test
IMA'd at its first `cudaMalloc`/`cudaStreamCreate`), yet `TestKernelSoftmax`
passed in isolation. Bisected with the standing gate using `-v -failfast` (which
puts the first failure at the log tail, where Spark's truncation cannot hide it).
The first-faulting test is **`TestFP16GracefulWithoutCUDA`** -- the only
`*GracefulWithoutCUDA` test missing the `if cuda.Available() { t.Skip() }` guard
its six siblings all have. On a live context `klib()` is non-nil, so
`AddFP16(nil,nil,nil,1,nil)` launches the real FP16 kernel with NULL device
pointers; the on-device null dereference is an illegal memory access that leaves
a sticky error (cuda 700) on the context, poisoning every subsequent test. The
async launch returns success, so the wrapper also returned nil -- failing the
test's own "should return error" assertion.

### Changes
- `fix(cuda)`: add the missing `cuda.Available()` skip guard to
  `TestFP16GracefulWithoutCUDA`, matching the sibling graceful tests.
- `fix(scripts)`: **zero-matched-tests guard** in `dgx-validate-inpod.sh` -- a
  `-run` regex that matches no tests printed "no tests to run" and still exited
  0, so the gate reported a false PASS (the footgun recorded in the T131.3
  devlog). It now fails loudly; `[no test files]` stays allowed.
- `docs`: design.md 8.5 (guard + the `|` sed-delimiter constraint on `-run`
  regexes), devlog (bisection narrative + evidence + residual), lore L-0013
  (null-pointer launch poisons the context).

### Validation (GB10 via Spark, one pod at a time)
- Repro `-v` (pod `...1783046310`): package-wide IMA cascade confirmed.
- `-v -failfast` (pod `...1783046501`): first fail = `TestFP16GracefulWithoutCUDA/AddFP16`.
- Post-fix full `-v` kernels (pod `...1783046820`, ref 27026e73): **IMA cascade
  GONE** -- gather / gemm_q4 / offset_memcpy / rope_select / sgemv+gemv parity
  now PASS where they all previously IMA'd.
- Local: `go build ./...` clean, `go vet ./internal/cuda/kernels/` clean.

### Not fixed here (unmasked by removing the poison) -> T135.2 / T135.3
Removing the poison surfaced pre-existing kernel failures it had hidden:
1. `TestSgemvM1_MultipleSizes/odd_N_127x255` -> `misaligned address` (sgemv_m1.cu
   casts `A + row*N` to `float4*`; odd N makes odd rows 16-byte-unaligned). A
   `.cu` bug -> #847 tail / T135.3 oracle-gate.
2. FP32 reduction-order tolerance failures (rel err ~1e-4..7.5e-4 vs the 1e-4
   bar) in `TestGemvQ4KF32_*` and `TestSgemvM1_MultipleSizes` -> fixed-order
   fp32 reductions (T135.2, ztensor) + per-op oracle tolerance table (T135.3).

The gate mounts a **prebuilt** `libkernels.so` (read-only) and never recompiles
`.cu` in-pod, so these are neither fixable nor verifiable in this gate.
**Consequence:** milestone **M-P1-1** (default-scope gate green) is *not*
achievable by T135.1 alone -- it depends on T135.2 + T135.3.


> Residual tracked in #926 (handoff to T135.2 / T135.3).
