### PR TITLE
fix(cuda): oracle-gate kernel sweep -- sgemv_m1 alignment + per-op tolerances (T135.3)

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -73,6 +73,25 @@ the drift is recoverable/diagnosable without re-cloning history.
   the underlying kernel symbol is now present so there is no reason to
   expect it specifically to fail, but it was not directly observed here.
 
+**Watch-item resolved -- the intermittent gather/attention flake is host GPU
+contention, not code:** the sporadic `cudaMemcpy failed: invalid argument`
+failures (gather H2D copies; also the one truncated `layers/attention` FAIL
+above) tracked a concurrent `ltx-render-*` pod on the DGX host exactly: the
+SAME ref (`fd194a98`) was full-package green twice, then red on 6
+consecutive full-package runs while `ltx-render-20260703-0657/0708` were
+active (the failing test varied run to run -- GatherI32/single_index,
+GatherInt64/multiple_indices, GatherInt64/single_index -- classic
+environmental nondeterminism), then green twice consecutively (pods
+`zerfoo-validate-wave2taskT13-1783063105`, `...1783063177`) immediately
+after the render pod completed, with zero code change. Note the render pod
+is NOT gpu-accounted by Spark (`/api/v1/resources` showed
+`gpuMemoryMB allocated: 0` throughout), so `SPARK_GPU_MAX=1` does NOT
+serialize against it -- a gap in the one-GPU-pod-at-a-time invariant when a
+workload requests no `nvidia.com/gpu` limit but still touches the unified
+GPU. Follow-up for Spark scheduling hygiene: either make such workloads
+request the GPU so they serialize, or accept sporadic gate flakes while
+they run.
+
 ## 2026-07-03: Oracle-gate kernel sweep -- sgemv_m1 alignment fix + honest per-op tolerances (T135.3, #847)
 
 **Type:** fix + finding

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,77 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-07-03: T135.3 .so rebuild dropped flash_decode_splitkv_f32 -- ported the missing .cu from ztensor (T133.2 cross-check)
+
+**Type:** regression + fix
+**Tags:** cuda, kernels, gb10, spark, flash-decode, split-kv, fork-drift, T135.3, T133.1, T133.2
+
+**Problem (reported by the parallel T133.2 agent):** immediately after this
+task's first `libkernels.so` rebuild+deploy (see the T135.3 entry below,
+build ref `1082cced`), `TestTryFlashDecodeEngineStreamParity` (T133.1,
+already merged to main) started failing on unmodified `origin/main` through
+the standing gate (control pod `zerfoo-validate-5cbac6769563-1783059932`).
+Since the Go source hadn't changed, this pointed at the freshly-deployed
+`.so` itself.
+
+**Root cause:** `flash_decode_splitkv_purego.go` (added in `fb53c412`, wiring
+`FlashDecodeSplitKV`/`IsFlashDecodeSplitKVSupported` against the
+`flash_decode_splitkv_f32` symbol) was merged with ONLY the Go-side purego
+plumbing -- no `.cu` kernel source and no `Makefile` `SRCS` entry were ever
+added to zerfoo's `internal/cuda/kernels/`. The kernel only ever existed in
+`github.com/zerfoo/ztensor`'s copy of the kernel fork
+(`internal/cuda/kernels/flash_decode.cu`). This was invisible for months
+because the production `.so` at `/opt/zerfoo/lib` predated this task and
+was never rebuilt purely from zerfoo's own Makefile -- whatever process
+originally produced it evidently included the symbol from elsewhere. T135.3's
+from-scratch rebuild (the first time this repo's `internal/cuda/kernels`
+Makefile alone was used to produce the deployed `.so`) surfaced the gap by
+silently dropping the symbol; `IsFlashDecodeSplitKVSupported()` then returns
+false and `tryFlashDecode` bails to `(nil, nil)`, which the parity test does
+not expect.
+
+**Fix:** ported `flash_decode.cu` + `flash_decode.h` verbatim from
+`github.com/zerfoo/ztensor@v1.19.2` (the version zerfoo's `go.mod` currently
+requires; fetched from the local `GOMODCACHE`, byte-identical per `diff`)
+into `internal/cuda/kernels/`, and added `flash_decode.cu` to the Makefile's
+`SRCS` list so it is part of every future rebuild of this repo's kernel
+fork, not a one-off patch to the deployed binary.
+
+**.so provenance (both rebuilds, for next time this class of drift needs
+diagnosing):**
+
+| Build | Source ref | sha256 | Pod |
+|---|---|---|---|
+| 1st (missing flash_decode) | `1082cced57c670746b302c8ef0eb35deece41b34` | `d1fcbbc7ae1df8d4c8e9c22ab6bb53f4ca28c32788d6fe95e4009d17ca4b3c49` | `zerfoo-build-libkernels-t1353-1082cced` |
+| 2nd (flash_decode ported) | `bff530313d269852c6207779c2183e505d6f32a6` | `8f7b430acb9ab973ee9d6cb78e25572733794da463a1c55148308abbe96e8add` | `zerfoo-build-libkernels-t1353-bff53031` |
+
+Both prior backups (including the pre-T135.3 production `.so`, whatever
+built it) are retained on the host as
+`/opt/zerfoo/lib/libkernels.so.bak-<timestamp>-<sha>` (plus the older
+`libkernels.so.bak-apr10` / `libkernels.so.bak-pre-v1180-202606182102`), so
+the drift is recoverable/diagnosable without re-cloning history.
+
+**Verification (GB10, ref `bff530313`):**
+- `./internal/cuda/kernels/` -- full package green, pod
+  `zerfoo-validate-wave2taskT13-1783061096`
+  (`{"build":"pass","vet":"pass","cuda_tests":"pass","failures":[]}`).
+- `TestTryFlashDecodeEngineStreamParity` -- PASS in isolation, pod
+  `zerfoo-validate-wave2taskT13-1783061167`.
+- `./layers/attention/...` (full package) -- green on 2 of 3 runs (pods
+  `...1783061323` with `-failfast`, `...1783061242` truncated-tail
+  originally showed a FAIL whose specific test was hidden by Spark's
+  tail-only logs, then 2 immediate re-runs of the full package passed
+  clean). Not chased further: this package is outside the standing gate's
+  default scope, and the one kernel this task's fix touches
+  (`TestTryFlashDecodeEngineStreamParity`) passed cleanly and
+  reproducibly across all 3 runs. Logged as a watch-item for whoever next
+  touches `layers/attention` CI stability.
+- `TestFlashDecodeScratchReusedAcrossCalls` (PR #933, not yet merged at
+  time of writing) could not be exercised -- it does not exist on this
+  branch. T133.2 should re-verify it against this `.so` once #933 merges;
+  the underlying kernel symbol is now present so there is no reason to
+  expect it specifically to fail, but it was not directly observed here.
+
 ## 2026-07-03: Oracle-gate kernel sweep -- sgemv_m1 alignment fix + honest per-op tolerances (T135.3, #847)
 
 **Type:** fix + finding

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,110 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-07-03: Oracle-gate kernel sweep -- sgemv_m1 alignment fix + honest per-op tolerances (T135.3, #847)
+
+**Type:** fix + finding
+**Tags:** cuda, kernels, gb10, spark, sgemv, gemv_q4k, oracle, tolerance, T135.3, #847, #922
+
+**Problem:** T135.1 unmasked two residuals in `./internal/cuda/kernels/` on
+the GB10 that had been hidden behind the #922 CUDA-context poison:
+(1) `sgemv_m1.cu` faulted with a misaligned-address error on
+`TestSgemvM1_MultipleSizes/odd_N_127x255`, re-poisoning the context for
+subsequent subtests; (2) `TestGemvQ4KF32_LargerMatrix/MultipleSizes` and
+`TestSgemvM1_MultipleSizes` failed a flat `1e-4` relative-error bar with
+errors up to ~7.5e-4.
+
+**Fix 1 -- sgemv_m1.cu misalignment:** `sgemv_m1_kernel` cast
+`A + row*N` to `float4*` unconditionally for its vectorized `__ldg` load
+path. When `N` is not a multiple of 4, most rows are not 16-byte aligned, so
+the vectorized load faults -- a hard misaligned-address error, not just
+slow, and it poisons the whole CUDA context for the rest of the process
+(the same class as #922/L-0013, but a kernel bug this time, not a test-guard
+gap). Fixed by gating the float4 path on the row pointer's ACTUAL 16-byte
+alignment (`(uintptr_t)row_ptr & 0xF == 0`) instead of assuming
+`N % 4 == 0`; misaligned rows fall back to the existing scalar remainder
+loop, correct for any `N`.
+
+**Fix 2 (found during the .so rebuild, not one of the two known
+residuals) -- gemv_q4k_sm121.cu build failure:** rebuilding `libkernels.so`
+from scratch with nvcc 13.1 failed with `namespace "cooperative_groups" has
+no member "reduce"/"plus"` -- `cg::reduce`/`cg::plus` live in
+`cooperative_groups/reduce.h`, not pulled in transitively by the
+`cooperative_groups.h` umbrella header on this toolchain. Added the
+explicit include. Without this the kernel fork does not compile at all on a
+from-scratch rebuild, independent of any test outcome -- this would have
+silently blocked every future .so rebuild until someone tried one.
+
+**The .so rebuild path (T135.3's main infrastructure question):** the
+standing gate (`scripts/dgx-validate.sh`) mounts
+`/opt/zerfoo/lib/libkernels.so` READ-ONLY and never recompiles `.cu` in-pod
+(zerfoo#921 territory). Fixing a `.cu` bug requires a separate one-shot
+Spark build pod: `nvcr.io/nvidia/pytorch:26.02-py3` (already used as the
+oracle image; confirmed via a throw-away probe pod to ship nvcc 13.1 with
+`compute_121`/sm_121 support) clones the fix branch, runs
+`make -j8 shared CUDA_ARCH=sm_121` in `internal/cuda/kernels/`, mounts
+`/opt/zerfoo/lib` READ-WRITE (unlike the validation manifest), backs up the
+existing `.so` (`libkernels.so.bak-<timestamp>-<sha>`), and atomically `mv`s
+the new build into place. No `nvidia.com/gpu` claim needed (nvcc
+cross-assembles for sm_121 without touching the device), so it does not
+contend with `SPARK_GPU_MAX=1`. Ran end-to-end with no human step required;
+build+deploy completed in ~15s per attempt. Footgun hit and worked around:
+Spark's YAML parser does not round-trip embedded double-quotes/backslash
+escapes in a pod's inline command (`\"` came through as literal
+backslash-quote text and broke bash parsing) -- keep build-pod commands to
+bare words / single quotes, matching the `validate-arm64.yaml` convention.
+
+**Fix 3 -- honest tolerance, not a looser bar:** the first attempt raised
+the flat relative bound from `1e-4` to `1e-3` to cover the observed
+failures. That surfaced a SECOND, more interesting test bug: the original
+per-element loop called `t.Errorf` + `break` at the first
+tolerance-exceeding index, so the logged "max relative error" only ever
+reflected the error up to that first break point -- never the true
+dataset-wide max. Raising the tolerance changed WHICH element the loop
+broke on, which made the logged max jump around between runs in a way that
+briefly looked like kernel nondeterminism. It was not: the kernel is
+bit-reproducible (verified by re-running the same isolated subtest twice,
+identical result both times). Fixed the test to scan to completion
+(`checkGemvRelError` in `internal/cuda/kernels/tolerance_test.go`), which
+revealed the TRUE worst case: `TestSgemvM1_MultipleSizes/large_4096x4096`
+hits rel err 7.32e-3 at `y[3862]`, but the absolute diff is only ~5e-6
+against `want=6.30e-4` -- catastrophic cancellation on a near-zero
+reduction row inflates relative error while absolute error stays tiny. A
+pure relative bound loose enough to admit that (~1e-2) would also mask a
+real bug on any legitimately small-magnitude output. Switched to a
+numpy-`allclose`-style combined bound instead:
+`|got-want| <= gemvReductionAbsTol + gemvReductionRelTol*|want|`, with
+`gemvReductionAbsTol=1e-5` (covers the ~6e-6 cancellation noise with
+margin) and `gemvReductionRelTol=1e-4` (unchanged from the original tight
+relative bound for normal-magnitude elements). Full rationale and measured
+numbers in `internal/cuda/kernels/tolerance_test.go` and
+`docs/kernel-tolerances.md`.
+
+**Standing per-op tolerance table:** `docs/kernel-tolerances.md` (new) --
+covers the GEMV reduction family in detail, records the other kernel
+families' existing (unchanged) tolerances swept during this pass, and notes
+the coverage gap for kernels with no dedicated numeric-parity test in this
+package (dequant_q4k, gemm_int4/int8/q8, gemv_q5k/q6k, transpose, rmsnorm,
+argmax, scaled_softmax, the fused_* kernels, megakernel_ops) as follow-up,
+not a T135.3 blocker.
+
+**Result (GB10, ref `368d68d1`, pod `zerfoo-validate-wave2taskT13-1783060264`):**
+full `./internal/cuda/kernels/` package green -- build pass, vet pass,
+`{"cuda_tests":"pass","failures":[]}`. Reconfirmed via several isolated
+`-run` subsets during triage (elementwise, flash-attention purego, fp8_ops,
+counter, gather, signature tests) to rule out log truncation hiding a
+failure; all green. One transient `TestGatherI32Parity/single_index`
+failure was observed once in a full-package run and did not reproduce in
+three subsequent runs (isolated and full-package) -- logged here as a
+watch-item, not chased further within T135.3's scope.
+
+**M-P1-1 impact:** this closes the "T135.3" half of the M-P1-1 correction
+recorded in the T135.1 devlog entry (T135.2's ztensor bump was the other
+half, already done). The standing gate's default scope
+(`./internal/cuda/... ./internal/xblas/... ./tabular/...`) should now be
+green end-to-end on `main` once this PR merges, modulo whatever T135.4/T135.5
+still owe.
+
 ## 2026-07-02: FusedSDPA replay-stable flash scratch (T133.2, #870)
 
 **Type:** fix

--- a/docs/kernel-tolerances.md
+++ b/docs/kernel-tolerances.md
@@ -163,3 +163,20 @@ them correctly (observed live during this task: a `\"` inside the command
 string was passed through as literal backslash-quote text and broke bash
 parsing). Prefer bare words / single quotes only, matching the existing
 `validate-arm64.yaml` bootstrap one-liner convention.
+
+**Footgun (found live during this task): a from-scratch rebuild can be a
+downgrade, not a no-op.** The `.so` deployed at `/opt/zerfoo/lib` before
+this task predated any rebuild through zerfoo's own `internal/cuda/kernels`
+Makefile -- it silently carried a kernel (`flash_decode_splitkv_f32`) whose
+`.cu` source was never actually checked into this repo (only ztensor's copy
+of the kernel fork has it; zerfoo's Go-side purego wrapper was merged
+without the corresponding kernel). Rebuilding strictly from `SRCS` in this
+repo's Makefile therefore silently DROPPED that symbol on first rebuild,
+breaking `TestTryFlashDecodeEngineStreamParity` on unmodified `main`. Fixed
+by porting `flash_decode.cu`/`flash_decode.h` from
+`github.com/zerfoo/ztensor` into this repo and adding it to `SRCS` (see the
+2026-07-03 "T135.3 .so rebuild dropped flash_decode_splitkv_f32" devlog
+entry for the full story and .so provenance table). **Before any future
+from-scratch `.so` rebuild, diff `internal/cuda/kernels/purego.go`'s symbol
+table against the Makefile's `SRCS` list** to catch this class of fork
+drift before it reaches the host, rather than after.

--- a/docs/kernel-tolerances.md
+++ b/docs/kernel-tolerances.md
@@ -1,0 +1,165 @@
+# Kernel tolerance table (standing gate)
+
+> **Status:** ACTIVE
+> **Created:** 2026-07-03 (T135.3, `docs/plan-gpu-training-hardening.md` T3.3)
+> **Scope:** `internal/cuda/kernels/` (zerfoo's CUDA kernel fork; the
+> purego-loaded `libkernels.so` production path). This is the same directory
+> the standing gate (`scripts/dgx-validate.sh`, default `TEST_PKGS` includes
+> `./internal/cuda/kernels/...`) exercises on the GB10.
+
+## Why this exists
+
+T3.3 (oracle-gate every remaining kernel; fix divergences) asks for a
+committed, per-op tolerance table as the standing gate, not ad-hoc numbers
+buried in test files. This document is that table. The Go-level parity tests
+in `internal/cuda/kernels/*_test.go` (kernel output vs. a CPU/float64
+reference computed in the same test) are this repo's oracle harness for the
+kernel fork -- distinct from ztensor's PyTorch-oracle harness (ADR-091),
+which gates ztensor's copy of the same kernel family separately. Both must
+stay honest; this table only covers the zerfoo-side fork.
+
+## How to read a tolerance
+
+Two shapes appear below:
+
+- **Relative-only** (`|got-want| / |want| <= rtol`, with an absolute floor
+  used only to avoid division by ~0): the traditional bound, correct for ops
+  whose outputs never pass near zero relative to the compared magnitudes.
+- **Combined absolute+relative** (numpy-`allclose` style,
+  `|got-want| <= atol + rtol*|want|`): required wherever the *reference*
+  value can be small compared to the terms that produced it (reduction /
+  dot-product kernels operating on signed data, where catastrophic
+  cancellation makes relative error explode on a near-zero row even though
+  absolute error stays tiny). Using a purely relative bound loose enough to
+  admit the cancellation case would also mask a real bug on any legitimately
+  small-magnitude output -- so combined bounds are the honest choice, not a
+  relaxation.
+
+## GEMV kernel family (combined tolerance)
+
+`sgemv_m1.cu` (custom M=1 decode GEMV) and `gemv_q4k.cu` / `gemv_q4k_sm121.cu`
+(Q4_K dequant-GEMV) share the same reduction shape: each warp lane
+sequentially accumulates a strided subset of the row, then a 5-level
+warp-shuffle tree combines the 32 lane partials. This is a **fixed,
+deterministic** order (bit-reproducible across runs on the same input) but a
+**different valid parenthesization** than the naive left-to-right CPU/
+float64 reference the tests compare against, so fp32 rounding legitimately
+differs between the two.
+
+| Constant | Value | File |
+|---|---|---|
+| `gemvReductionAbsTol` | `1e-5` | `internal/cuda/kernels/tolerance_test.go` |
+| `gemvReductionRelTol` | `1e-4` | `internal/cuda/kernels/tolerance_test.go` |
+
+Bound: `|got[i] - want[i]| <= gemvReductionAbsTol + gemvReductionRelTol*|want[i]|`.
+
+Applies to: `TestSgemvM1_Parity`, `TestSgemvM1_MultipleSizes`,
+`TestGemvQ4KF32_Parity`, `TestGemvQ4KF32_LargerMatrix`,
+`TestGemvQ4KF32_MultipleSizes` (all in `sgemv_m1_test.go` /
+`gemv_q4k_test.go`, via the shared `checkGemvRelError` helper).
+
+**Measured on the GB10 (2026-07-03, T135.3, ref `368d68d1`)** -- true
+full-array worst case per test (not the first-failure value; see the
+`checkGemvRelError` doc comment for why a first-failure scan under-reports):
+
+| Test | Size | Max rel err | At |diff| |
+|---|---|---|---|
+| `TestSgemvM1_MultipleSizes/large_4096x4096` | 4096x4096 | 7.32e-3 | ~5e-6 (want=6.30e-4) |
+| `TestSgemvM1_MultipleSizes/gemma3_1b_6144x1536` | 6144x1536 | 3.96e-3 | ~6e-6 (want=-1.521e-3) |
+| `TestSgemvM1_MultipleSizes/gemma3_1b_1536x1536` | 1536x1536 | 2.39e-3 | ~3e-6 (want=1.253e-3) |
+| `TestGemvQ4KF32_MultipleSizes/medium_64x512` | 64x512 | 7.55e-4 | ~6e-7 (want=7.94e-4) |
+| `TestGemvQ4KF32_LargerMatrix` | 512x1024 | 4.38e-4 | -- |
+| `TestSgemvM1_MultipleSizes/medium_128x512` | 128x512 | 2.36e-4 | -- |
+
+Every observed absolute diff stayed at or below ~6e-6, which is what
+`gemvReductionAbsTol=1e-5` is sized against (with margin). At
+normal-magnitude references (`|want| ~ 1`), the combined bound is
+`~1.1e-4`, essentially unchanged from a flat `1e-4` relative test. A real
+kernel bug (wrong index, dropped term, a fast-math-class blowup like the
+tanh overflow in ztensor#125) produces absolute errors many orders of
+magnitude above `1e-5` and stays caught.
+
+## sgemv_m1.cu alignment fix (T135.3)
+
+`sgemv_m1_kernel` cast `A + row*N` to `float4*` unconditionally for its
+vectorized load path. When `N` is not a multiple of 4, most rows are not
+16-byte aligned, and the vectorized `__ldg` float4 load faulted with a
+misaligned-address error that poisoned the whole CUDA context for the rest
+of the process (first observed as
+`TestSgemvM1_MultipleSizes/odd_N_127x255` cascading into the next subtest,
+#847 tail / #922 class). Fixed by gating the float4 path on the row
+pointer's actual 16-byte alignment (`(uintptr_t)row_ptr & 0xF == 0`) instead
+of assuming `N % 4 == 0`; misaligned rows fall back to the existing scalar
+remainder loop, which is correct for any `N`. Verified on the GB10: the
+`odd_N_127x255` and `large_4096x4096` subtests, which previously crashed the
+whole package (poisoned-context cascade), now run and pass under the
+tolerance above.
+
+## Other kernel families in this package (existing tolerances, unchanged by T135.3)
+
+These were swept through the same oracle-style parity tests during T135.3's
+inventory pass; all passed at their existing bars, so no change was needed.
+Listed here for completeness of the standing table.
+
+| Kernel(s) | Test(s) | Tolerance | Shape | Notes |
+|---|---|---|---|---|
+| `elementwise.cu` (add, mul, exp, tanh, sum-axis, softmax, fill, broadcast ops) | `TestKernel*` (`elementwise_test.go`) | `1e-5` / `1e-6` | absolute | Elementwise + reduction ops over small fixed test tensors; no cancellation-prone data. |
+| `gemm_q4.cu` (Q4 dequant-GEMM) | `TestGemmQ4F32_Correctness`, `TestGemmQ4F32_LargerMatrix` (`gemm_q4_test.go`) | `0.15` / `0.2` | absolute | Dominated by Q4 quantization noise (dequant error), not fp32 accumulation order -- a coarse bound is correct here, not a red flag. |
+| `flash_attention.cu` (purego path) | `TestFlashAttentionPurego*` (`flash_attention_purego_test.go`) | `1e-4` | absolute | Softmax + weighted-sum reduction; passes comfortably at the tight bound. |
+| `gather.cu`, `offset_memcpy.cu`, `rope_select.cu` | `TestGather*`, `TestOffsetMemcpy*`, `TestRoPESelect*` | exact match | -- | Pure index/copy operations; no floating-point reduction, so no tolerance needed. |
+| `fp8_ops.cu`, `elementwise_fp16.cu` (signature/symbol checks only) | `TestFP8Ops*`, `TestFP16SignaturesCompile` | n/a | -- | These check the purego wrapper signatures and `libkernels.so` symbol presence, not numerics. |
+
+**Coverage gap (noted, not a T135.3 blocker):** `dequant_q4k.cu`,
+`gemm_int4.cu`, `gemm_int8.cu`, `gemm_q8.cu`, `gemv_q5k.cu`, `gemv_q6k.cu`,
+`transpose.cu`, `rmsnorm.cu`, `argmax.cu`, `scaled_softmax.cu`,
+`fused_add_rmsnorm.cu`, `fused_norm_add.cu`, `fused_qk_norm_rope.cu`,
+`fused_rope.cu`, `fused_swiglu.cu`, and `megakernel_ops.cu` have no
+dedicated numeric-parity test inside `internal/cuda/kernels/`; they are
+presumably exercised indirectly through higher-level Go wrapper tests
+elsewhere (`layers/`, `tests/parity/`). Extending this table to cover them
+directly is follow-up work, not part of T135.3's scope (fix the two named
+residuals + sweep what the standing gate's existing test suite covers).
+
+## Build-blocking bug found and fixed during this sweep
+
+Rebuilding `libkernels.so` for this task (see below) failed independently of
+both known residuals: `gemv_q4k_sm121.cu` uses `cg::reduce` / `cg::plus`
+(Cooperative Groups) but only included the `cooperative_groups.h` umbrella
+header, not `cooperative_groups/reduce.h` where those symbols live on
+nvcc 13.1 (`nvcr.io/nvidia/pytorch:26.02-py3`, sm_121). Fixed by adding the
+explicit include. Without this fix the kernel fork does not compile at all
+on a from-scratch nvcc rebuild, independent of any test outcome.
+
+## .so rebuild path (sanctioned, used for this task)
+
+The standing gate (`scripts/dgx-validate.sh` /
+`docs/bench/manifests/validate-arm64.yaml`) mounts
+`/opt/zerfoo/lib/libkernels.so` **read-only** from the DGX host and never
+recompiles `.cu` in-pod (see zerfoo#921 for why `-tags cuda` in-pod is out of
+scope). Fixing a `.cu` bug therefore requires a **separate one-shot Spark
+build pod**:
+
+1. Push the `.cu` fix to a branch.
+2. Submit a `Pod` manifest using a CUDA **devel** image with `nvcc`
+   (`nvcr.io/nvidia/pytorch:26.02-py3` -- already used as the oracle image,
+   ships nvcc 13.1 with `compute_121`/sm_121 support) that:
+   - clones the branch,
+   - runs `make -j8 shared CUDA_ARCH=sm_121` in `internal/cuda/kernels/`,
+   - mounts `/opt/zerfoo/lib` **read-write** (`readOnly: false`, unlike the
+     validation manifest),
+   - backs up the existing `.so` (`cp libkernels.so
+     libkernels.so.bak-<timestamp>-<sha>`) before an atomic `mv` of the new
+     build into place.
+3. Delete the build pod; run the standing gate as usual (it will now pick up
+   the new `.so` via the same read-only host mount).
+
+No GPU resource claim (`nvidia.com/gpu`) is needed for the build pod --
+`nvcc` cross-assembles for `sm_121` without touching the device, so it does
+not contend with `SPARK_GPU_MAX=1` validation/training pods.
+
+**Footgun:** keep the build pod's inline command free of embedded
+double-quotes / backslash escapes -- Spark's YAML parser does not round-trip
+them correctly (observed live during this task: a `\"` inside the command
+string was passed through as literal backslash-quote text and broke bash
+parsing). Prefer bare words / single quotes only, matching the existing
+`validate-arm64.yaml` bootstrap one-liner convention.

--- a/docs/plan-gpu-training-hardening.md
+++ b/docs/plan-gpu-training-hardening.md
@@ -336,7 +336,7 @@ fp32 fixed-order, every kernel passes the oracle gate, perf delta recorded.
 - [ ] S3.2.1 Tests + lint for reduction changes
        Owner: TBD  Est: 2h  verifies: [UC-GH-005]  kind: agent  blocked-by: [T3.2]
 
-- [ ] T3.3 Oracle-gate every remaining kernel; fix divergences
+- [x] T3.3 Oracle-gate every remaining kernel; fix divergences  2026 07 03  (DONE zerfoo T135.3, PR wave-2-task-T135.3: sgemv_m1.cu float4 misalignment fixed [row-pointer alignment guard, scalar fallback]; gemv_q4k_sm121.cu missing `cooperative_groups/reduce.h` include fixed [build-blocking on nvcc 13.1, found during this sweep]; libkernels.so rebuilt via a one-shot Spark build pod with nvcr.io/nvidia/pytorch:26.02-py3 [nvcc devel image, writable /opt/zerfoo/lib mount] and deployed to the DGX host; TestSgemvM1_MultipleSizes / TestGemvQ4KF32_* switched from a flat 1e-4 relative bound to a combined abs+rel tolerance [gemvReductionAbsTol=1e-5, gemvReductionRelTol=1e-4] to honestly bound fp32 reduction-order + cancellation error instead of masking it with a loose flat relative bound; full ./internal/cuda/kernels/ green on GB10, ref 368d68d1, pod zerfoo-validate-wave2taskT13-1783060264. Standing tolerance table: docs/kernel-tolerances.md.)
        Owner: TBD  Est: 1.5d  verifies: [UC-GH-005]  kind: agent  blocked-by: [T1.3, T3.1]
   - Sweep internal/cuda/kernels (elementwise, argmax, dequant paths used in
     training, fill, scaled softmax) through the oracle; fix any out-of-
@@ -461,7 +461,7 @@ T5.1) serialize on the single GPU -- never fan those out.
 ### Wave 3: Migration + audit (3 agents)
 - [ ] T2.3 Backward-impl audit + migration (both repos)
 - [ ] T3.2 Reduction-accumulation audit
-- [ ] T3.3 Oracle-gate remaining kernels
+- [x] T3.3 Oracle-gate remaining kernels (DONE 2026 07 03, zerfoo T135.3)
 
 ### Wave 4: Hardening tail (3 agents)
 - [ ] T2.4 Wolf-pattern stress test

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -119,7 +119,7 @@ Component: kernels (mostly ztensor) + internal/cuda/kernels. Task-level detail l
 - [x] T135.2 Fixed-order fp32 tree reductions (plan-gpu-training-hardening T3.2)  Owner: agent  Est: 1.5d  verifies: [UC-H2-003]  kind: agent  (done 2026-07-02, ztensor v1.19.2; zerfoo bumped b9613f7b)
   - ztensor-side: audit every reduction (ReduceSum, softmax denominator, norm stats, optimizer clipping norms) for accumulation order/dtype; convert to fixed-order pairwise/tree fp32 accumulation. Oracle diffs must tighten.
 - [x] S135.2.1 Tests + lint (ztensor)  Owner: agent  Est: 2h  verifies: [UC-H2-003]  kind: agent  blocked-by: [T135.2]  (done 2026-07-02, ztensor main CI green through v1.19.2 release)
-- [ ] T135.3 Oracle-gate remaining kernels (T3.3)  Owner: TBD  Est: 1.5d  verifies: [UC-H2-003]  kind: agent  blocked-by: [T135.1]
+- [x] T135.3 Oracle-gate remaining kernels (T3.3)  Owner: agent  Est: 1.5d  verifies: [UC-H2-003]  kind: agent  blocked-by: [T135.1]  (done 2026-07-03, PR wave-2-task-T135.3: sgemv_m1.cu alignment fix, gemv_q4k_sm121.cu build fix, .so rebuilt via Spark build pod, honest per-op tolerance table docs/kernel-tolerances.md, full ./internal/cuda/kernels/ green on GB10)
   - Sweep the kernel inventory through the ztensor oracle harness on GB10; fix out-of-tolerance ops; commit the standing per-op tolerance table.
 - [ ] T135.4 Fused encoder fwd/bwd audit (T3.4)  Owner: TBD  Est: 1d  verifies: [UC-H2-003]  kind: agent  blocked-by: [T135.1]
 - [ ] T135.5 ZTENSOR_DETERMINISTIC mode (T4.1)  Owner: TBD  Est: 1.5d  verifies: [UC-H2-003]  kind: agent  blocked-by: [T135.2]
@@ -183,7 +183,7 @@ GB10 serialization: one GPU pod at a time across ALL tracks (E133 proofs, E135 b
 ### Wave 2: Build-out (5 agents)
 - [ ] S133.1.1, T133.2 (chain)  verifies: [UC-H2-003]
 - [ ] S135.2.1  verifies: [UC-H2-003]
-- [ ] T135.3 oracle-gate kernels  (after T135.1)
+- [x] T135.3 oracle-gate kernels  (after T135.1) -- DONE 2026-07-03
 - [x] T135.4 fused encoder audit  (after T135.1)  2026 07 02  (DONE devlog entry; FFN/SwiGLU + FusedSDPA gradcheck added; FFN GELU-mode Backward bug fixed [always called SwiGLU backward regardless of useGELU]; fused PatchTST encoder backward wiring gap filed on #522 [E55, parked])
 - [ ] T134.1 gemma4e fix attempt  (after T136.2)
 
@@ -253,6 +253,25 @@ Estimated wall-clock: 2-4 weeks; the long poles are GB10 serialization and the h
 ---
 
 ## Progress Log
+
+### 2026 07 03 -- Change Summary: T135.3 oracle-gate kernels done (Wave 2)
+
+- T135.3 done: sgemv_m1.cu float4 vectorized-load misalignment fixed (row
+  pointer alignment guard + scalar fallback, replacing the `N % 4 == 0`
+  assumption that faulted for odd N and poisoned the CUDA context); found
+  and fixed a SEPARATE build-blocking bug in gemv_q4k_sm121.cu (missing
+  `cooperative_groups/reduce.h` include, nvcc 13.1 does not pull it in
+  transitively) while rebuilding libkernels.so; rebuilt + deployed the .so
+  via a one-shot Spark build pod (nvcr.io/nvidia/pytorch:26.02-py3 devel
+  image, writable /opt/zerfoo/lib mount -- the sanctioned rebuild path,
+  documented in docs/kernel-tolerances.md); replaced the flat 1e-4 relative
+  bound in TestSgemvM1_MultipleSizes / TestGemvQ4KF32_* with a combined
+  abs+rel tolerance (gemvReductionAbsTol=1e-5, gemvReductionRelTol=1e-4)
+  honestly sized against measured GB10 worst-case error (catastrophic
+  cancellation on near-zero reduction rows, not nondeterminism). Full
+  `./internal/cuda/kernels/` green on GB10 (ref 368d68d1, pod
+  zerfoo-validate-wave2taskT13-1783060264). Standing tolerance table:
+  docs/kernel-tolerances.md. PR: wave-2-task-T135.3, references #847.
 
 ### 2026 07 02 (late) -- Change Summary: Wave 1 complete (T132.1 -> Wave 2 dispatched)
 

--- a/internal/cuda/kernels/Makefile
+++ b/internal/cuda/kernels/Makefile
@@ -11,7 +11,7 @@ ifeq ($(CUDA_ARCH),sm_121)
 NVCC_FLAGS += -DFLASH_BLOCK_SIZE=64
 endif
 
-SRCS = counter.cu dequant_q4k.cu elementwise.cu elementwise_fp16.cu flash_attention.cu fp8_ops.cu fused_add_rmsnorm.cu fused_norm_add.cu fused_qk_norm_rope.cu fused_rope.cu fused_swiglu.cu gemm_int8.cu gemm_int4.cu gemm_q4.cu gemm_q8.cu gemv_q4k.cu gemv_q4k_sm121.cu gemv_q5k.cu gemv_q6k.cu offset_memcpy.cu rope_select.cu scaled_softmax.cu sgemv_m1.cu transpose.cu gather.cu rmsnorm.cu argmax.cu
+SRCS = counter.cu dequant_q4k.cu elementwise.cu elementwise_fp16.cu flash_attention.cu flash_decode.cu fp8_ops.cu fused_add_rmsnorm.cu fused_norm_add.cu fused_qk_norm_rope.cu fused_rope.cu fused_swiglu.cu gemm_int8.cu gemm_int4.cu gemm_q4.cu gemm_q8.cu gemv_q4k.cu gemv_q4k_sm121.cu gemv_q5k.cu gemv_q6k.cu offset_memcpy.cu rope_select.cu scaled_softmax.cu sgemv_m1.cu transpose.cu gather.cu rmsnorm.cu argmax.cu
 OBJS = $(SRCS:.cu=.o)
 PIC_OBJS = $(SRCS:.cu=.pic.o)
 LIB  = libkernels.a

--- a/internal/cuda/kernels/flash_decode.cu
+++ b/internal/cuda/kernels/flash_decode.cu
@@ -1,0 +1,299 @@
+/* Split-KV flash decode CUDA kernel (float32).
+ *
+ * For autoregressive decode (seqLen_Q = 1), splits the KV cache across
+ * S thread blocks per (batch, head). Each block computes partial attention
+ * over its chunk of the KV sequence using online softmax. A second kernel
+ * reduces the partial results across blocks using log-sum-exp correction.
+ *
+ * Two kernels:
+ * 1. flash_decode_partial_v2_kernel — each block processes one chunk of KV.
+ *    Stores partial output (unnormalized), local max, and local sum per block.
+ * 2. flash_decode_reduce_v2_kernel — merges partial outputs across S blocks
+ *    for each (batch, head) using rescaling by exp(local_max - global_max).
+ *
+ * Grid for partial: [numHeads, S] where S = ceil(seqLen_KV / chunk_size).
+ * Grid for reduce:  [numHeads].
+ */
+
+#include "flash_decode.h"
+#include <float.h>
+#include <math.h>
+
+/* Maximum head dimension (shared-memory based). */
+#define FD_MAX_HEAD_DIM 256
+
+/* Threads per block for partial kernel. */
+#ifndef FD_PARTIAL_WARPS
+#define FD_PARTIAL_WARPS 4
+#endif
+
+#define FD_WARP_SIZE 32
+#define FD_PARTIAL_THREADS (FD_PARTIAL_WARPS * FD_WARP_SIZE)
+
+/* Maximum number of splits for the reduce kernel. */
+#define FD_MAX_SPLITS 128
+
+/* Threads per block for reduce kernel. */
+#define FD_REDUCE_THREADS 128
+
+/* ================================================================
+ * Partial kernel — one block per (head, chunk).
+ *
+ * Each thread block processes KV positions [chunk_id * chunk_size,
+ * min((chunk_id+1) * chunk_size, kv_len)). Multiple warps tile the
+ * chunk with interleaved assignment. Each warp maintains its own
+ * partial softmax state; a cross-warp reduction within the block
+ * produces the block-level partial output and log-sum-exp.
+ *
+ * Shared memory layout:
+ *   sQ[head_dim]                              — scaled query
+ *   warp_max[FD_PARTIAL_WARPS]                — per-warp softmax max
+ *   warp_sum[FD_PARTIAL_WARPS]                — per-warp softmax sum
+ *   warp_acc[FD_PARTIAL_WARPS * head_dim]     — per-warp V accumulator
+ * ================================================================ */
+__global__ void flash_decode_partial_v2_kernel(
+    const float* __restrict__ Q,
+    const float* __restrict__ K,
+    const float* __restrict__ V,
+    float* __restrict__ partial_O,
+    float* __restrict__ partial_max,
+    float* __restrict__ partial_sum,
+    int max_kv_len, int head_dim, int kv_dim,
+    int kv_len_param,
+    const int* __restrict__ kv_len_ptr,
+    int num_q_heads, int num_kv_heads,
+    int chunk_size, int num_splits)
+{
+    int bh = blockIdx.x;
+    int chunk_id = blockIdx.y;
+    int tid = threadIdx.x;
+    int warp_id = tid / FD_WARP_SIZE;
+    int lane_id = tid % FD_WARP_SIZE;
+
+    int kv_len = kv_len_ptr ? *kv_len_ptr : kv_len_param;
+    int partial_idx = bh * num_splits + chunk_id;
+
+    /* Chunk boundaries. */
+    int chunk_start = chunk_id * chunk_size;
+    if (chunk_start >= kv_len) {
+        if (tid == 0) {
+            partial_max[partial_idx] = -FLT_MAX;
+            partial_sum[partial_idx] = 0.0f;
+        }
+        for (int d = tid; d < head_dim; d += FD_PARTIAL_THREADS) {
+            partial_O[partial_idx * head_dim + d] = 0.0f;
+        }
+        return;
+    }
+    int chunk_end = min(chunk_start + chunk_size, kv_len);
+
+    /* GQA head mapping. */
+    int head_ratio = num_q_heads / num_kv_heads;
+    int batch_idx = bh / num_q_heads;
+    int q_head = bh % num_q_heads;
+    int kv_head = q_head / head_ratio;
+
+    const float* Q_bh = Q + bh * head_dim;
+    const float* K_base = K + batch_idx * max_kv_len * kv_dim + kv_head * head_dim;
+    const float* V_base = V + batch_idx * max_kv_len * kv_dim + kv_head * head_dim;
+
+    float scale = rsqrtf((float)head_dim);
+
+    extern __shared__ float smem[];
+    float* sQ = smem;
+    float* warp_max_arr = smem + head_dim;
+    float* warp_sum_arr = warp_max_arr + FD_PARTIAL_WARPS;
+    float* warp_acc = warp_sum_arr + FD_PARTIAL_WARPS;
+
+    /* Load and scale Q. */
+    for (int d = tid; d < head_dim; d += FD_PARTIAL_THREADS) {
+        sQ[d] = Q_bh[d] * scale;
+    }
+    for (int d = tid; d < FD_PARTIAL_WARPS * head_dim; d += FD_PARTIAL_THREADS) {
+        warp_acc[d] = 0.0f;
+    }
+    __syncthreads();
+
+    float local_max = -FLT_MAX;
+    float local_sum = 0.0f;
+    float* my_acc = warp_acc + warp_id * head_dim;
+
+    for (int j = chunk_start + warp_id; j < chunk_end; j += FD_PARTIAL_WARPS) {
+        float partial = 0.0f;
+        for (int d = lane_id; d < head_dim; d += FD_WARP_SIZE) {
+            partial += sQ[d] * K_base[j * kv_dim + d];
+        }
+        for (int offset = FD_WARP_SIZE / 2; offset > 0; offset >>= 1) {
+            partial += __shfl_down_sync(0xFFFFFFFF, partial, offset);
+        }
+        float s = __shfl_sync(0xFFFFFFFF, partial, 0);
+
+        float prev_max = local_max;
+        if (s > local_max) local_max = s;
+        float exp_diff = expf(prev_max - local_max);
+        float exp_s = expf(s - local_max);
+        local_sum = local_sum * exp_diff + exp_s;
+
+        for (int d = lane_id; d < head_dim; d += FD_WARP_SIZE) {
+            my_acc[d] = my_acc[d] * exp_diff + exp_s * V_base[j * kv_dim + d];
+        }
+    }
+
+    if (lane_id == 0) {
+        warp_max_arr[warp_id] = local_max;
+        warp_sum_arr[warp_id] = local_sum;
+    }
+    __syncthreads();
+
+    /* Cross-warp reduction. */
+    float global_max_block = warp_max_arr[0];
+    for (int w = 1; w < FD_PARTIAL_WARPS; w++) {
+        if (warp_max_arr[w] > global_max_block) global_max_block = warp_max_arr[w];
+    }
+
+    float my_warp_max = warp_max_arr[warp_id];
+    float my_warp_sum = warp_sum_arr[warp_id];
+    float rescale = expf(my_warp_max - global_max_block);
+    float scaled_sum = my_warp_sum * rescale;
+
+    for (int d = lane_id; d < head_dim; d += FD_WARP_SIZE) {
+        my_acc[d] *= rescale;
+    }
+    if (lane_id == 0) {
+        warp_sum_arr[warp_id] = scaled_sum;
+    }
+    __syncthreads();
+
+    float block_sum = 0.0f;
+    for (int w = 0; w < FD_PARTIAL_WARPS; w++) {
+        block_sum += warp_sum_arr[w];
+    }
+
+    /* Store unnormalized partial output, local max, and local sum. */
+    for (int d = tid; d < head_dim; d += FD_PARTIAL_THREADS) {
+        float total = 0.0f;
+        for (int w = 0; w < FD_PARTIAL_WARPS; w++) {
+            total += warp_acc[w * head_dim + d];
+        }
+        partial_O[partial_idx * head_dim + d] = total;
+    }
+    if (tid == 0) {
+        partial_max[partial_idx] = global_max_block;
+        partial_sum[partial_idx] = block_sum;
+    }
+}
+
+/* ================================================================
+ * Reduce kernel — merges partial outputs across S splits.
+ *
+ * One block per (batch, head). Each thread handles a stripe of head_dim.
+ * Reads S partial outputs and their max/sum values, then combines
+ * them using the standard rescaling formula:
+ *   O = sum_s(exp(max_s - global_max) * partial_O_s)
+ *     / sum_s(exp(max_s - global_max) * sum_s)
+ * ================================================================ */
+__global__ void flash_decode_reduce_v2_kernel(
+    const float* __restrict__ partial_O,
+    const float* __restrict__ partial_max,
+    const float* __restrict__ partial_sum,
+    float* __restrict__ O,
+    int head_dim, int num_splits)
+{
+    int bh = blockIdx.x;
+    int tid = threadIdx.x;
+
+    /* Find global max across all splits. */
+    float global_max = -FLT_MAX;
+    for (int s = 0; s < num_splits; s++) {
+        float m = partial_max[bh * num_splits + s];
+        if (m > global_max) global_max = m;
+    }
+
+    /* Compute total denominator: sum_s(exp(max_s - global_max) * sum_s). */
+    __shared__ float s_inv_denom;
+    if (tid == 0) {
+        float denom = 0.0f;
+        for (int s = 0; s < num_splits; s++) {
+            int idx = bh * num_splits + s;
+            denom += expf(partial_max[idx] - global_max) * partial_sum[idx];
+        }
+        s_inv_denom = (denom > 0.0f) ? (1.0f / denom) : 0.0f;
+    }
+    __syncthreads();
+
+    float inv_denom = s_inv_denom;
+
+    /* Accumulate rescaled partial outputs and normalize. */
+    for (int d = tid; d < head_dim; d += FD_REDUCE_THREADS) {
+        float acc = 0.0f;
+        for (int s = 0; s < num_splits; s++) {
+            int idx = bh * num_splits + s;
+            float w = expf(partial_max[idx] - global_max);
+            acc += w * partial_O[idx * head_dim + d];
+        }
+        O[bh * head_dim + d] = acc * inv_denom;
+    }
+}
+
+/* ---- C entry point ---- */
+
+extern "C" cudaError_t flash_decode_splitkv_f32(
+    const float* Q, const float* K, const float* V, float* O,
+    float* partial_O, float* partial_lse,
+    int num_bh, int max_kv_len, int head_dim,
+    int kv_len, const int* kv_len_ptr,
+    int num_q_heads, int num_kv_heads,
+    int chunk_size,
+    cudaStream_t stream)
+{
+    if (head_dim > FD_MAX_HEAD_DIM) {
+        return cudaErrorInvalidValue;
+    }
+
+    int num_splits = (kv_len + chunk_size - 1) / chunk_size;
+    if (num_splits < 1) num_splits = 1;
+    if (num_splits > FD_MAX_SPLITS) {
+        return cudaErrorInvalidValue;
+    }
+
+    int kv_dim = num_kv_heads * head_dim;
+
+    /* partial_lse is repurposed as two contiguous arrays:
+     * partial_max: partial_lse[0 .. num_bh*num_splits)
+     * partial_sum: partial_lse[num_bh*num_splits .. 2*num_bh*num_splits) */
+    float* p_max = partial_lse;
+    float* p_sum = partial_lse + num_bh * num_splits;
+
+    /* --- Launch partial kernel --- */
+    {
+        dim3 grid(num_bh, num_splits);
+        dim3 block(FD_PARTIAL_THREADS);
+
+        size_t smem = (head_dim + 2 * FD_PARTIAL_WARPS +
+                       FD_PARTIAL_WARPS * head_dim) * sizeof(float);
+
+        if (smem > 48 * 1024) {
+            cudaFuncSetAttribute(flash_decode_partial_v2_kernel,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                 (int)smem);
+        }
+
+        flash_decode_partial_v2_kernel<<<grid, block, smem, stream>>>(
+            Q, K, V, partial_O, p_max, p_sum,
+            max_kv_len, head_dim, kv_dim,
+            kv_len, kv_len_ptr,
+            num_q_heads, num_kv_heads,
+            chunk_size, num_splits);
+    }
+
+    /* --- Launch reduce kernel --- */
+    {
+        dim3 grid(num_bh);
+        dim3 block(FD_REDUCE_THREADS);
+
+        flash_decode_reduce_v2_kernel<<<grid, block, sizeof(float), stream>>>(
+            partial_O, p_max, p_sum, O, head_dim, num_splits);
+    }
+
+    return cudaGetLastError();
+}

--- a/internal/cuda/kernels/flash_decode.h
+++ b/internal/cuda/kernels/flash_decode.h
@@ -1,0 +1,50 @@
+/* Split-KV flash decode kernel interface (float32).
+ *
+ * Optimized for autoregressive decode (seqLen_Q = 1): splits the KV cache
+ * across S thread blocks per head, each computing partial attention with
+ * online softmax. A second reduction kernel merges partial results using
+ * log-sum-exp correction.
+ *
+ * Grid: [numHeads, S] where S = ceil(seqLen_KV / chunk_size).
+ */
+#ifndef FLASH_DECODE_H
+#define FLASH_DECODE_H
+
+#include <cuda_runtime.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* flash_decode_splitkv_f32 computes single-query attention with split-KV
+ * parallelism for long KV caches.
+ *
+ * Q:             [batch * num_q_heads, head_dim]
+ * K:             [batch, max_kv_len, num_kv_heads * head_dim]
+ * V:             [batch, max_kv_len, num_kv_heads * head_dim]
+ * O:             [batch * num_q_heads, head_dim]
+ * partial_O:     [batch * num_q_heads * S, head_dim] scratch buffer
+ * partial_lse:   [2 * batch * num_q_heads * S] scratch buffer (max + sum)
+ * max_kv_len:    allocated KV dimension
+ * head_dim:      dimension per head
+ * kv_len:        actual KV sequence length (used if kv_len_ptr is null)
+ * kv_len_ptr:    GPU-resident int32; if non-null, read at runtime for CUDA
+ *                graph compatibility
+ * num_q_heads:   query heads per batch element
+ * num_kv_heads:  KV heads per batch element
+ * chunk_size:    number of KV positions per thread block
+ */
+cudaError_t flash_decode_splitkv_f32(
+    const float* Q, const float* K, const float* V, float* O,
+    float* partial_O, float* partial_lse,
+    int num_bh, int max_kv_len, int head_dim,
+    int kv_len, const int* kv_len_ptr,
+    int num_q_heads, int num_kv_heads,
+    int chunk_size,
+    cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FLASH_DECODE_H */

--- a/internal/cuda/kernels/gemv_q4k_sm121.cu
+++ b/internal/cuda/kernels/gemv_q4k_sm121.cu
@@ -34,6 +34,12 @@
 #include "gemv_q4k.h"   /* decode_scales_mins is shared */
 #include <cuda_fp16.h>
 #include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>  /* cg::reduce / cg::plus live here, not
+                                          * in the cooperative_groups.h umbrella
+                                          * header -- CUDA 13.1/nvcc 13.1.115
+                                          * (this rebuild's toolchain) fails
+                                          * "namespace has no member reduce/plus"
+                                          * without it. T135.3 oracle-gate build. */
 #include <stdint.h>
 
 namespace cg = cooperative_groups;

--- a/internal/cuda/kernels/gemv_q4k_test.go
+++ b/internal/cuda/kernels/gemv_q4k_test.go
@@ -253,27 +253,7 @@ func TestGemvQ4KF32_Parity(t *testing.T) {
 		t.Fatalf("Memcpy y: %v", err)
 	}
 
-	maxRelErr := 0.0
-	for i := range got {
-		absRef := math.Abs(float64(ref[i]))
-		diff := math.Abs(float64(got[i] - ref[i]))
-		var relErr float64
-		if absRef > 1e-6 {
-			relErr = diff / absRef
-		} else {
-			relErr = diff
-		}
-		if relErr > maxRelErr {
-			maxRelErr = relErr
-		}
-		if relErr > gemvReductionRelTol {
-			t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
-			if t.Failed() {
-				break
-			}
-		}
-	}
-	t.Logf("max relative error: %e", maxRelErr)
+	checkGemvRelError(t, got, ref, gemvReductionRelTol)
 }
 
 func TestGemvQ4KF32_LargerMatrix(t *testing.T) {
@@ -328,27 +308,7 @@ func TestGemvQ4KF32_LargerMatrix(t *testing.T) {
 		t.Fatalf("Memcpy y: %v", err)
 	}
 
-	maxRelErr := 0.0
-	for i := range got {
-		absRef := math.Abs(float64(ref[i]))
-		diff := math.Abs(float64(got[i] - ref[i]))
-		var relErr float64
-		if absRef > 1e-6 {
-			relErr = diff / absRef
-		} else {
-			relErr = diff
-		}
-		if relErr > maxRelErr {
-			maxRelErr = relErr
-		}
-		if relErr > gemvReductionRelTol {
-			t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
-			if t.Failed() {
-				break
-			}
-		}
-	}
-	t.Logf("max relative error: %e", maxRelErr)
+	checkGemvRelError(t, got, ref, gemvReductionRelTol)
 }
 
 func TestGemvQ4KF32_MultipleSizes(t *testing.T) {
@@ -416,27 +376,7 @@ func TestGemvQ4KF32_MultipleSizes(t *testing.T) {
 				t.Fatalf("Memcpy y: %v", err)
 			}
 
-			maxRelErr := 0.0
-			for i := range got {
-				absRef := math.Abs(float64(ref[i]))
-				diff := math.Abs(float64(got[i] - ref[i]))
-				var relErr float64
-				if absRef > 1e-6 {
-					relErr = diff / absRef
-				} else {
-					relErr = diff
-				}
-				if relErr > maxRelErr {
-					maxRelErr = relErr
-				}
-				if relErr > gemvReductionRelTol {
-					t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
-					if t.Failed() {
-						break
-					}
-				}
-			}
-			t.Logf("max relative error: %e", maxRelErr)
+			checkGemvRelError(t, got, ref, gemvReductionRelTol)
 		})
 	}
 }

--- a/internal/cuda/kernels/gemv_q4k_test.go
+++ b/internal/cuda/kernels/gemv_q4k_test.go
@@ -253,7 +253,7 @@ func TestGemvQ4KF32_Parity(t *testing.T) {
 		t.Fatalf("Memcpy y: %v", err)
 	}
 
-	checkGemvRelError(t, got, ref, gemvReductionRelTol)
+	checkGemvRelError(t, got, ref, gemvReductionAbsTol, gemvReductionRelTol)
 }
 
 func TestGemvQ4KF32_LargerMatrix(t *testing.T) {
@@ -308,7 +308,7 @@ func TestGemvQ4KF32_LargerMatrix(t *testing.T) {
 		t.Fatalf("Memcpy y: %v", err)
 	}
 
-	checkGemvRelError(t, got, ref, gemvReductionRelTol)
+	checkGemvRelError(t, got, ref, gemvReductionAbsTol, gemvReductionRelTol)
 }
 
 func TestGemvQ4KF32_MultipleSizes(t *testing.T) {
@@ -376,7 +376,7 @@ func TestGemvQ4KF32_MultipleSizes(t *testing.T) {
 				t.Fatalf("Memcpy y: %v", err)
 			}
 
-			checkGemvRelError(t, got, ref, gemvReductionRelTol)
+			checkGemvRelError(t, got, ref, gemvReductionAbsTol, gemvReductionRelTol)
 		})
 	}
 }

--- a/internal/cuda/kernels/gemv_q4k_test.go
+++ b/internal/cuda/kernels/gemv_q4k_test.go
@@ -266,7 +266,7 @@ func TestGemvQ4KF32_Parity(t *testing.T) {
 		if relErr > maxRelErr {
 			maxRelErr = relErr
 		}
-		if relErr > 1e-4 {
+		if relErr > gemvReductionRelTol {
 			t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
 			if t.Failed() {
 				break
@@ -341,7 +341,7 @@ func TestGemvQ4KF32_LargerMatrix(t *testing.T) {
 		if relErr > maxRelErr {
 			maxRelErr = relErr
 		}
-		if relErr > 1e-4 {
+		if relErr > gemvReductionRelTol {
 			t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
 			if t.Failed() {
 				break
@@ -429,7 +429,7 @@ func TestGemvQ4KF32_MultipleSizes(t *testing.T) {
 				if relErr > maxRelErr {
 					maxRelErr = relErr
 				}
-				if relErr > 1e-4 {
+				if relErr > gemvReductionRelTol {
 					t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
 					if t.Failed() {
 						break

--- a/internal/cuda/kernels/sgemv_m1.cu
+++ b/internal/cuda/kernels/sgemv_m1.cu
@@ -11,6 +11,7 @@
  */
 
 #include <cuda_runtime.h>
+#include <cstdint>
 
 #define BLOCK_SIZE       256
 #define WARP_SIZE        32
@@ -40,21 +41,35 @@ __global__ void sgemv_m1_kernel(
     const float* row_ptr = A + (size_t)row * N;
     float acc = 0.0f;
 
-    /* Vectorized float4 path for the bulk of the row. */
-    int n4 = N / 4;
-    const float4* row4 = (const float4*)row_ptr;
-    const float4* sx4  = (const float4*)sx;
+    /* Vectorized float4 path for the bulk of the row -- ONLY when row_ptr is
+     * 16-byte aligned. row_ptr = A + row*N; A itself is at least 16-byte
+     * aligned (cudaMalloc), but when N is not a multiple of 4 the per-row
+     * byte offset (row*N*4) is not a multiple of 16 for most rows, so
+     * reinterpreting row_ptr as float4* and __ldg-loading it is a misaligned
+     * vector load -- a hard fault ("misaligned address"), not just slow, and
+     * it poisons the whole CUDA context for the rest of the process (#847
+     * tail, T135.3). Gate the vectorized path on actual pointer alignment
+     * instead of assuming N % 4 == 0; misaligned rows fall back to the
+     * scalar loop below, which is always correct regardless of N or row. */
+    bool row_aligned = ((reinterpret_cast<uintptr_t>(row_ptr) & 0xF) == 0);
 
-    for (int i = lane_id; i < n4; i += WARP_SIZE) {
-        float4 a4 = __ldg(&row4[i]);
-        float4 x4 = sx4[i];
-        acc = __fmaf_rn(a4.x, x4.x, acc);
-        acc = __fmaf_rn(a4.y, x4.y, acc);
-        acc = __fmaf_rn(a4.z, x4.z, acc);
-        acc = __fmaf_rn(a4.w, x4.w, acc);
+    int n4 = row_aligned ? (N / 4) : 0;
+    if (row_aligned) {
+        const float4* row4 = (const float4*)row_ptr;
+        const float4* sx4  = (const float4*)sx;
+
+        for (int i = lane_id; i < n4; i += WARP_SIZE) {
+            float4 a4 = __ldg(&row4[i]);
+            float4 x4 = sx4[i];
+            acc = __fmaf_rn(a4.x, x4.x, acc);
+            acc = __fmaf_rn(a4.y, x4.y, acc);
+            acc = __fmaf_rn(a4.z, x4.z, acc);
+            acc = __fmaf_rn(a4.w, x4.w, acc);
+        }
     }
 
-    /* Handle remainder elements (N not divisible by 4). */
+    /* Scalar remainder: the tail when row_aligned (N not divisible by 4), or
+     * the entire row when !row_aligned. */
     int rem_start = n4 * 4;
     for (int i = rem_start + lane_id; i < N; i += WARP_SIZE) {
         acc = __fmaf_rn(row_ptr[i], sx[i], acc);

--- a/internal/cuda/kernels/sgemv_m1_test.go
+++ b/internal/cuda/kernels/sgemv_m1_test.go
@@ -89,27 +89,7 @@ func TestSgemvM1_Parity(t *testing.T) {
 		t.Fatalf("Memcpy y: %v", err)
 	}
 
-	maxRelErr := 0.0
-	for i := range got {
-		absRef := math.Abs(float64(ref[i]))
-		diff := math.Abs(float64(got[i] - ref[i]))
-		var relErr float64
-		if absRef > 1e-6 {
-			relErr = diff / absRef
-		} else {
-			relErr = diff
-		}
-		if relErr > maxRelErr {
-			maxRelErr = relErr
-		}
-		if relErr > gemvReductionRelTol {
-			t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
-			if t.Failed() {
-				break
-			}
-		}
-	}
-	t.Logf("max relative error: %e", maxRelErr)
+	checkGemvRelError(t, got, ref, gemvReductionRelTol)
 }
 
 func TestSgemvM1_MultipleSizes(t *testing.T) {
@@ -178,27 +158,7 @@ func TestSgemvM1_MultipleSizes(t *testing.T) {
 				t.Fatalf("Memcpy y: %v", err)
 			}
 
-			maxRelErr := 0.0
-			for i := range got {
-				absRef := math.Abs(float64(ref[i]))
-				diff := math.Abs(float64(got[i] - ref[i]))
-				var relErr float64
-				if absRef > 1e-6 {
-					relErr = diff / absRef
-				} else {
-					relErr = diff
-				}
-				if relErr > maxRelErr {
-					maxRelErr = relErr
-				}
-				if relErr > gemvReductionRelTol {
-					t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
-					if t.Failed() {
-						break
-					}
-				}
-			}
-			t.Logf("max relative error: %e", maxRelErr)
+			checkGemvRelError(t, got, ref, gemvReductionRelTol)
 		})
 	}
 }

--- a/internal/cuda/kernels/sgemv_m1_test.go
+++ b/internal/cuda/kernels/sgemv_m1_test.go
@@ -102,7 +102,7 @@ func TestSgemvM1_Parity(t *testing.T) {
 		if relErr > maxRelErr {
 			maxRelErr = relErr
 		}
-		if relErr > 1e-4 {
+		if relErr > gemvReductionRelTol {
 			t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
 			if t.Failed() {
 				break
@@ -191,7 +191,7 @@ func TestSgemvM1_MultipleSizes(t *testing.T) {
 				if relErr > maxRelErr {
 					maxRelErr = relErr
 				}
-				if relErr > 1e-4 {
+				if relErr > gemvReductionRelTol {
 					t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
 					if t.Failed() {
 						break

--- a/internal/cuda/kernels/sgemv_m1_test.go
+++ b/internal/cuda/kernels/sgemv_m1_test.go
@@ -89,7 +89,7 @@ func TestSgemvM1_Parity(t *testing.T) {
 		t.Fatalf("Memcpy y: %v", err)
 	}
 
-	checkGemvRelError(t, got, ref, gemvReductionRelTol)
+	checkGemvRelError(t, got, ref, gemvReductionAbsTol, gemvReductionRelTol)
 }
 
 func TestSgemvM1_MultipleSizes(t *testing.T) {
@@ -158,7 +158,7 @@ func TestSgemvM1_MultipleSizes(t *testing.T) {
 				t.Fatalf("Memcpy y: %v", err)
 			}
 
-			checkGemvRelError(t, got, ref, gemvReductionRelTol)
+			checkGemvRelError(t, got, ref, gemvReductionAbsTol, gemvReductionRelTol)
 		})
 	}
 }

--- a/internal/cuda/kernels/tolerance_test.go
+++ b/internal/cuda/kernels/tolerance_test.go
@@ -1,0 +1,26 @@
+package kernels
+
+// gemvReductionRelTol is the standing relative-error gate for the GEMV
+// kernel family's fp32 accumulation (sgemv_m1.cu, gemv_q4k.cu /
+// gemv_q4k_sm121.cu). See docs/kernel-tolerances.md for the full per-op
+// tolerance table and the T135.3 oracle-gate sweep it belongs to
+// (docs/plan-gpu-training-hardening.md T3.3).
+//
+// Both kernels reduce K/N elements with a FIXED, deterministic order (each
+// warp lane sequentially accumulates a strided subset, then a 5-level
+// warp-shuffle tree combines the 32 lane partials) -- this is not
+// nondeterministic accumulation. It is, however, a DIFFERENT valid
+// parenthesization of the sum than the naive left-to-right CPU reference
+// (cpuSgemv / buildQ4KTestData's float64 reference) used by these tests, so
+// fp32 rounding differs between the two orders. The synthetic sin()-based
+// test data also produces occasional near-zero row sums (catastrophic
+// cancellation), which inflates RELATIVE error for those rows even though
+// absolute error stays tiny.
+//
+// Measured on the GB10 (2026-07-03, T135.3, ref 1082cced): max observed
+// relative error 7.55e-4 at K=512 (TestGemvQ4KF32_MultipleSizes/medium_64x512)
+// and 2.36e-4 at N=512 (TestSgemvM1_MultipleSizes/medium_128x512), both well
+// under 1e-3. A real kernel bug (wrong index, dropped term, a fast-math-class
+// blowup like the tanh overflow in ztensor#125) produces errors one to
+// several orders of magnitude larger and stays caught at this bar.
+const gemvReductionRelTol = 1e-3

--- a/internal/cuda/kernels/tolerance_test.go
+++ b/internal/cuda/kernels/tolerance_test.go
@@ -5,46 +5,67 @@ import (
 	"testing"
 )
 
-// gemvReductionRelTol is the standing relative-error gate for the GEMV
-// kernel family's fp32 accumulation (sgemv_m1.cu, gemv_q4k.cu /
-// gemv_q4k_sm121.cu). See docs/kernel-tolerances.md for the full per-op
-// tolerance table and the T135.3 oracle-gate sweep it belongs to
-// (docs/plan-gpu-training-hardening.md T3.3).
+// gemvReductionAbsTol and gemvReductionRelTol are the standing
+// numpy-allclose-style tolerance gate for the GEMV kernel family's fp32
+// accumulation (sgemv_m1.cu, gemv_q4k.cu / gemv_q4k_sm121.cu): an element
+// passes when
+//
+//	|got - want| <= gemvReductionAbsTol + gemvReductionRelTol*|want|
+//
+// See docs/kernel-tolerances.md for the full per-op tolerance table and the
+// T135.3 oracle-gate sweep it belongs to (docs/plan-gpu-training-hardening.md
+// T3.3).
 //
 // Both kernels reduce K/N elements with a FIXED, deterministic order (each
 // warp lane sequentially accumulates a strided subset, then a 5-level
 // warp-shuffle tree combines the 32 lane partials) -- this is not
 // nondeterministic accumulation. It is, however, a DIFFERENT valid
-// parenthesization of the sum than the naive left-to-right CPU reference
-// (cpuSgemv / buildQ4KTestData's float64 reference) used by these tests, so
-// fp32 rounding differs between the two orders. The synthetic sin()-based
-// test data also produces occasional near-zero row sums (catastrophic
-// cancellation), which inflates RELATIVE error for those rows even though
-// absolute error stays tiny.
+// parenthesization of the sum than the naive left-to-right CPU/float64
+// reference (cpuSgemv / buildQ4KTestData's reference) used by these tests, so
+// fp32 rounding legitimately differs between the two orders.
 //
-// Measured on the GB10 (2026-07-03, T135.3, ref 1082cced): max observed
-// relative error 7.55e-4 at K=512 (TestGemvQ4KF32_MultipleSizes/medium_64x512)
-// and 2.36e-4 at N=512 (TestSgemvM1_MultipleSizes/medium_128x512), both well
-// under 1e-3. A real kernel bug (wrong index, dropped term, a fast-math-class
-// blowup like the tanh overflow in ztensor#125) produces errors one to
-// several orders of magnitude larger and stays caught at this bar.
-const gemvReductionRelTol = 1e-3
+// A pure RELATIVE bound is the wrong shape for this failure mode: the
+// synthetic sin()-based test data produces occasional near-zero row sums
+// (catastrophic cancellation), and for those rows the ABSOLUTE error stays a
+// few micro-units while the RELATIVE error explodes because the denominator
+// (the reference value) is itself tiny. Measured on the GB10 (2026-07-03,
+// T135.3, ref 08531b5f), the true (full-array, not first-failure) worst
+// cases were:
+//   - TestSgemvM1_MultipleSizes/large_4096x4096: y[3862] rel err 7.32e-3,
+//     but |diff| = 5e-6 against want=6.30e-4.
+//   - TestSgemvM1_MultipleSizes/gemma3_1b_6144x1536: y[1791] rel err 3.96e-3,
+//     |diff| = 6e-6 against want=-1.521e-3.
+//   - TestGemvQ4KF32_MultipleSizes/medium_64x512: rel err 7.55e-4,
+//     |diff| ~ 6e-7 against want=7.94e-4.
+//
+// In every case |diff| stayed at or below ~6e-6. gemvReductionAbsTol=1e-5
+// covers all of them with margin while gemvReductionRelTol=1e-4 keeps the
+// original tight relative bound for normal-magnitude elements (at |want|~1,
+// the combined bound is ~1.1e-4, essentially unchanged from the original flat
+// 1e-4 test). A real kernel bug (wrong index, dropped term, a
+// fast-math-class blowup like the tanh overflow in ztensor#125) produces
+// absolute errors many orders of magnitude above 1e-5 and stays caught.
+const (
+	gemvReductionAbsTol = 1e-5
+	gemvReductionRelTol = 1e-4
+)
 
-// checkGemvRelError scans the FULL output array against the reference and
-// reports the TRUE maximum relative error, then asserts it once against tol.
+// checkGemvRelError scans the FULL output array against the reference using
+// the combined absolute+relative bound (see gemvReductionAbsTol /
+// gemvReductionRelTol above), reports the true maximum relative error found,
+// and asserts once at the end.
 //
 // The original per-element loop called t.Errorf + `break` at the first
-// offending index, which meant maxRelErr only ever reflected the error at
-// (or before) that first-broken element -- NOT the true dataset-wide max.
-// That under-reporting bug surfaced directly during T135.3: raising the
-// tolerance from 1e-4 to 1e-3 changed which element the loop broke on
-// (a smaller-index, smaller-error element no longer tripped the earlier,
-// tighter bar), which made the logged "max relative error" jump around
-// between runs and looked like kernel nondeterminism. It was not -- the
-// kernel is bit-reproducible; only the test's early-exit reporting was
-// unstable. Scan to completion so the reported max is honest regardless of
-// where the tolerance line sits.
-func checkGemvRelError(t *testing.T, got, ref []float32, tol float64) {
+// offending index, which meant the logged "max relative error" only ever
+// reflected the error at (or before) that first-broken element -- NOT the
+// true dataset-wide max. That under-reporting bug surfaced directly during
+// T135.3 tolerance tuning: changing the bound changed WHICH element the loop
+// broke on, so the logged max jumped between runs in a way that looked like
+// kernel nondeterminism but was actually just the test giving up early at a
+// different point each time (the kernel itself is bit-reproducible). Scan to
+// completion so the reported max is honest regardless of where the
+// tolerance line sits.
+func checkGemvRelError(t *testing.T, got, ref []float32, absTol, relTol float64) {
 	t.Helper()
 
 	maxRelErr := 0.0
@@ -54,6 +75,7 @@ func checkGemvRelError(t *testing.T, got, ref []float32, tol float64) {
 	for i := range got {
 		absRef := math.Abs(float64(ref[i]))
 		diff := math.Abs(float64(got[i] - ref[i]))
+
 		var relErr float64
 		if absRef > 1e-6 {
 			relErr = diff / absRef
@@ -64,15 +86,17 @@ func checkGemvRelError(t *testing.T, got, ref []float32, tol float64) {
 			maxRelErr = relErr
 			maxIdx = i
 		}
-		if relErr > tol {
+
+		if diff > absTol+relTol*absRef {
 			badCount++
 			if badCount <= maxReported {
-				t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
+				t.Errorf("y[%d] = %f, want %f (diff %e > %e + %e*%e)",
+					i, got[i], ref[i], diff, absTol, relTol, absRef)
 			}
 		}
 	}
 	if badCount > maxReported {
-		t.Errorf("... and %d more elements exceeded tol %e", badCount-maxReported, tol)
+		t.Errorf("... and %d more elements exceeded tol", badCount-maxReported)
 	}
 	t.Logf("max relative error: %e (at index %d)", maxRelErr, maxIdx)
 }

--- a/internal/cuda/kernels/tolerance_test.go
+++ b/internal/cuda/kernels/tolerance_test.go
@@ -1,5 +1,10 @@
 package kernels
 
+import (
+	"math"
+	"testing"
+)
+
 // gemvReductionRelTol is the standing relative-error gate for the GEMV
 // kernel family's fp32 accumulation (sgemv_m1.cu, gemv_q4k.cu /
 // gemv_q4k_sm121.cu). See docs/kernel-tolerances.md for the full per-op
@@ -24,3 +29,50 @@ package kernels
 // blowup like the tanh overflow in ztensor#125) produces errors one to
 // several orders of magnitude larger and stays caught at this bar.
 const gemvReductionRelTol = 1e-3
+
+// checkGemvRelError scans the FULL output array against the reference and
+// reports the TRUE maximum relative error, then asserts it once against tol.
+//
+// The original per-element loop called t.Errorf + `break` at the first
+// offending index, which meant maxRelErr only ever reflected the error at
+// (or before) that first-broken element -- NOT the true dataset-wide max.
+// That under-reporting bug surfaced directly during T135.3: raising the
+// tolerance from 1e-4 to 1e-3 changed which element the loop broke on
+// (a smaller-index, smaller-error element no longer tripped the earlier,
+// tighter bar), which made the logged "max relative error" jump around
+// between runs and looked like kernel nondeterminism. It was not -- the
+// kernel is bit-reproducible; only the test's early-exit reporting was
+// unstable. Scan to completion so the reported max is honest regardless of
+// where the tolerance line sits.
+func checkGemvRelError(t *testing.T, got, ref []float32, tol float64) {
+	t.Helper()
+
+	maxRelErr := 0.0
+	maxIdx := -1
+	badCount := 0
+	const maxReported = 5
+	for i := range got {
+		absRef := math.Abs(float64(ref[i]))
+		diff := math.Abs(float64(got[i] - ref[i]))
+		var relErr float64
+		if absRef > 1e-6 {
+			relErr = diff / absRef
+		} else {
+			relErr = diff
+		}
+		if relErr > maxRelErr {
+			maxRelErr = relErr
+			maxIdx = i
+		}
+		if relErr > tol {
+			badCount++
+			if badCount <= maxReported {
+				t.Errorf("y[%d] = %f, want %f (rel err %e)", i, got[i], ref[i], relErr)
+			}
+		}
+	}
+	if badCount > maxReported {
+		t.Errorf("... and %d more elements exceeded tol %e", badCount-maxReported, tol)
+	}
+	t.Logf("max relative error: %e (at index %d)", maxRelErr, maxIdx)
+}


### PR DESCRIPTION
## Summary

- Fix `sgemv_m1.cu`'s float4 vectorized-load misalignment: the kernel cast
  `A + row*N` to `float4*` unconditionally, faulting with a misaligned-address
  error (and poisoning the CUDA context for the rest of the process) for any
  `N` not a multiple of 4. Gate the vectorized path on the row pointer's
  actual 16-byte alignment; misaligned rows fall back to the existing scalar
  loop.
- Fix a separate build-blocking bug found while rebuilding `libkernels.so`:
  `gemv_q4k_sm121.cu` uses `cg::reduce`/`cg::plus` but only includes the
  `cooperative_groups.h` umbrella header, not `cooperative_groups/reduce.h`
  where those symbols live on nvcc 13.1.
- Replace the flat `1e-4` relative-error bound in the GEMV parity tests
  (`TestSgemvM1_MultipleSizes`, `TestGemvQ4KF32_*`) with an honest,
  numpy-`allclose`-style combined abs+rel bound
  (`gemvReductionAbsTol=1e-5`, `gemvReductionRelTol=1e-4`), sized against
  measured GB10 worst-case error. Also fixed a test bug where the original
  loop broke on the first tolerance-exceeding element, under-reporting the
  true max relative error.
- Rebuild + deploy `libkernels.so` to the DGX host (`/opt/zerfoo/lib`) via a
  one-shot Spark build pod (CUDA devel image with nvcc, writable host mount)
  -- the sanctioned rebuild path for the standing gate's read-only `.so`
  mount. No human step was required.
- Commit the standing per-op kernel tolerance table: `docs/kernel-tolerances.md`.

## Test plan

- [x] `go build ./...` and `go vet ./internal/cuda/...` clean locally
- [x] `libkernels.so` rebuilt via Spark build pod (`nvcr.io/nvidia/pytorch:26.02-py3`,
      nvcc 13.1, sm_121) and deployed to `/opt/zerfoo/lib` on the GB10, with the
      previous `.so` backed up
- [x] `scripts/dgx-validate.sh -ref wave-2-task-T135.3 -pkgs "-v ./internal/cuda/kernels/"`
      green on GB10 -- ref `368d68d1`, pod `zerfoo-validate-wave2taskT13-1783060264`,
      `{"build":"pass","vet":"pass","cuda_tests":"pass","failures":[]}`
- [x] Previously-crashing `TestSgemvM1_MultipleSizes/odd_N_127x255` now runs
      and passes without poisoning subsequent subtests
- [x] Re-ran the same isolated subtest twice to confirm the kernel is
      bit-reproducible (ruled out a nondeterminism scare that turned out to
      be a test-reporting artifact)

Refs #847.