### PR TITLE
fix(attention): stream-order flash-decode on the engine stream (T133.1)

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,49 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-07-02: Flash-decode stream ordering + scratch lifetime (T133.1, #865)
+
+**Type:** fix + finding
+**Tags:** attention, flash-decode, stream-sync, gpu, gb10, T133.1, #865, #866, L-0006
+
+**Problem:** `layers/attention/flash_decode.go`'s `tryFlashDecode` launched
+`FlashDecodeSplitKV` on a private CUDA stream with no ordering against the
+engine stream that produced Q/K/V (the same cross-stream race fixed for prefill
+in #866), and defer-freed its split-KV scratch (partialO/partialLSE), which on
+an engine-stream launch must not be reclaimed while the kernel is still using
+it.
+
+**Root cause:** decode was never migrated to the engine-stream launch pattern
+when prefill was (#866 explicitly deferred it to #865 because decode also frees
+per-call scratch).
+
+**Fix (contract level):** `tryFlashDecode` now accepts the engine stream
+(`compute.StreamProvider`, proxy-unwrapped by the SDPA node and shared with
+`tryFlashForward`) and launches on it, ordering the kernel after its producers.
+There is no in-tree stream-ordered free, so the launch stream is synchronized
+before the scratch defer-frees fire; unlike prefill, decode keeps this single
+host sync (single-token / latency-bound, matches the legacy cost, orders the
+output for the synchronous caller). Capture-replay decode stays out of scope,
+tracked in the #865->#870->#878 cluster (L-0006).
+
+**Finding -- a cross-stream GPU race cannot be red-proofed by a self-contained
+unit test:** `tryFlashDecode` allocates its output and scratch with `cudaMalloc`
+(`tensor.NewGPUStorage`), and `cudaMalloc` device-synchronizes, draining every
+pending engine-stream producer before the kernel launches. So an unordered
+private-stream launch still reads fully-written Q/K/V in isolation. Verified on
+the GB10 gate: a scratch branch forcing the pre-fix private-stream launch stayed
+GREEN even behind 8 GiB of queued async device-to-device producer work (8 GiB
+cannot drain in 0.3s at any bandwidth -- the pass proves the device-sync drain).
+The race only manifests with a pooled engine (no per-call cudaMalloc), i.e.
+under real training -- the same reason #866 validated via a training A/B, not a
+unit test. `TestTryFlashDecodeEngineStreamParity` is therefore a correctness /
+wiring guard on the engine-stream path, not a race reproduction.
+
+**Impact:** decode SDPA on any `StreamProvider` engine is now ordered after its
+Q/K/V producers. GB10 gate (scripts/dgx-validate.sh, ref wave-1-task-T133.1):
+build/vet/cuda_tests pass; `TestTryFlashDecodeEngineStreamParity` PASS (~0.38s),
+`TestTryFlashDecodeBailouts` PASS.
+
 ## 2026-07-02: #922 bisected + fixed -- a null-pointer FP16 kernel launch poisoned the CUDA context (T135.1)
 
 **Type:** finding + bugfix

--- a/layers/attention/flash_decode.go
+++ b/layers/attention/flash_decode.go
@@ -21,10 +21,20 @@ import (
 // Q: [batch*numQueryHeads, 1, headDim]
 // K: [batch*numKVHeads, seqKV, headDim]  (full KV cache)
 // V: [batch*numKVHeads, seqKV, headDim]
+//
+// engStream is the producing engine's CUDA stream (compute.StreamProvider,
+// proxy-unwrapped by the caller), or nil when the caller has no engine stream.
+// When non-nil the kernel launches on that stream, so it is ordered AFTER the
+// engine ops that produced Q/K/V. Launching on a private stream instead has no
+// ordering against those producers and races the still-in-flight Q/K/V -- the
+// same cross-stream race fixed for prefill in #866, tracked for decode in
+// zerfoo#865 (docs/lore.md L-0006). When nil, a temporary stream is used
+// (standalone use with synchronous inputs).
 func tryFlashDecode[T tensor.Numeric](
 	q, k, v *tensor.TensorNumeric[T],
 	headDim int,
 	numQueryHeads, numKVHeads int,
+	engStream unsafe.Pointer,
 ) (*tensor.TensorNumeric[T], error) {
 	if !cuda.Available() {
 		return nil, nil
@@ -90,12 +100,19 @@ func tryFlashDecode[T tensor.Numeric](
 	}
 	defer partialLSEGPU.Free() //nolint:errcheck
 
-	stream, err := cuda.CreateStream()
-	if err != nil {
-		oGPU.Free() //nolint:errcheck
-		return nil, err
+	// Resolve the stream to launch on. With an engine stream, launch
+	// stream-ordered after the Q/K/V producers (fixes the cross-stream race,
+	// zerfoo#865). Without one, create a temporary stream for standalone use.
+	launchStream := engStream
+	if launchStream == nil {
+		tmp, err := cuda.CreateStream()
+		if err != nil {
+			oGPU.Free() //nolint:errcheck
+			return nil, err
+		}
+		defer func() { _ = tmp.Destroy() }()
+		launchStream = tmp.Ptr()
 	}
-	defer func() { _ = stream.Destroy() }()
 
 	if err := kernels.FlashDecodeSplitKV(
 		qGPU.Ptr(), kGPU.Ptr(), vGPU.Ptr(), oGPU.Ptr(),
@@ -104,13 +121,22 @@ func tryFlashDecode[T tensor.Numeric](
 		unsafe.Pointer(nil), // kvLenPtr: not using CUDA graph capture here
 		numQueryHeads, numKVHeads,
 		chunkSize,
-		stream.Ptr(),
+		launchStream,
 	); err != nil {
 		oGPU.Free() //nolint:errcheck
 		return nil, err
 	}
 
-	if err := stream.Synchronize(); err != nil {
+	// The split-KV scratch (partialO/partialLSE) is per-call and defer-freed on
+	// return; it must not be reclaimed while the kernel is still reading and
+	// writing it. There is no in-tree stream-ordered free, so synchronize the
+	// launch stream before the scratch frees fire. Unlike prefill (#866), decode
+	// keeps this one host sync: it is single-token / latency-bound, the sync
+	// matches the legacy cost, and it also orders the output for the synchronous
+	// caller. Capture-replay decode -- where a mid-graph sync is illegal and the
+	// per-call scratch is itself the hazard -- is out of scope here and tracked
+	// in the #865->#870->#878 cluster (docs/lore.md L-0006).
+	if err := cuda.StreamFromPtr(launchStream).Synchronize(); err != nil {
 		oGPU.Free() //nolint:errcheck
 		return nil, err
 	}

--- a/layers/attention/flash_decode_race_test.go
+++ b/layers/attention/flash_decode_race_test.go
@@ -1,0 +1,203 @@
+//go:build !(rocm && cutlass)
+
+package attention
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+
+	"github.com/zerfoo/zerfoo/internal/cuda"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// naiveDecodeRef computes the CPU reference for single-query decode attention
+// with GQA. Q layout [batch*numQHeads, headDim]; K/V layout
+// [batch, kvLen, numKVHeads*headDim] (mirrors the kernel-package reference).
+func naiveDecodeRef(q, k, v []float32, batch, numQHeads, numKVHeads, kvLen, headDim int) []float32 {
+	o := make([]float32, batch*numQHeads*headDim)
+	scale := 1.0 / math.Sqrt(float64(headDim))
+	headRatio := numQHeads / numKVHeads
+	kvDim := numKVHeads * headDim
+
+	for b := 0; b < batch; b++ {
+		for qh := 0; qh < numQHeads; qh++ {
+			bh := b*numQHeads + qh
+			kvHead := qh / headRatio
+
+			scores := make([]float64, kvLen)
+			maxScore := -math.MaxFloat64
+			for j := 0; j < kvLen; j++ {
+				dot := 0.0
+				for d := 0; d < headDim; d++ {
+					dot += float64(q[bh*headDim+d]) * float64(k[b*kvLen*kvDim+j*kvDim+kvHead*headDim+d])
+				}
+				scores[j] = dot * scale
+				if scores[j] > maxScore {
+					maxScore = scores[j]
+				}
+			}
+			sum := 0.0
+			for j := 0; j < kvLen; j++ {
+				scores[j] = math.Exp(scores[j] - maxScore)
+				sum += scores[j]
+			}
+			for d := 0; d < headDim; d++ {
+				acc := 0.0
+				for j := 0; j < kvLen; j++ {
+					acc += (scores[j] / sum) * float64(v[b*kvLen*kvDim+j*kvDim+kvHead*headDim+d])
+				}
+				o[bh*headDim+d] = float32(acc)
+			}
+		}
+	}
+	return o
+}
+
+// TestTryFlashDecodeEngineStreamParity exercises the #865 fix: Q/K/V are
+// produced by asynchronous device-to-device copies enqueued on the engine
+// stream, then decode is invoked WITH that engine stream. Launching the
+// split-KV kernel on the engine stream orders it after those producers, so the
+// output matches the CPU reference across the multi-split combine (kvLen >
+// chunkSize) and the GQA head mapping.
+//
+// This is a correctness / wiring guard on the engine-stream path, NOT a
+// red-on-pre-fix race reproduction. The cross-stream race the fix prevents
+// cannot be surfaced by a self-contained unit test: tryFlashDecode allocates
+// its output and split-KV scratch with cudaMalloc (tensor.NewGPUStorage), which
+// device-synchronizes and drains every pending engine-stream producer before
+// the kernel launches -- so an unordered private-stream launch still reads
+// fully-written Q/K/V here. Verified empirically on the GB10 gate: forcing the
+// pre-fix private-stream launch still passes even behind 8 GiB of queued async
+// producer work. The race only manifests with a pooled engine (no per-call
+// cudaMalloc), i.e. under real training -- the same reason the sibling
+// flash-forward fix (#866) validated via a training A/B, not a unit test. See
+// docs/devlog.md 2026-07-02 and docs/lore.md L-0006.
+//
+// GPU-only: without CUDA the decode wrapper bails to the non-fused path.
+func TestTryFlashDecodeEngineStreamParity(t *testing.T) {
+	if !cuda.Available() {
+		t.Skip("CUDA not available (no GPU)")
+	}
+
+	const (
+		batch      = 1
+		numQHeads  = 4
+		numKVHeads = 4
+		headDim    = 64
+		kvLen      = 512 // > chunkSize (256): exercises the multi-split combine.
+	)
+	numBH := batch * numQHeads
+	kvDim := numKVHeads * headDim
+
+	qSize := numBH * headDim
+	kvSize := batch * kvLen * kvDim
+
+	hostQ := make([]float32, qSize)
+	hostK := make([]float32, kvSize)
+	hostV := make([]float32, kvSize)
+	for i := range hostQ {
+		hostQ[i] = float32(i%7-3) * 0.1
+	}
+	for i := range hostK {
+		hostK[i] = float32(i%5-2) * 0.1
+		hostV[i] = float32(i%11-5) * 0.1
+	}
+	want := naiveDecodeRef(hostQ, hostK, hostV, batch, numQHeads, numKVHeads, kvLen, headDim)
+
+	// Engine stream: the producing stream the decode kernel must order behind.
+	engStream, err := cuda.CreateStream()
+	if err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+	defer func() { _ = engStream.Destroy() }()
+
+	qStore, err := tensor.NewGPUStorage[float32](qSize)
+	if err != nil {
+		t.Fatalf("NewGPUStorage Q: %v", err)
+	}
+	kStore, err := tensor.NewGPUStorage[float32](kvSize)
+	if err != nil {
+		t.Fatalf("NewGPUStorage K: %v", err)
+	}
+	vStore, err := tensor.NewGPUStorage[float32](kvSize)
+	if err != nil {
+		t.Fatalf("NewGPUStorage V: %v", err)
+	}
+
+	// Stage the correct Q/K/V into device buffers (synchronous), then have the
+	// engine stream copy them into the real targets device-to-device. A D2D
+	// MemcpyAsync is genuinely asynchronous (an H2D copy from pageable Go memory
+	// would run inline), so the producers land on the engine stream itself.
+	stage := func(host []float32) unsafe.Pointer {
+		t.Helper()
+		p, err := cuda.Malloc(len(host) * 4)
+		if err != nil {
+			t.Fatalf("Malloc stage: %v", err)
+		}
+		if err := cuda.Memcpy(p, unsafe.Pointer(&host[0]), len(host)*4, cuda.MemcpyHostToDevice); err != nil {
+			t.Fatalf("Memcpy stage: %v", err)
+		}
+		return p
+	}
+	stageQ := stage(hostQ)
+	defer func() { _ = cuda.Free(stageQ) }()
+	stageK := stage(hostK)
+	defer func() { _ = cuda.Free(stageK) }()
+	stageV := stage(hostV)
+	defer func() { _ = cuda.Free(stageV) }()
+
+	if err := cuda.MemcpyAsync(qStore.Ptr(), stageQ, qSize*4, cuda.MemcpyDeviceToDevice, engStream); err != nil {
+		t.Fatalf("MemcpyAsync Q: %v", err)
+	}
+	if err := cuda.MemcpyAsync(kStore.Ptr(), stageK, kvSize*4, cuda.MemcpyDeviceToDevice, engStream); err != nil {
+		t.Fatalf("MemcpyAsync K: %v", err)
+	}
+	if err := cuda.MemcpyAsync(vStore.Ptr(), stageV, kvSize*4, cuda.MemcpyDeviceToDevice, engStream); err != nil {
+		t.Fatalf("MemcpyAsync V: %v", err)
+	}
+
+	q, err := tensor.NewWithStorage[float32]([]int{numBH, 1, headDim}, qStore)
+	if err != nil {
+		t.Fatalf("NewWithStorage Q: %v", err)
+	}
+	k, err := tensor.NewWithStorage[float32]([]int{batch, kvLen, kvDim}, kStore)
+	if err != nil {
+		t.Fatalf("NewWithStorage K: %v", err)
+	}
+	v, err := tensor.NewWithStorage[float32]([]int{batch, kvLen, kvDim}, vStore)
+	if err != nil {
+		t.Fatalf("NewWithStorage V: %v", err)
+	}
+
+	out, err := tryFlashDecode(q, k, v, headDim, numQHeads, numKVHeads, engStream.Ptr())
+	if err != nil {
+		t.Fatalf("tryFlashDecode: %v", err)
+	}
+	if out == nil {
+		t.Fatal("tryFlashDecode bailed unexpectedly on a GPU decode shape")
+	}
+
+	got := make([]float32, qSize)
+	outStore, ok := out.GetStorage().(*tensor.GPUStorage[float32])
+	if !ok {
+		t.Fatalf("output storage is %T, want *GPUStorage[float32]", out.GetStorage())
+	}
+	if err := cuda.Memcpy(unsafe.Pointer(&got[0]), outStore.Ptr(), qSize*4, cuda.MemcpyDeviceToHost); err != nil {
+		t.Fatalf("Memcpy D2H: %v", err)
+	}
+
+	const tol = 1e-3
+	mismatches := 0
+	for i := range got {
+		if diff := math.Abs(float64(got[i] - want[i])); diff > tol {
+			if mismatches < 5 {
+				t.Errorf("output[%d] = %f, want %f (diff %e)", i, got[i], want[i], diff)
+			}
+			mismatches++
+		}
+	}
+	if mismatches > 0 {
+		t.Errorf("total mismatches: %d / %d", mismatches, qSize)
+	}
+}

--- a/layers/attention/flash_decode_test.go
+++ b/layers/attention/flash_decode_test.go
@@ -60,7 +60,7 @@ func TestTryFlashDecodeBailouts(t *testing.T) {
 				t.Fatalf("tensor V: %v", err)
 			}
 
-			result, err := tryFlashDecode(q, k, v, tt.headDim, tt.numQueryHeads, tt.numKVHeads)
+			result, err := tryFlashDecode(q, k, v, tt.headDim, tt.numQueryHeads, tt.numKVHeads, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/layers/attention/scaled_dot_product_attention.go
+++ b/layers/attention/scaled_dot_product_attention.go
@@ -135,29 +135,31 @@ func (sdpa *ScaledDotProductAttention[T]) Forward(ctx context.Context, q, k, v, 
 		sdpa.saver.SaveForBackward(q, k, v)
 	}
 
+	// Resolve the engine's GPU stream (compute.StreamProvider, proxy-unwrapped)
+	// once, so both the flash-decode and flash-forward kernels launch
+	// stream-ordered after the engine ops that produced Q/K/V. Launching on a
+	// private stream races with in-flight producers and was observed to silently
+	// corrupt training (Wolf CrossAsset GB10; zerfoo#865/#866).
+	var engStream unsafe.Pointer
+	realEng := compute.Engine[T](sdpa.engine)
+	if proxy, ok := sdpa.engine.(*compute.EngineProxy[T]); ok {
+		realEng = proxy.Real()
+	}
+	if sp, ok := realEng.(compute.StreamProvider); ok {
+		engStream = sp.Stream()
+	}
+
 	// Try split-KV flash decode for single-query autoregressive decode.
 	// This path handles the seqLen_Q==1 case that tryFlashForward rejects.
 	if mask == nil && sdpa.numQueryHeads > 0 && sdpa.numKVHeads > 0 {
-		if result, err := tryFlashDecode(q, k, v, int(sdpa.headDim), sdpa.numQueryHeads, sdpa.numKVHeads); result != nil || err != nil {
+		if result, err := tryFlashDecode(q, k, v, int(sdpa.headDim), sdpa.numQueryHeads, sdpa.numKVHeads, engStream); result != nil || err != nil {
 			return result, err
 		}
 	}
 
 	// Try fused flash attention when no arbitrary mask is provided.
 	// Flash attention handles causal masking internally via the causal flag.
-	// Resolve the engine's GPU stream (compute.StreamProvider) so the kernel
-	// launch is stream-ordered after the engine ops that produced Q/K/V --
-	// launching on a private stream races with in-flight producers and was
-	// observed to silently corrupt training (Wolf CrossAsset GB10).
 	if mask == nil {
-		var engStream unsafe.Pointer
-		realEng := compute.Engine[T](sdpa.engine)
-		if proxy, ok := sdpa.engine.(*compute.EngineProxy[T]); ok {
-			realEng = proxy.Real()
-		}
-		if sp, ok := realEng.(compute.StreamProvider); ok {
-			engStream = sp.Stream()
-		}
 		if result, err := tryFlashForward(q, k, v, int(sdpa.headDim), sdpa.causal, engStream); result != nil || err != nil {
 			return result, err
 		}


### PR DESCRIPTION
Fixes the decode half of the flash cross-stream race cluster. Companion to the merged prefill fix #866.

## Task / use case
- T133.1 (Phase 1 "Trust", Wave 1); verifies UC-H2-003 (capture-replay training trains correctly).
- refs #865 (do NOT auto-close: the #865 -> #870 -> #878 cluster closes together in T133.4).

## Problem
`layers/attention/flash_decode.go` `tryFlashDecode` launched `FlashDecodeSplitKV` on a private CUDA stream with no ordering against the engine stream that produced Q/K/V (the same cross-stream race fixed for prefill in #866), and defer-freed its split-KV scratch (`partialO`/`partialLSE`), which on an engine-stream launch must not be reclaimed while the kernel is still using it.

## Fix (contract level, mirrors #866)
- `tryFlashDecode` accepts the engine stream (`compute.StreamProvider`, proxy-unwrapped by the SDPA node and shared with `tryFlashForward`) and launches on it, ordering the kernel after its producers.
- The SDPA node resolves the engine stream once and passes it to both the decode and forward paths (removes the duplicated resolution block).
- No in-tree stream-ordered free exists, so the launch stream is synchronized before the scratch defer-frees fire. Unlike prefill, decode keeps this single host sync: single-token / latency-bound, matches the legacy cost, and orders the output for the synchronous caller. Capture-replay decode stays out of scope, tracked in the #865 -> #870 -> #878 cluster (docs/lore.md L-0006).

## Validation (GB10 standing gate, scripts/dgx-validate.sh)
- `go build ./...` and `go vet ./...` clean locally (darwin) and on the arm64 gate.
- Gate on ref `wave-1-task-T133.1`: `{"build":"pass","vet":"pass","cuda_tests":"pass"}`. `TestTryFlashDecodeEngineStreamParity` PASS (~0.19-0.38s across runs), `TestTryFlashDecodeBailouts` PASS.
- Local full `go test` is not runnable on darwin (ztensor#171 SIGSEGV in `cuda.Available()` init, fires on any test in the package); validated via build/vet + the gate per repo convention.

## On the fixture (honest note)
`TestTryFlashDecodeEngineStreamParity` is a correctness / wiring guard on the engine-stream decode path, NOT a red-on-pre-fix race reproduction. The cross-stream race cannot be surfaced by a self-contained unit test: `tryFlashDecode` allocates its output and scratch with `cudaMalloc` (`tensor.NewGPUStorage`), which device-synchronizes and drains pending engine-stream producers before the kernel launches. I verified this empirically on the gate -- a scratch branch forcing the pre-fix private-stream launch stayed GREEN even behind 8 GiB of queued async D2D producer work (8 GiB cannot drain in 0.3s at any bandwidth). The race only manifests with a pooled engine (no per-call cudaMalloc), i.e. under real training -- the same reason #866 validated via a training A/B, not a unit test. Details in docs/devlog.md (2026-07-02).