### PR TITLE
fix(attention): replay-stable FusedSDPA scratch (T133.2)

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -75,10 +75,25 @@ GPU-only (skip without CUDA); the CPU-runnable bailout/fallback wiring is
 unchanged and still covered by `TestTryFlashForwardFallback` and
 `TestSDPAFlashFallbackParity`.
 
-**GB10 evidence:** ref `wave-2-task-T133.2`, `scripts/dgx-validate.sh -pkgs
-"-v -run TestFusedSDPAForwardReplayStableScratch|TestFlashDecodeScratchReusedAcrossCalls|TestTryFlashDecodeEngineStreamParity ./layers/attention/"`,
-pod `<POD_NAME>`: PASS (511/511 replays, no illegal memory access; decode
-scratch reuse verified over 20 calls).
+**GB10 evidence:** ref `wave-2-task-T133.2` (7c24032e), `scripts/dgx-validate.sh
+-pkgs "-v -failfast ./layers/attention/..."`, pod
+`zerfoo-validate-wave2taskT13-1783060338`: `TestFusedSDPAForwardReplayStableScratch`
+PASS (0.33s) -- 511/511 replays, no illegal memory access, output verified
+against the CPU reference; this is the direct #870 reproduction (the flash
+FORWARD/prefill path, which is what Wolf's CrossAsset training actually
+exercises). `TestFlashDecodeScratchReusedAcrossCalls` SKIP (split-KV kernel
+not loaded on this host -- see finding below).
+
+**Finding (pre-existing, unrelated to this fix):** the split-KV flash-decode
+kernel (`kernels.IsFlashDecodeSplitKVSupported()`) is not currently loaded on
+the GB10 gate's `/opt/zerfoo/lib` libkernels.so mount. Confirmed via a control
+run on unmodified `origin/main` (5cbac676, pod
+`zerfoo-validate-5cbac6769563-1783059932`): the existing T133.1 test
+`TestTryFlashDecodeEngineStreamParity` bails out identically ("bailed
+unexpectedly on a GPU decode shape") on main, so this is a standing-gate /
+host-image regression independent of T133.2, not something introduced here.
+Left out of scope per "stay on task"; worth a follow-up issue to check the
+mounted kernel library on the DGX host.
 
 ## 2026-07-02: Fused encoder fwd/bwd audit -- FFN GELU-backward bug + zero gradcheck coverage on FusedSDPA/FFN closed (T135.4)
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,84 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-07-02: FusedSDPA replay-stable flash scratch (T133.2, #870)
+
+**Type:** fix
+**Tags:** attention, flash-attention, cuda-graph, capture-replay, gpu, gb10, T133.2, #870, #865, #866, L-0006
+
+**Problem:** Training through `training.CaptureReplayRunner` with FusedSDPA
+enabled captured successfully but crashed on replay (~#141 of 511):
+`cudaStreamSynchronize failed: an illegal memory access was encountered`.
+The identically-shaped discrete (non-fused) chain was clean under the same
+capture-replay harness.
+
+**Root cause:** `tryFlashForward` and `tryFlashDecode`
+(`layers/attention/flash.go`, `layers/attention/flash_decode.go`) allocate
+their scratch/output GPU buffers directly via `tensor.NewGPUStorage` (raw
+`cudaMalloc`), bypassing the engine arena entirely -- they operate on bare
+device pointers below the `compute.Engine[T]` abstraction. `tryFlashDecode`
+additionally freed its split-KV scratch (partialO/partialLSE) via a bare
+`defer` on every call; `tryFlashForward`'s output had no per-call free at
+all, relying on Go's GC finalizer to reclaim it once unreferenced. Either
+way, a CUDA graph bakes in the literal device address a captured kernel
+launch reads or writes. Freeing that address between replays -- via `defer`
+(decode) or a finalizer firing on some later, nondeterministic GC cycle
+(forward) -- hands the address to an unrelated later allocation while the
+graph keeps replaying kernels against it. This is exactly the L-0006 class
+("no per-call scratch with defer-frees inside the captured region"), and the
+GC-finalizer variant explains the non-deterministic ~141/511 crash point:
+whichever replay happened to follow the GC cycle that reclaimed the address.
+
+**Fix (contract level, persistent scratch):** Added `gpuScratchBuffer[T]`
+(`layers/attention/flash_scratch.go`), a small cache that allocates a GPU
+buffer once (lazily, on first use) and returns a non-owning `.View()` of it
+on every subsequent call instead of a fresh `cudaMalloc`/`cudaFree`. Cached
+instances live as fields on `ScaledDotProductAttention[T]` (one per
+output/scratch slot: forward output, decode output, decode partialO, decode
+partialLSE), so their lifetime matches the owning SDPA node -- which spans
+the whole capture-replay life of the graph it belongs to, exactly like the
+already-sanctioned "persistent gradient accumulator" / "lazy engine
+workspace" pattern ztensor's `compute.StepScope` doc calls out. Considered
+and rejected `GPUStorage.FreeAtEpoch` (the mechanism T133.1 used for
+epoch-checked pool frees): these buffers are not arena/pool-backed (raw
+`cudaMalloc`, no `EpochMemPool`), so applying it would require plumbing an
+engine/pool reference down into free functions that currently take only an
+`engStream unsafe.Pointer` -- a bigger, unscoped refactor for no benefit over
+simply never freeing the buffer for the node's lifetime.
+
+Growth (an actual `cudaFree` + `cudaMalloc`) only happens when a call needs
+more capacity than currently cached, which the `CaptureReplayRunner` static-
+shape contract guarantees never occurs after the eager warmup steps that
+precede capture (matching ztensor's own capture rule: "All tensors used
+during capture must be pre-allocated").
+
+`tryFlashDecode`'s pre-existing mid-graph `cudaStreamSynchronize` (needed for
+eager/inference callers, illegal under active stream capture) is a separate,
+already-documented limitation -- decode is an inference-time (KV-cache) path
+that `CaptureReplayRunner`'s training walk does not exercise, so it is left
+out of scope here (still tracked in the #865->#870->#878 cluster) rather than
+silently fixed alongside the scratch-lifetime issue.
+
+**Tests:** `layers/attention/flash_capture_replay_test.go` (new, the ADR-091
+regression fixture for #870):
+`TestFusedSDPAForwardReplayStableScratch` drives the real
+`compute.GraphCapturer` state machine (`BeginCapture`/`EndCapture`/
+`ReplayGraph`/`DestroyGraph`) around one `ScaledDotProductAttention.Forward`
+call and replays 511 times -- the issue's exact reproduction scale -- then
+asserts every replay succeeded, the output buffer's device address never
+moved, and the output still matches the CPU reference.
+`TestFlashDecodeScratchReusedAcrossCalls` verifies decode's three scratch
+buffers are reused (stable device address, correct output) across 20 eager
+calls, since decode's capture-compatibility remains out of scope. Both are
+GPU-only (skip without CUDA); the CPU-runnable bailout/fallback wiring is
+unchanged and still covered by `TestTryFlashForwardFallback` and
+`TestSDPAFlashFallbackParity`.
+
+**GB10 evidence:** ref `wave-2-task-T133.2`, `scripts/dgx-validate.sh -pkgs
+"-v -run TestFusedSDPAForwardReplayStableScratch|TestFlashDecodeScratchReusedAcrossCalls|TestTryFlashDecodeEngineStreamParity ./layers/attention/"`,
+pod `<POD_NAME>`: PASS (511/511 replays, no illegal memory access; decode
+scratch reuse verified over 20 calls).
+
 ## 2026-07-02: Fused encoder fwd/bwd audit -- FFN GELU-backward bug + zero gradcheck coverage on FusedSDPA/FFN closed (T135.4)
 
 **Type:** audit + bugfix + coverage

--- a/layers/attention/flash.go
+++ b/layers/attention/flash.go
@@ -31,11 +31,26 @@ import (
 // produced on the engine stream is a cross-stream race -- the kernel can read
 // in-flight Q/K/V (observed as a silently-wrong training trajectory in Wolf's
 // CrossAsset GB10 run, fold-0 acc 0.7042 -> 0.4948 at identical seed).
+//
+// out is the caller-owned persistent output scratch cache (zerfoo#870,
+// docs/lore.md L-0006). The output used to be a fresh tensor.NewGPUStorage
+// (raw cudaMalloc) on every call with no per-call free -- safe in eager
+// execution (Go's GC finalizer eventually reclaims it once unreferenced) but
+// fatal under training.CaptureReplayRunner: the captured graph bakes in the
+// device address written by the ONE call made during capture, and once the
+// wrapping Go object becomes unreferenced the finalizer's Free() hands that
+// exact address back to the allocator for a later, unrelated allocation to
+// reuse -- the same "per-call scratch" landmine as a defer-free, just
+// GC-triggered and later. This crashed Wolf's CrossAsset training under
+// capture-replay around replay #141/511 (zerfoo#870). Reusing the same
+// cached buffer on every call means the address is never freed for the life
+// of the node. Callers pass nil only when they know CUDA is unavailable.
 func tryFlashForward[T tensor.Numeric](
 	q, k, v *tensor.TensorNumeric[T],
 	headDim int,
 	causal bool,
 	engStream unsafe.Pointer,
+	out *gpuScratchBuffer[T],
 ) (*tensor.TensorNumeric[T], error) {
 	if !cuda.Available() {
 		return nil, nil
@@ -97,9 +112,10 @@ func tryFlashForward[T tensor.Numeric](
 	batchHeads := shape[0]
 	seqLen := shape[1]
 
-	// Allocate output on the same GPU device.
+	// Persistent output buffer on the same GPU device (zerfoo#870): reused
+	// across calls instead of a fresh cudaMalloc each time.
 	n := batchHeads * seqLen * headDim
-	oGPU, err := tensor.NewGPUStorage[T](n, qGPU.DeviceID())
+	oGPU, err := out.view(n, qGPU.DeviceID())
 	if err != nil {
 		return nil, err
 	}

--- a/layers/attention/flash_capture_replay_test.go
+++ b/layers/attention/flash_capture_replay_test.go
@@ -1,0 +1,285 @@
+package attention
+
+import (
+	"context"
+	"math"
+	"testing"
+	"unsafe"
+
+	"github.com/zerfoo/zerfoo/internal/cuda"
+	"github.com/zerfoo/ztensor/compute"
+	"github.com/zerfoo/ztensor/numeric"
+	"github.com/zerfoo/ztensor/tensor"
+)
+
+// This file is the ADR-091 fixture for zerfoo#870 (docs/lore.md L-0006).
+//
+// FusedSDPA's flash kernels used to allocate their scratch/output GPU
+// buffers per call: tryFlashDecode's split-KV scratch was freed via a bare
+// defer, and tryFlashForward's output had no per-call free at all (relying
+// on Go's GC finalizer to reclaim it once unreferenced). Either way, a CUDA
+// graph bakes in the literal device address a captured kernel launch reads
+// or writes, so freeing that address between replays -- via defer or via a
+// finalizer that fires whenever GC next runs -- hands it to an unrelated
+// later allocation while the graph keeps replaying kernels against it. Wolf's
+// CrossAsset training crashed with "an illegal memory access was
+// encountered" around replay #141 of 511 under training.CaptureReplayRunner
+// this way.
+//
+// TestFusedSDPAForwardReplayStableScratch drives the same
+// BeginCapture/EndCapture/ReplayGraph state machine CaptureReplayRunner uses
+// (compute.GraphCapturer), scoped to a single SDPA node instead of a whole
+// training step, and replays 511 times -- matching the issue's exact
+// reproduction scale -- to prove the persistent-scratch fix (flash_scratch.go)
+// survives it: every replay must succeed, the output buffer's device address
+// must never move, and the output must still match the CPU reference after
+// the last replay.
+//
+// GPU-only: without CUDA, engine construction fails and the test skips.
+// CUDA-graph capture has no CPU analogue to assert against, so there is no
+// CPU-runnable equivalent for the capture/replay assertions themselves; the
+// CPU-runnable bailout/fallback wiring is already covered by
+// TestTryFlashForwardFallback and TestSDPAFlashFallbackParity in flash_test.go.
+func TestFusedSDPAForwardReplayStableScratch(t *testing.T) {
+	if !cuda.Available() {
+		t.Skip("CUDA not available (no GPU)")
+	}
+
+	engine, err := compute.NewGPUEngine[float32](numeric.Float32Ops{})
+	if err != nil {
+		t.Skipf("NewGPUEngine: %v", err)
+	}
+
+	var engIface compute.Engine[float32] = engine
+	gc, ok := engIface.(compute.GraphCapturer)
+	if !ok {
+		t.Skip("engine does not implement compute.GraphCapturer")
+	}
+
+	const (
+		batchHeads = 2
+		seqLen     = 32 // >= tryFlashForward's short-sequence bailout threshold (32).
+		headDim    = 64
+	)
+	n := batchHeads * seqLen * headDim
+
+	hostQ := make([]float32, n)
+	hostK := make([]float32, n)
+	hostV := make([]float32, n)
+	for i := range hostQ {
+		hostQ[i] = float32(i%7-3) * 0.1
+		hostK[i] = float32(i%5-2) * 0.1
+		hostV[i] = float32(i%11-5) * 0.1
+	}
+	want := naiveSoftmaxAttention(hostQ, hostK, hostV, batchHeads, seqLen, headDim)
+
+	shape := []int{batchHeads, seqLen, headDim}
+	q := newDeviceTensor(t, hostQ, shape)
+	k := newDeviceTensor(t, hostK, shape)
+	v := newDeviceTensor(t, hostV, shape)
+
+	sdpa := NewScaledDotProductAttention[float32](engine, headDim)
+
+	ctx := context.Background()
+
+	// Warmup: an eager (uncaptured) call, exactly like CaptureReplayRunner's
+	// warmup steps, so the persistent scratch buffer is allocated BEFORE
+	// capture begins. ztensor's own capture contract requires this: "All
+	// tensors used during capture must be pre-allocated. Allocations during
+	// capture (cudaMalloc) will fail with error 901" (compute.GraphCapturer
+	// doc, ztensor compute/engine.go).
+	warmOut, err := sdpa.Forward(ctx, q, k, v, nil)
+	if err != nil {
+		t.Fatalf("warmup Forward: %v", err)
+	}
+	if warmOut == nil {
+		t.Fatal("warmup Forward bailed out of the flash path unexpectedly (check seqLen/headDim thresholds)")
+	}
+	warmStore, ok := warmOut.GetStorage().(*tensor.GPUStorage[float32])
+	if !ok {
+		t.Fatalf("warmup output storage is %T, want *GPUStorage[float32]", warmOut.GetStorage())
+	}
+	prePtr := warmStore.Ptr()
+
+	// Capture: record one more forward pass into a CUDA graph. No new
+	// allocation should happen here -- the scratch buffer is already sized
+	// from the warmup call above.
+	if err := gc.BeginCapture(); err != nil {
+		t.Fatalf("BeginCapture: %v", err)
+	}
+	capOut, capErr := sdpa.Forward(ctx, q, k, v, nil)
+	handle, endErr := gc.EndCapture()
+	if capErr != nil {
+		if endErr == nil {
+			_ = gc.DestroyGraph(handle)
+		}
+		t.Fatalf("captured Forward: %v", capErr)
+	}
+	if endErr != nil {
+		t.Fatalf("EndCapture: %v", endErr)
+	}
+	defer func() { _ = gc.DestroyGraph(handle) }()
+
+	capStore, ok := capOut.GetStorage().(*tensor.GPUStorage[float32])
+	if !ok {
+		t.Fatalf("captured output storage is %T, want *GPUStorage[float32]", capOut.GetStorage())
+	}
+	if capStore.Ptr() != prePtr {
+		t.Fatalf("output buffer reallocated between warmup and capture: %p != %p", capStore.Ptr(), prePtr)
+	}
+
+	// Replay 511 times -- the exact scale zerfoo#870 crashed at (~#141/511).
+	// ReplayGraph synchronizes the stream (training/capture_replay.go relies
+	// on this too), so a replay-time illegal memory access surfaces here as
+	// an error, not a later flaky failure.
+	const replays = 511
+	for i := 0; i < replays; i++ {
+		if err := gc.ReplayGraph(handle); err != nil {
+			t.Fatalf("ReplayGraph failed at replay #%d/%d: %v", i+1, replays, err)
+		}
+	}
+
+	if sdpa.flashFwdOut.storage.Ptr() != prePtr {
+		t.Fatalf("persistent scratch buffer moved after %d replays: %p != %p", replays, sdpa.flashFwdOut.storage.Ptr(), prePtr)
+	}
+
+	got, err := capStore.TrySlice()
+	if err != nil {
+		t.Fatalf("TrySlice: %v", err)
+	}
+	const tol = 1e-4
+	mismatches := 0
+	for i := range got {
+		if diff := math.Abs(float64(got[i] - want[i])); diff > tol {
+			if mismatches < 5 {
+				t.Errorf("output[%d] = %f, want %f (diff %e)", i, got[i], want[i], diff)
+			}
+			mismatches++
+		}
+	}
+	if mismatches > 0 {
+		t.Errorf("total mismatches after %d replays: %d / %d", replays, mismatches, len(got))
+	}
+}
+
+// TestFlashDecodeScratchReusedAcrossCalls covers the decode (split-KV) side
+// of the same fix. Decode's Synchronize call on the launch stream (a
+// genuine host-blocking call, needed so eager/inference callers see a
+// completed result) is illegal mid-CUDA-graph-capture, so decode-under-
+// capture is a separate, pre-existing, documented limitation (see
+// flash_decode.go's tryFlashDecode doc comment and the #865->#870->#878
+// cluster in docs/lore.md L-0006) that this fix does not newly introduce or
+// claim to close -- decode is an inference-time (KV-cache) path that
+// training.CaptureReplayRunner's training walk does not exercise. What this
+// test DOES verify on real hardware: repeated EAGER calls (the only mode
+// decode actually runs in) reuse the SAME persistent output/scratch buffers
+// instead of reallocating every call, and correctness holds throughout --
+// i.e. the scratch-lifetime half of the zerfoo#870 fix applies to decode
+// too, independent of the capture-compatibility question.
+func TestFlashDecodeScratchReusedAcrossCalls(t *testing.T) {
+	if !cuda.Available() {
+		t.Skip("CUDA not available (no GPU)")
+	}
+
+	engine, err := compute.NewGPUEngine[float32](numeric.Float32Ops{})
+	if err != nil {
+		t.Skipf("NewGPUEngine: %v", err)
+	}
+
+	const (
+		batch      = 2
+		numQHeads  = 4
+		numKVHeads = 4
+		headDim    = 64
+		kvLen      = 512 // > chunkSize (256): exercises the multi-split combine.
+	)
+	numBH := batch * numQHeads
+	kvDim := numKVHeads * headDim
+
+	hostQ := make([]float32, numBH*headDim)
+	hostK := make([]float32, batch*kvLen*kvDim)
+	hostV := make([]float32, batch*kvLen*kvDim)
+	for i := range hostQ {
+		hostQ[i] = float32(i%7-3) * 0.1
+	}
+	for i := range hostK {
+		hostK[i] = float32(i%5-2) * 0.1
+		hostV[i] = float32(i%11-5) * 0.1
+	}
+	want := naiveDecodeRef(hostQ, hostK, hostV, batch, numQHeads, numKVHeads, kvLen, headDim)
+
+	q := newDeviceTensor(t, hostQ, []int{numBH, 1, headDim})
+	k := newDeviceTensor(t, hostK, []int{batch, kvLen, kvDim})
+	v := newDeviceTensor(t, hostV, []int{batch, kvLen, kvDim})
+
+	sdpa := NewScaledDotProductAttention[float32](engine, headDim, WithHeadCounts[float32](numQHeads, numKVHeads))
+
+	ctx := context.Background()
+
+	var (
+		outPtr, partialOPtr, partialLSEPtr unsafe.Pointer
+	)
+
+	const calls = 20
+	for i := 0; i < calls; i++ {
+		out, err := sdpa.Forward(ctx, q, k, v, nil)
+		if err != nil {
+			t.Fatalf("Forward call #%d: %v", i, err)
+		}
+		if out == nil {
+			t.Fatalf("Forward call #%d bailed out of the flash decode path unexpectedly", i)
+		}
+
+		outStore, ok := out.GetStorage().(*tensor.GPUStorage[float32])
+		if !ok {
+			t.Fatalf("output storage is %T, want *GPUStorage[float32]", out.GetStorage())
+		}
+
+		if i == 0 {
+			outPtr = outStore.Ptr()
+			partialOPtr = sdpa.flashDecPartialO.storage.Ptr()
+			partialLSEPtr = sdpa.flashDecPartialLSE.storage.Ptr()
+		} else {
+			if outStore.Ptr() != outPtr {
+				t.Fatalf("call #%d: output buffer moved: %p != %p", i, outStore.Ptr(), outPtr)
+			}
+			if sdpa.flashDecPartialO.storage.Ptr() != partialOPtr {
+				t.Fatalf("call #%d: partialO scratch moved: %p != %p", i, sdpa.flashDecPartialO.storage.Ptr(), partialOPtr)
+			}
+			if sdpa.flashDecPartialLSE.storage.Ptr() != partialLSEPtr {
+				t.Fatalf("call #%d: partialLSE scratch moved: %p != %p", i, sdpa.flashDecPartialLSE.storage.Ptr(), partialLSEPtr)
+			}
+		}
+
+		got, err := outStore.TrySlice()
+		if err != nil {
+			t.Fatalf("call #%d: TrySlice: %v", i, err)
+		}
+		const tol = 1e-3
+		mismatches := 0
+		for j := range got {
+			if diff := math.Abs(float64(got[j] - want[j])); diff > tol {
+				if mismatches < 5 {
+					t.Errorf("call #%d: output[%d] = %f, want %f (diff %e)", i, j, got[j], want[j], diff)
+				}
+				mismatches++
+			}
+		}
+		if mismatches > 0 {
+			t.Errorf("call #%d: total mismatches: %d / %d", i, mismatches, len(got))
+		}
+	}
+}
+
+func newDeviceTensor(t *testing.T, host []float32, shape []int) *tensor.TensorNumeric[float32] {
+	t.Helper()
+	store, err := tensor.NewGPUStorageFromSlice(host)
+	if err != nil {
+		t.Fatalf("NewGPUStorageFromSlice: %v", err)
+	}
+	tt, err := tensor.NewWithStorage[float32](shape, store)
+	if err != nil {
+		t.Fatalf("NewWithStorage: %v", err)
+	}
+	return tt
+}

--- a/layers/attention/flash_capture_replay_test.go
+++ b/layers/attention/flash_capture_replay_test.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 
 	"github.com/zerfoo/zerfoo/internal/cuda"
+	"github.com/zerfoo/zerfoo/internal/cuda/kernels"
 	"github.com/zerfoo/ztensor/compute"
 	"github.com/zerfoo/ztensor/numeric"
 	"github.com/zerfoo/ztensor/tensor"
@@ -179,6 +180,17 @@ func TestFusedSDPAForwardReplayStableScratch(t *testing.T) {
 func TestFlashDecodeScratchReusedAcrossCalls(t *testing.T) {
 	if !cuda.Available() {
 		t.Skip("CUDA not available (no GPU)")
+	}
+	if !kernels.IsFlashDecodeSplitKVSupported() {
+		// Pre-existing, environment-level: the split-KV kernel symbol is not
+		// loaded from this host's libkernels.so, independent of this fix (the
+		// unmodified T133.1 test, TestTryFlashDecodeEngineStreamParity, bails
+		// out with the same "bailed unexpectedly on a GPU decode shape"
+		// message on unmodified main). Q/K/V here use the flash-decode-only
+		// GQA layout ([batch, kvLen, numKVHeads*headDim]), which the
+		// generic/naive SDPA fallback does not understand, so asserting
+		// against that fallback would fail for an unrelated reason.
+		t.Skip("split-KV flash decode kernel not loaded on this host (pre-existing, unrelated to zerfoo#870)")
 	}
 
 	engine, err := compute.NewGPUEngine[float32](numeric.Float32Ops{})

--- a/layers/attention/flash_decode.go
+++ b/layers/attention/flash_decode.go
@@ -30,11 +30,23 @@ import (
 // same cross-stream race fixed for prefill in #866, tracked for decode in
 // zerfoo#865 (docs/lore.md L-0006). When nil, a temporary stream is used
 // (standalone use with synchronous inputs).
+//
+// out, partialO, and partialLSE are the caller-owned persistent scratch
+// caches (zerfoo#870, docs/lore.md L-0006): the output and split-KV scratch
+// buffers are allocated once (lazily, on first use) and reused across calls
+// instead of being malloc'd and defer-freed per call, which is what made
+// replay under training.CaptureReplayRunner dereference freed memory. Callers
+// pass nil only when they know CUDA is unavailable (the function bails before
+// touching any of them in that case); production callers (SDPA.Forward) pass
+// buffers cached on the owning node so their lifetime spans the whole
+// capture-replay life of the graph.
 func tryFlashDecode[T tensor.Numeric](
 	q, k, v *tensor.TensorNumeric[T],
 	headDim int,
 	numQueryHeads, numKVHeads int,
 	engStream unsafe.Pointer,
+	out, partialO *gpuScratchBuffer[T],
+	partialLSE *gpuScratchBuffer[float32],
 ) (*tensor.TensorNumeric[T], error) {
 	if !cuda.Available() {
 		return nil, nil
@@ -74,31 +86,33 @@ func tryFlashDecode[T tensor.Numeric](
 	numBH := q.Shape()[0] // batch * numQueryHeads
 	kvLen := k.Shape()[1] // KV sequence length
 
-	// Allocate output GPU storage: [batch*numQueryHeads, headDim].
-	oGPU, err := tensor.NewGPUStorage[T](numBH*headDim, qGPU.DeviceID())
+	// Output GPU storage: [batch*numQueryHeads, headDim]. Persistent (cached on
+	// the caller-owned scratch buffer) so its device address survives across
+	// CUDA-graph replays -- see the gpuScratchBuffer doc comment and zerfoo#870.
+	oGPU, err := out.view(numBH*headDim, qGPU.DeviceID())
 	if err != nil {
 		return nil, err
 	}
 
-	// Split-KV scratch buffers.
+	// Split-KV scratch buffers. Also persistent: these were previously
+	// malloc'd and defer-freed per call, which is exactly the "per-call
+	// scratch with defer-frees inside the captured region" landmine
+	// (docs/lore.md L-0006) that crashed replay ~#141/511 under
+	// training.CaptureReplayRunner (zerfoo#870).
 	const chunkSize = 256
 	numSplits := (kvLen + chunkSize - 1) / chunkSize
 
-	partialOGPU, err := tensor.NewGPUStorage[T](numBH*numSplits*headDim, qGPU.DeviceID())
+	partialOGPU, err := partialO.view(numBH*numSplits*headDim, qGPU.DeviceID())
 	if err != nil {
-		oGPU.Free() //nolint:errcheck
 		return nil, err
 	}
-	defer partialOGPU.Free() //nolint:errcheck
 
 	// partialLSE stores 2 floats (max, sum) per (bh, split) pair.
 	// Allocate as float32 regardless of T — the kernel always uses f32 for LSE.
-	partialLSEGPU, err := tensor.NewGPUStorage[float32](2*numBH*numSplits, qGPU.DeviceID())
+	partialLSEGPU, err := partialLSE.view(2*numBH*numSplits, qGPU.DeviceID())
 	if err != nil {
-		oGPU.Free() //nolint:errcheck
 		return nil, err
 	}
-	defer partialLSEGPU.Free() //nolint:errcheck
 
 	// Resolve the stream to launch on. With an engine stream, launch
 	// stream-ordered after the Q/K/V producers (fixes the cross-stream race,
@@ -127,15 +141,17 @@ func tryFlashDecode[T tensor.Numeric](
 		return nil, err
 	}
 
-	// The split-KV scratch (partialO/partialLSE) is per-call and defer-freed on
-	// return; it must not be reclaimed while the kernel is still reading and
-	// writing it. There is no in-tree stream-ordered free, so synchronize the
-	// launch stream before the scratch frees fire. Unlike prefill (#866), decode
-	// keeps this one host sync: it is single-token / latency-bound, the sync
-	// matches the legacy cost, and it also orders the output for the synchronous
-	// caller. Capture-replay decode -- where a mid-graph sync is illegal and the
-	// per-call scratch is itself the hazard -- is out of scope here and tracked
-	// in the #865->#870->#878 cluster (docs/lore.md L-0006).
+	// Synchronize before returning so the output is ready for the synchronous
+	// caller (single-token / latency-bound; matches the legacy cost). The
+	// output and split-KV scratch are now persistent (zerfoo#870) so this sync
+	// is no longer protecting a defer-free race -- but it is still a genuine
+	// host-blocking call on the launch stream, which is illegal mid-capture.
+	// Capture-replay decode therefore remains out of scope (tracked in the
+	// #865->#870->#878 cluster, docs/lore.md L-0006): decode is an
+	// inference-time (KV-cache) path CaptureReplayRunner's training walk does
+	// not exercise, so this is a pre-existing, documented limitation, not a
+	// regression -- callers that DO reach this under capture get a loud
+	// EndCapture error instead of a silent replay corruption.
 	if err := cuda.StreamFromPtr(launchStream).Synchronize(); err != nil {
 		oGPU.Free() //nolint:errcheck
 		return nil, err

--- a/layers/attention/flash_decode_race_test.go
+++ b/layers/attention/flash_decode_race_test.go
@@ -170,7 +170,12 @@ func TestTryFlashDecodeEngineStreamParity(t *testing.T) {
 		t.Fatalf("NewWithStorage V: %v", err)
 	}
 
-	out, err := tryFlashDecode(q, k, v, headDim, numQHeads, numKVHeads, engStream.Ptr())
+	var (
+		outScratch        gpuScratchBuffer[float32]
+		partialOScratch   gpuScratchBuffer[float32]
+		partialLSEScratch gpuScratchBuffer[float32]
+	)
+	out, err := tryFlashDecode(q, k, v, headDim, numQHeads, numKVHeads, engStream.Ptr(), &outScratch, &partialOScratch, &partialLSEScratch)
 	if err != nil {
 		t.Fatalf("tryFlashDecode: %v", err)
 	}

--- a/layers/attention/flash_decode_test.go
+++ b/layers/attention/flash_decode_test.go
@@ -60,7 +60,7 @@ func TestTryFlashDecodeBailouts(t *testing.T) {
 				t.Fatalf("tensor V: %v", err)
 			}
 
-			result, err := tryFlashDecode(q, k, v, tt.headDim, tt.numQueryHeads, tt.numKVHeads, nil)
+			result, err := tryFlashDecode(q, k, v, tt.headDim, tt.numQueryHeads, tt.numKVHeads, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/layers/attention/flash_scratch.go
+++ b/layers/attention/flash_scratch.go
@@ -1,0 +1,74 @@
+package attention
+
+import "github.com/zerfoo/ztensor/tensor"
+
+// gpuScratchBuffer caches a single GPU device allocation across calls so a
+// flash-attention kernel's scratch/output buffer is replay-stable under
+// CUDA-graph capture (docs/lore.md L-0006, zerfoo#870).
+//
+// tryFlashForward and tryFlashDecode bypass the compute.Engine arena and
+// allocate their scratch/output buffers directly via tensor.NewGPUStorage
+// (raw cudaMalloc), because they operate below the engine abstraction on
+// bare device pointers. Doing that per call and releasing it before
+// returning (the previous behavior: a defer'd Free) is safe in eager
+// execution but fatal under training.CaptureReplayRunner: a CUDA graph
+// bakes in the literal device pointer used by the kernel launch it records,
+// so freeing that allocation makes it available for reuse by any later,
+// unrelated cudaMalloc -- and the graph keeps replaying kernels against the
+// stale address. zerfoo#870 crashed with an illegal memory access around
+// replay #141/511 once something else's allocation happened to land on the
+// freed split-KV scratch.
+//
+// The fix: allocate once, lazily, and reuse the SAME buffer on every call
+// instead of freeing it. A gpuScratchBuffer is meant to be a field on a
+// graph node (e.g. ScaledDotProductAttention) so its lifetime matches the
+// node's -- which spans the whole capture-replay life of the graph it
+// belongs to. CaptureReplayRunner's own contract (static shapes across every
+// captured step) guarantees the requested size is unchanged from the eager
+// warmup steps (which is when growth, i.e. a real free+malloc, actually
+// happens) through every subsequent captured/replayed call.
+type gpuScratchBuffer[T tensor.Numeric] struct {
+	storage  *tensor.GPUStorage[T]
+	capacity int
+	deviceID int
+}
+
+// view returns a non-owning GPUStorage view of exactly elems elements backed
+// by the cached allocation, growing (freeing the old allocation and making a
+// new one) first if the cache is empty, undersized, or on a different
+// device. The returned view's Free() is a no-op, so callers on error paths
+// may call Free() on it without releasing the persistent buffer early; the
+// buffer itself is only released via release (or its GC finalizer).
+func (b *gpuScratchBuffer[T]) view(elems, deviceID int) (*tensor.GPUStorage[T], error) {
+	if b.storage == nil || b.capacity < elems || b.deviceID != deviceID {
+		if b.storage != nil {
+			_ = b.storage.Free()
+		}
+
+		s, err := tensor.NewGPUStorage[T](elems, deviceID)
+		if err != nil {
+			b.storage = nil
+			b.capacity = 0
+
+			return nil, err
+		}
+
+		b.storage = s
+		b.capacity = elems
+		b.deviceID = deviceID
+	}
+
+	return b.storage.View(elems), nil
+}
+
+// release frees the cached allocation, if any. Intended for tests and any
+// explicit node-teardown path; ordinary operation relies on the buffer
+// living for the node's lifetime and the GC finalizer on the underlying
+// GPUStorage as the backstop.
+func (b *gpuScratchBuffer[T]) release() {
+	if b.storage != nil {
+		_ = b.storage.Free()
+		b.storage = nil
+		b.capacity = 0
+	}
+}

--- a/layers/attention/flash_test.go
+++ b/layers/attention/flash_test.go
@@ -17,7 +17,7 @@ func TestTryFlashForwardFallback(t *testing.T) {
 	k, _ := tensor.New([]int{2, 4, 8}, make([]float32, 2*4*8))
 	v, _ := tensor.New([]int{2, 4, 8}, make([]float32, 2*4*8))
 
-	result, err := tryFlashForward(q, k, v, 8, false, nil)
+	result, err := tryFlashForward(q, k, v, 8, false, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestTryFlashForwardSeqLenMismatch(t *testing.T) {
 	k, _ := tensor.New([]int{4, 10, headDim}, make([]float32, 4*10*headDim))
 	v, _ := tensor.New([]int{4, 10, headDim}, make([]float32, 4*10*headDim))
 
-	result, err := tryFlashForward(q, k, v, headDim, false, nil)
+	result, err := tryFlashForward(q, k, v, headDim, false, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestTryFlashForwardBatchMismatch(t *testing.T) {
 	k, _ := tensor.New([]int{1, 8, headDim}, make([]float32, 1*8*headDim))
 	v, _ := tensor.New([]int{1, 8, headDim}, make([]float32, 1*8*headDim))
 
-	result, err := tryFlashForward(q, k, v, headDim, false, nil)
+	result, err := tryFlashForward(q, k, v, headDim, false, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestTryFlashForwardMatchingDims(t *testing.T) {
 	k, _ := tensor.New([]int{4, 8, headDim}, make([]float32, 4*8*headDim))
 	v, _ := tensor.New([]int{4, 8, headDim}, make([]float32, 4*8*headDim))
 
-	result, err := tryFlashForward(q, k, v, headDim, false, nil)
+	result, err := tryFlashForward(q, k, v, headDim, false, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/layers/attention/scaled_dot_product_attention.go
+++ b/layers/attention/scaled_dot_product_attention.go
@@ -46,6 +46,24 @@ type ScaledDotProductAttention[T tensor.Numeric] struct {
 	v                *tensor.TensorNumeric[T]
 	attentionWeights *tensor.TensorNumeric[T]
 	saver            graph.Saver[T] // fanned in by the owning attention node; nil outside a Graph
+
+	// Persistent flash-kernel scratch (zerfoo#870, docs/lore.md L-0006).
+	// tryFlashForward and tryFlashDecode allocate GPU buffers directly via
+	// tensor.NewGPUStorage (bypassing the engine arena, since they operate on
+	// bare device pointers below the engine abstraction). A per-call
+	// malloc+free of those buffers is safe in eager execution but corrupts
+	// training under training.CaptureReplayRunner: a CUDA graph bakes in the
+	// literal device address a kernel launch reads/writes, so freeing that
+	// address (via defer or GC finalizer) lets an unrelated later allocation
+	// reuse it while the graph still replays against it -- observed as an
+	// illegal memory access around replay #141/511. Caching the buffers here,
+	// keyed to this SDPA node's lifetime (which spans the whole capture-replay
+	// life of the graph it belongs to), means they are allocated once and
+	// reused for every call instead of being freed per call.
+	flashFwdOut        gpuScratchBuffer[T]
+	flashDecOut        gpuScratchBuffer[T]
+	flashDecPartialO   gpuScratchBuffer[T]
+	flashDecPartialLSE gpuScratchBuffer[float32]
 }
 
 // SetSaver implements graph.SaverAware. Owning nodes (AttentionHead,
@@ -151,8 +169,13 @@ func (sdpa *ScaledDotProductAttention[T]) Forward(ctx context.Context, q, k, v, 
 
 	// Try split-KV flash decode for single-query autoregressive decode.
 	// This path handles the seqLen_Q==1 case that tryFlashForward rejects.
+	// Scratch buffers are cached on sdpa (zerfoo#870) so they are
+	// replay-stable under CUDA-graph capture instead of being freed per call.
 	if mask == nil && sdpa.numQueryHeads > 0 && sdpa.numKVHeads > 0 {
-		if result, err := tryFlashDecode(q, k, v, int(sdpa.headDim), sdpa.numQueryHeads, sdpa.numKVHeads, engStream); result != nil || err != nil {
+		if result, err := tryFlashDecode(
+			q, k, v, int(sdpa.headDim), sdpa.numQueryHeads, sdpa.numKVHeads, engStream,
+			&sdpa.flashDecOut, &sdpa.flashDecPartialO, &sdpa.flashDecPartialLSE,
+		); result != nil || err != nil {
 			return result, err
 		}
 	}
@@ -160,7 +183,7 @@ func (sdpa *ScaledDotProductAttention[T]) Forward(ctx context.Context, q, k, v, 
 	// Try fused flash attention when no arbitrary mask is provided.
 	// Flash attention handles causal masking internally via the causal flag.
 	if mask == nil {
-		if result, err := tryFlashForward(q, k, v, int(sdpa.headDim), sdpa.causal, engStream); result != nil || err != nil {
+		if result, err := tryFlashForward(q, k, v, int(sdpa.headDim), sdpa.causal, engStream, &sdpa.flashFwdOut); result != nil || err != nil {
 			return result, err
 		}
 	}


### PR DESCRIPTION
## Summary

- `tryFlashForward` and `tryFlashDecode` allocated their scratch/output GPU buffers directly via `tensor.NewGPUStorage` (raw cudaMalloc) and released them per call (a bare `defer` for decode's split-KV scratch; a GC finalizer for forward's output). A CUDA graph bakes in the device address a captured kernel reads/writes, so freeing that address between replays corrupts later replays once the address is reused elsewhere -- the L-0006 landmine. This crashed Wolf's CrossAsset training under `training.CaptureReplayRunner` with an illegal memory access around replay #141 of 511 (#870).
- Fix: `gpuScratchBuffer[T]` (`layers/attention/flash_scratch.go`) allocates once, lazily, and returns a reusable, non-owning view on every subsequent call. Instances are cached as fields on `ScaledDotProductAttention[T]`, so their lifetime spans the whole capture-replay life of the graph the SDPA node belongs to.
- `layers/attention/flash_capture_replay_test.go` is the ADR-091 regression fixture: `TestFusedSDPAForwardReplayStableScratch` drives a real `compute.GraphCapturer` capture/replay loop (511 replays, matching the issue's scale) around one SDPA forward pass and verifies every replay succeeds, the output buffer's address never moves, and the result matches the CPU reference. `TestFlashDecodeScratchReusedAcrossCalls` covers decode's scratch reuse across repeated eager calls (decode's own capture-compatibility, blocked on a separate mid-graph sync issue, stays out of scope and is documented as such).

## GB10 evidence

- ref `wave-2-task-T133.2` (ab228351), `scripts/dgx-validate.sh -pkgs "-v -failfast ./layers/attention/..."`, pod `zerfoo-validate-wave2taskT13-1783060338`: `TestFusedSDPAForwardReplayStableScratch` PASS (511/511 replays, no illegal memory access).
- `TestFlashDecodeScratchReusedAcrossCalls` SKIPs on this host: the split-KV flash-decode kernel is not currently loaded from `/opt/zerfoo/lib`. Confirmed via a control run on unmodified `origin/main` (pod `zerfoo-validate-5cbac6769563-1783059932`) that the existing T133.1 test (`TestTryFlashDecodeEngineStreamParity`) fails identically there -- a pre-existing, host-image-level gap unrelated to this change. Left out of scope; worth a follow-up issue to check the DGX's mounted kernel library.

## Test plan

- [x] `gofmt -l`, `go vet ./layers/attention/...`, `go test ./layers/attention/...` locally (CPU, darwin)
- [x] `go build ./...` and `go test ./...` locally (pre-existing unrelated flakes in `inference` and `timeseries` packages, confirmed unrelated to this diff)
- [x] GB10: `TestFusedSDPAForwardReplayStableScratch` -- 511/511 replays, no IMA
- [x] GB10 control run on unmodified main confirms the decode-kernel skip is pre-existing, not a regression

refs #870