### PR TITLE
fix(training): allocation-stable captured training state (T133.3)

### DIFF
--- a/docs/bench/manifests/validate-arm64.yaml
+++ b/docs/bench/manifests/validate-arm64.yaml
@@ -66,6 +66,10 @@ spec:
           value: "/usr/local/cuda/lib64:/opt/zerfoo/lib"
         - name: GOFLAGS
           value: "-mod=mod"
+        # EXTRA_ENV_PLACEHOLDER -- scripts/dgx-validate.sh's -env flag expands
+        # additional "- name: K / value: V" pairs here for one-off test runs
+        # (e.g. env-gated fixtures) that need vars beyond CUDA_PKGS/MODELS_DIR.
+        # Left as a no-op comment when -env is not passed.
       resources:
         limits:
           memory: 32Gi

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -2,6 +2,98 @@
 
 Investigation findings, debugging sessions, and benchmark results.
 
+## 2026-07-03: #878 root-caused and fixed -- the cached loss seed was arena-backed; capture-replay training now trajectory-identical to eager (T133.3)
+
+**Type:** fix + finding
+**Tags:** training, capture-replay, cuda-graph, arena, loss-seed, gb10, T133.3, #878, #875, #870, #865, L-0006
+
+**Confirmed root cause (red-proofed on GB10, not hypothesis):** the cached
+d(loss)/d(loss)=1 seed (#875, `training/grad_accum.go`) was built via
+`engine.Fill`, whose GPU path allocates the seed's storage from the engine's
+ARENA pool (`gpuFill` -> `pool.Alloc` + `SetStorage`). The seed is cached on
+the strategy and read by every subsequent step's loss.Backward, but a
+consumer's per-sample/per-epoch `engine.ResetPool` recycles that arena block
+to a later step's intermediates. In eager mode this silently re-scales every
+gradient by whatever value lands in the recycled block (AdamW's approximate
+scale invariance can hide it -- training still "converges", on wrong
+gradients). Under CUDA-graph capture-replay it is structural: the captured
+graph bakes the seed's device address, the SAME address is later assigned to
+an in-graph per-step intermediate, and every replay computes gradients from
+the aliased value -- correct counters (captures=1, replays=N-warmup),
+silently drifting loss: the exact #878 signature. Every OTHER piece of
+cross-step training state was already allocation-stable (persistent gradient
+accumulators are nil-pool `NewGPUStorageFromSlice`; ztensor's fused-AdamW
+moments are raw `runtime.Malloc`; uploaded weights are bulk buffers) -- the
+seed was the one arena-backed hole.
+
+**Fix (contract level):** `buildOnesSeed` now writes the ones host-side and
+re-homes them into a raw nil-pool `GPUStorage` (`NewGPUStorageFromSlice`) on
+the loss tensor's device -- the same allocation-stability guarantee as
+`newPersistentGradTensor`. The one-time H2D upload happens on the first
+`ComputeGradients` call (an eager warmup step, outside any capture region),
+preserving #875's no-host-copy-under-capture property. CPU/engine-less paths
+are byte-identical to before. No consumer special-casing; the rule is the one
+L-0006 already states: everything a captured graph touches -- and everything
+a strategy caches across steps -- must be allocation-stable.
+
+**Fixture hardening (the old fixture could not see the bug):** three
+pre-existing gaps in `tests/training/capture_replay_divergence_878_test.go`
+(T129.1) were closed on the way to the red proof:
+1. Its ReLU went through `BaseActivation` -> `engine.UnaryOp`, which
+   GPUEngine delegates to the CPU engine -- host math mid-graph, capture-
+   illegal ("operation would make the legacy stream depend on a capturing
+   blocking stream" live on GB10). Swapped for Sigmoid (engine-primitive
+   composition: Exp/AddScalar/Div), making the walk device-pure.
+2. It never called `engine.ResetPool`, so it could not trigger arena reuse at
+   all -- with no resets, capture-on vs eager is bit-identical on GB10.
+   Added the consumer-realistic per-step reset (legal under a live captured
+   graph since ztensor#167's arena reset floor).
+3. Its ascend/3x assertion was too coarse: with the bug present, eager and
+   capture both still converge at fixture scale, just along silently
+   different trajectories. Since all trajectories run identical
+   deterministic math on identical data, the fixture now asserts per-step
+   loss-trajectory EQUALITY (tol 1e-4) of eager+reset and capture+reset
+   against a no-reset baseline, keeping the coarse assertion for its
+   diagnostic message.
+
+**GB10 evidence (branch `wave-3-task-T133.3`, via `scripts/dgx-validate.sh`
+with the new `-env` flag plumbing the fixture's env gates):**
+- RED (fixture sharpened, fix absent; commit 2eadff69, pod
+  `zerfoo-validate-wave3taskT13-1783115552`): baseline 1.1656->0.8951,
+  capture-on diverged, max per-step |diff| 0.024751 at step 6, counters
+  correct -- silent wrong gradients reproduced.
+- GREEN (fix applied; commit 22691515, pod
+  `zerfoo-validate-wave3taskT13-1783116105`): baseline, eager+reset, and
+  capture+reset all bit-identical (1.1656->0.8951, captures=1 replays=37).
+- Regression sweeps, all green: standing-gate default scope
+  (`internal/cuda`, `internal/cuda/kernels`, `internal/xblas`, `tabular`; pod
+  `...1783116265`), full `./layers/attention/...` with `-failfast` (pod
+  `...1783116385`), and the full CPU suite locally.
+
+**Blocking regression found and fixed on the way (fork drift, same class as
+the T135.3 flash_decode port):** the T135.3 from-scratch `.so` rebuild was
+the first ever produced from zerfoo's own kernel-fork Makefile, and it
+silently dropped FIVE symbols ztensor v1.19.2's loader treats as REQUIRED
+(`launch_transpose_2d_bf16`, `launch_transpose_nd_bf16`, `dropout_f32`,
+`fused_adamw_f32`, `tiny_batched_gemm_f32`). One missing required symbol
+fails ztensor's dlsym loop wholesale, so EVERY `compute.GPUEngine` op
+reported "kernels not available" -- the deployed `.so` broke all
+ztensor-engine consumers (tabular, the training fixtures) while zerfoo's own
+fork-loader tests stayed green, which is why T135.3's verification missed
+it. Ported the four kernel sources verbatim from ztensor@v1.19.2 into
+`internal/cuda/kernels/` (+Makefile SRCS; the SRCS set now satisfies the
+required-symbol lists of BOTH loaders, verified by script), rebuilt and
+deployed per the T135.3 build-pod protocol: pod
+`zerfoo-build-libkernels-t1333-f4fb4505`, source ref `f4fb4505`, sha256
+`f77a1edca7da8e3d02fdaf7d280b3e027b53665c775b3231b1f48f2bdd0a1989`, prior
+`.so` kept as `/opt/zerfoo/lib/libkernels.so.bak-20260703213619-pre-t1333`.
+Follow-up worth automating: a fork-parity check (ztensor required-syms vs
+zerfoo SRCS) so the next drift is caught at build time, not on the host.
+
+**Deliberately NOT done here:** the T129.2 loud-fail gate
+(`ErrCaptureTrainingDisabled`) stays in place and #878 stays open -- removal
+is T133.4 after coordinator review. Wolf-scale re-validation of capture-on
+training is the consumer's re-bench, tracked on the issue.
 ## 2026-07-03: ZTENSOR_DETERMINISTIC mode -- GB10 bitwise double-run proof (T135.5 / T4.1)
 
 **Type:** feature + GB10 proof

--- a/internal/cuda/kernels/Makefile
+++ b/internal/cuda/kernels/Makefile
@@ -11,7 +11,7 @@ ifeq ($(CUDA_ARCH),sm_121)
 NVCC_FLAGS += -DFLASH_BLOCK_SIZE=64
 endif
 
-SRCS = counter.cu dequant_q4k.cu elementwise.cu elementwise_fp16.cu flash_attention.cu flash_decode.cu fp8_ops.cu fused_add_rmsnorm.cu fused_norm_add.cu fused_qk_norm_rope.cu fused_rope.cu fused_swiglu.cu gemm_int8.cu gemm_int4.cu gemm_q4.cu gemm_q8.cu gemv_q4k.cu gemv_q4k_sm121.cu gemv_q5k.cu gemv_q6k.cu offset_memcpy.cu rope_select.cu scaled_softmax.cu sgemv_m1.cu transpose.cu gather.cu rmsnorm.cu argmax.cu
+SRCS = counter.cu dequant_q4k.cu dropout.cu elementwise.cu elementwise_fp16.cu flash_attention.cu flash_decode.cu fp8_ops.cu fused_adamw.cu fused_add_rmsnorm.cu fused_norm_add.cu fused_qk_norm_rope.cu fused_rope.cu fused_swiglu.cu gemm_int8.cu gemm_int4.cu gemm_q4.cu gemm_q8.cu gemv_q4k.cu gemv_q4k_sm121.cu gemv_q5k.cu gemv_q6k.cu offset_memcpy.cu rope_select.cu scaled_softmax.cu sgemv_m1.cu tiny_batched_gemm.cu transpose.cu gather.cu rmsnorm.cu argmax.cu
 OBJS = $(SRCS:.cu=.o)
 PIC_OBJS = $(SRCS:.cu=.pic.o)
 LIB  = libkernels.a

--- a/internal/cuda/kernels/dropout.cu
+++ b/internal/cuda/kernels/dropout.cu
@@ -1,0 +1,111 @@
+// dropout.cu -- GB10 (sm_121) inverted-dropout with a deterministic Philox mask.
+//
+// The mask is drawn from a counter-based Philox4x32-10 generator keyed by
+// (seed, element offset), bit-identical to the CPU reference in
+// compute/philox.go. Because the draw is a pure function of (seed, offset, p),
+// the same seed produces the same mask on CPU and GPU -- which is what makes
+// ztensor's CPU-GPU parity gate pass -- and backward recomputes the mask from
+// (seed, p) rather than reading a cached buffer (capture-safe, no save pinned
+// across an arena reset; ztensor ADR 006).
+//
+// Inverted-dropout semantics (match torch.nn.functional.dropout): training mode
+// out[i] = keep(i) ? in[i] / (1 - p) : 0 with keep iff uniform >= p; eval mode
+// (training == 0) or p == 0 is exact identity. Forward and backward share one
+// kernel because dropout is linear in its input given the mask, so the host
+// passes the upstream gradient as `in` for the backward call.
+//
+// The Philox constants and round structure mirror compute/philox.go exactly.
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+#include <string.h>
+
+// host_uint_as_float reinterprets a 32-bit pattern as a float on the HOST
+// (the device intrinsic __uint_as_float is not callable from host code).
+static inline float host_uint_as_float(uint32_t bits) {
+    float f;
+    memcpy(&f, &bits, sizeof(f));
+    return f;
+}
+
+#define PHILOX_M0 0xD2511F53u
+#define PHILOX_M1 0xCD9E8D57u
+#define PHILOX_W0 0x9E3779B9u
+#define PHILOX_W1 0xBB67AE85u
+#define PHILOX_ROUNDS 10
+
+// Single Philox round: same word layout as the Go reference.
+__device__ __forceinline__ void philox_round(uint32_t c[4], const uint32_t k[2]) {
+    uint32_t hi0 = __umulhi(PHILOX_M0, c[0]);
+    uint32_t lo0 = PHILOX_M0 * c[0];
+    uint32_t hi1 = __umulhi(PHILOX_M1, c[2]);
+    uint32_t lo1 = PHILOX_M1 * c[2];
+    uint32_t n0 = hi1 ^ c[1] ^ k[0];
+    uint32_t n1 = lo1;
+    uint32_t n2 = hi0 ^ c[3] ^ k[1];
+    uint32_t n3 = lo0;
+    c[0] = n0; c[1] = n1; c[2] = n2; c[3] = n3;
+}
+
+// philox_uniform returns a uniform float in [0,1) for element `offset` under
+// `seed`, consuming only the first output lane (matches the Go reference).
+__device__ __forceinline__ float philox_uniform(uint64_t seed, uint64_t offset) {
+    uint32_t k[2] = { (uint32_t)seed, (uint32_t)(seed >> 32) };
+    uint32_t c[4] = { (uint32_t)offset, (uint32_t)(offset >> 32), 0u, 0u };
+#pragma unroll
+    for (int i = 0; i < PHILOX_ROUNDS; ++i) {
+        philox_round(c, k);
+        k[0] += PHILOX_W0;
+        k[1] += PHILOX_W1;
+    }
+    // Map a 32-bit word to [0,1) by dividing by 2^32; same keep/drop boundary
+    // (uniform >= p) the Go reference uses.
+    return (float)c[0] * (1.0f / 4294967296.0f);
+}
+
+__global__ void kernel_dropout(const float* __restrict__ in,
+                               float* __restrict__ out,
+                               int n, float p, uint64_t seed, float invKeep) {
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n) return;
+    float u = philox_uniform(seed, (uint64_t)gid);
+    out[gid] = (u >= p) ? (in[gid] * invKeep) : 0.0f;
+}
+
+__global__ void kernel_identity_copy(const float* __restrict__ in,
+                                     float* __restrict__ out, int n) {
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= n) return;
+    out[gid] = in[gid];
+}
+
+extern "C" {
+
+// dropout_f32 applies inverted dropout to in[0..n-1], writing out[0..n-1].
+// training != 0 and p > 0 => masked-and-scaled; otherwise exact identity copy.
+//
+// p and invKeep (= 1/(1-p)) are passed as their 32-bit IEEE-754 BIT PATTERNS in
+// integer parameters, not as `float`. The purego/dlopen launch path (no CGO)
+// loads every argument into integer registers only (the AAPCS64 trampoline
+// never populates the V float registers), so a `float` parameter would read
+// garbage and shift every following argument. Passing the bits as uint32 and
+// reinterpreting here with __uint_as_float keeps the ABI integer-only and
+// identical between the CGO and purego paths. invKeep is computed host-side so
+// the scale matches the CPU path bit-for-bit.
+cudaError_t dropout_f32(const float* in, float* out, int n,
+                        uint32_t pBits, uint64_t seed, int training, uint32_t invKeepBits,
+                        cudaStream_t stream) {
+    const int BLOCK = 256;
+    int grid = (n + BLOCK - 1) / BLOCK;
+    if (grid < 1) grid = 1;
+    float p = host_uint_as_float(pBits);
+    float invKeep = host_uint_as_float(invKeepBits);
+    if (training == 0 || p == 0.0f) {
+        kernel_identity_copy<<<grid, BLOCK, 0, stream>>>(in, out, n);
+        return cudaGetLastError();
+    }
+    kernel_dropout<<<grid, BLOCK, 0, stream>>>(in, out, n, p, seed, invKeep);
+    return cudaGetLastError();
+}
+
+} // extern "C"

--- a/internal/cuda/kernels/fused_adamw.cu
+++ b/internal/cuda/kernels/fused_adamw.cu
@@ -1,0 +1,103 @@
+// fused_adamw.cu -- CUDA kernel for the on-device AdamW mixed-precision update.
+//
+// Performs the full AdamW step IN PLACE on device, so param/grad/m never
+// round-trip to host (ADR 070 end state, ADR 075 lever L1). The second moment
+// (v) is held in float64 to preserve the f32-stability fix from the host
+// stepMixedV path: sqrt(v)+eps never collapses to eps under f32 underflow on
+// near-zero gradients.
+//
+// Layout per parameter (all device-resident, allocated once and persisted):
+//   param: f32[n]  -- updated in place
+//   m:     f32[n]  -- first moment, updated in place
+//   v:     f64[n]  -- second moment (sidecar), updated in place
+//   grad:  f32[n]  -- read, then zeroed in place
+//
+// The arithmetic mirrors stepMixedV exactly: the first moment and the param
+// step round to f32 the same way the host f64 update does, while v and the
+// sqrt(v)+eps denominator stay in f64. Bias-correction is folded into `alpha`
+// and `lrWd` on the host and passed in as scalars, matching the host code so
+// the equivalence gate holds bit-for-bit modulo f32 rounding.
+
+#include <cuda_runtime.h>
+
+__global__ void kernel_fused_adamw(float* __restrict__ param,
+                                   float* __restrict__ m,
+                                   double* __restrict__ v,
+                                   float* __restrict__ grad,
+                                   double beta1, double beta2,
+                                   double oneMinusBeta1, double oneMinusBeta2,
+                                   double eps, double alpha, double lrWd,
+                                   int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+
+    double g = (double)__ldg(&grad[idx]);
+
+    // First moment (rounded to f32, as in the host path: mData[i] = f32(mNew)).
+    double mOld = (double)__ldg(&m[idx]);
+    double mNew = beta1 * mOld + oneMinusBeta1 * g;
+    float mNewF = (float)mNew;
+    m[idx] = mNewF;
+
+    // Second moment in f64 (the precision the GPU f32 path needs for stability).
+    double vNew = beta2 * v[idx] + oneMinusBeta2 * g * g;
+    v[idx] = vNew;
+
+    // Update uses the rounded-to-f32 first moment, matching stepMixedV which
+    // reads mNew (the f64 value before rounding) -- see note below. The host
+    // code uses `mNew` (f64) in the numerator, so we use mNew (f64) here too.
+    double denomI = sqrt(vNew) + eps;
+    double update = alpha * mNew / denomI;
+
+    double pv = (double)__ldg(&param[idx]);
+    pv = pv - update - lrWd * pv;
+    param[idx] = (float)pv;
+
+    // Zero the gradient in place (same buffer, no realloc) -- the host path
+    // zeroes grad after reading it; doing it here keeps grad device-resident.
+    grad[idx] = 0.0f;
+}
+
+// ---------- Launcher function (extern "C" for CGO / purego) ----------
+//
+// ABI NOTE (critical): zerfoo's purego kernel dispatch (internal/cuda
+// ccall / ccall_wrapper) marshals EVERY argument through INTEGER registers
+// (AAPCS64 x0-x7 + stack) -- it never populates the NEON v0-v7 FP registers.
+// A launcher declared with `double`/`float` params would therefore receive
+// garbage in the FP registers and shift the integer args (n, stream) into the
+// wrong slots, launching the kernel with a bogus element count -> SIGSEGV.
+// So the scalars cross the boundary as their raw IEEE-754 BIT PATTERNS in
+// `unsigned long long` (integer) params and are reinterpreted to double here.
+
+static inline double bits_to_double(unsigned long long b) {
+    double d;
+    __builtin_memcpy(&d, &b, sizeof(d));
+    return d;
+}
+
+extern "C" {
+
+cudaError_t fused_adamw_f32(float* param, float* m, double* v, float* grad,
+                            unsigned long long beta1Bits, unsigned long long beta2Bits,
+                            unsigned long long oneMinusBeta1Bits, unsigned long long oneMinusBeta2Bits,
+                            unsigned long long epsBits, unsigned long long alphaBits,
+                            unsigned long long lrWdBits,
+                            int n, cudaStream_t stream) {
+    double beta1 = bits_to_double(beta1Bits);
+    double beta2 = bits_to_double(beta2Bits);
+    double oneMinusBeta1 = bits_to_double(oneMinusBeta1Bits);
+    double oneMinusBeta2 = bits_to_double(oneMinusBeta2Bits);
+    double eps = bits_to_double(epsBits);
+    double alpha = bits_to_double(alphaBits);
+    double lrWd = bits_to_double(lrWdBits);
+
+    int block = 256;
+    int grid = (n + block - 1) / block;
+    kernel_fused_adamw<<<grid, block, 0, stream>>>(
+        param, m, v, grad,
+        beta1, beta2, oneMinusBeta1, oneMinusBeta2,
+        eps, alpha, lrWd, n);
+    return cudaGetLastError();
+}
+
+} // extern "C"

--- a/internal/cuda/kernels/fused_adamw.h
+++ b/internal/cuda/kernels/fused_adamw.h
@@ -1,0 +1,48 @@
+/* Fused on-device AdamW mixed-precision update kernel interface.
+ *
+ * Performs the full AdamW step in place on device (ADR 070 end state, ADR 075
+ * lever L1): param, m, grad are f32 device buffers; v is an f64 device sidecar.
+ * No host<->device round-trip of any optimizer state. The second moment stays
+ * in f64 to preserve f32 training stability (the GPU "CrossAsset cliff" fix).
+ */
+#ifndef FUSED_ADAMW_H
+#define FUSED_ADAMW_H
+
+#include <cuda_runtime.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* fused_adamw_f32 applies one AdamW step in one kernel launch, in place.
+ *
+ * param:         device pointer to f32[n] -- updated in place.
+ * m:             device pointer to f32[n] first moment -- updated in place.
+ * v:             device pointer to f64[n] second moment -- updated in place.
+ * grad:          device pointer to f32[n] gradient -- read then zeroed in place.
+ * The scalar Adam hyperparameters cross as raw IEEE-754 double BIT PATTERNS in
+ * unsigned long long (integer) params -- NOT `double` -- because zerfoo's purego
+ * kernel dispatch marshals every arg through integer registers and never the
+ * NEON FP registers; the launcher reinterprets the bits to double.
+ *
+ * beta1Bits, beta2Bits:                 bits of the Adam decay rates.
+ * oneMinusBeta1Bits, oneMinusBeta2Bits: bits of the precomputed (1-beta) terms.
+ * epsBits:    bits of epsilon (added to sqrt(v)).
+ * alphaBits:  bits of lr * bias-correction (numer/denom), precomputed on host.
+ * lrWdBits:   bits of lr * weightDecay, precomputed on host.
+ * n:          number of elements.
+ * stream:     CUDA stream (pass NULL for default stream).
+ */
+cudaError_t fused_adamw_f32(
+    float* param, float* m, double* v, float* grad,
+    unsigned long long beta1Bits, unsigned long long beta2Bits,
+    unsigned long long oneMinusBeta1Bits, unsigned long long oneMinusBeta2Bits,
+    unsigned long long epsBits, unsigned long long alphaBits,
+    unsigned long long lrWdBits,
+    int n, cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FUSED_ADAMW_H */

--- a/internal/cuda/kernels/tiny_batched_gemm.cu
+++ b/internal/cuda/kernels/tiny_batched_gemm.cu
@@ -1,0 +1,119 @@
+// tiny_batched_gemm.cu -- custom small-matrix strided-batched GEMM for f32.
+//
+// Motivation (ADR 075 lever L3): cuBLAS SgemmStridedBatched routes tiny
+// matrices (e.g. CrossAsset attention's 12x12 Q@K^T and 12x64 weights@V over
+// batch = B*heads = 1024) through a GEMV + split-K reduction fan-out
+// (gemvNSP_kernel + splitKreduce_kernel, the T11.0c fingerprint): 2-3 internal
+// kernels per logical GEMM, none of which tile efficiently for m,n,k <= ~64.
+// This kernel computes one strided-batched GEMM in ONE launch with one CUDA
+// thread-block per batch element, staging the A[m,k] and B[k,n] tiles in shared
+// memory and writing the full C[m,n] tile cooperatively. It is GENERAL: any
+// small batched matmul (m,n,k all small, batch large) benefits.
+//
+// Semantics match SgemmStridedBatched with alpha=1, beta=0, row-major operands:
+//   C_b[i,j] = sum_l A_b[i,l] * B_b[l,j],   A_b = A + b*strideA (elements), etc.
+// Accumulation is in f32, matching cuBLAS Sgemm (the reference path this
+// replaces) so the result is bit-comparable within f32 GEMM tolerance.
+//
+// Dispatch guard (host side, gpu_engine.go): used only when m,n,k are all
+// <= TINY_GEMM_MAX_DIM and batch > 1; otherwise the cuBLAS path stays.
+
+#include <cuda_runtime.h>
+
+// Max supported dimension per side. The shared-memory tiles are sized for this
+// bound: A (m*k) + B (k*n) f32 floats. At 64 that is 64*64*2*4 = 32 KiB, within
+// the 48 KiB default dynamic-smem budget on sm_121 (GB10). The host launcher
+// also enforces this; the kernel guards defensively.
+#define TINY_GEMM_MAX_DIM 64
+
+// kernel_tiny_batched_gemm: one block per batch element. Threads cooperatively
+// load A_b (m x k) and B_b (k x n) into shared memory, then each thread owns a
+// strided subset of the m*n output cells and computes its dot products.
+//
+// blockDim.x threads span the m*n output cells in a grid-stride loop within the
+// block, so the kernel works for any (m,n) <= TINY_GEMM_MAX_DIM regardless of
+// the chosen block size.
+__global__ void kernel_tiny_batched_gemm(const float* __restrict__ A,
+                                         const float* __restrict__ B,
+                                         float* __restrict__ C,
+                                         int m, int n, int k,
+                                         long long strideA,
+                                         long long strideB,
+                                         long long strideC) {
+    int b = blockIdx.x;
+
+    const float* Ab = A + (long long)b * strideA;
+    const float* Bb = B + (long long)b * strideB;
+    float* Cb = C + (long long)b * strideC;
+
+    // Shared tiles for this batch element's A and B.
+    __shared__ float sA[TINY_GEMM_MAX_DIM * TINY_GEMM_MAX_DIM];
+    __shared__ float sB[TINY_GEMM_MAX_DIM * TINY_GEMM_MAX_DIM];
+
+    int tid = threadIdx.x;
+    int nthreads = blockDim.x;
+
+    // Cooperative load of A (m*k) and B (k*n) into shared memory.
+    int aElems = m * k;
+    for (int idx = tid; idx < aElems; idx += nthreads) {
+        sA[idx] = Ab[idx];
+    }
+    int bElems = k * n;
+    for (int idx = tid; idx < bElems; idx += nthreads) {
+        sB[idx] = Bb[idx];
+    }
+    __syncthreads();
+
+    // Each thread computes a strided subset of the m*n output cells.
+    int cElems = m * n;
+    for (int idx = tid; idx < cElems; idx += nthreads) {
+        int i = idx / n;   // row in [0,m)
+        int j = idx % n;   // col in [0,n)
+        float acc = 0.0f;
+        const float* aRow = &sA[i * k];
+        // sB is row-major [k, n]; element (l, j) is sB[l*n + j].
+        #pragma unroll 4
+        for (int l = 0; l < k; ++l) {
+            acc += aRow[l] * sB[l * n + j];
+        }
+        Cb[i * n + j] = acc;
+    }
+}
+
+extern "C" {
+
+// tiny_batched_gemm_f32 launches one strided-batched GEMM. All arguments cross
+// as integers / pointers -- there are NO floating-point scalars, so the purego
+// integer-register ABI (see fused_adamw.cu ABI note) is satisfied trivially.
+// alpha is fixed at 1 and beta at 0 to match the attention MatMul this serves.
+//
+// Returns cudaErrorInvalidValue if any dimension exceeds TINY_GEMM_MAX_DIM so
+// the host can fall back to cuBLAS rather than silently truncating.
+cudaError_t tiny_batched_gemm_f32(const float* A, const float* B, float* C,
+                                  int m, int n, int k,
+                                  long long strideA, long long strideB,
+                                  long long strideC,
+                                  int batch, cudaStream_t stream) {
+    if (m <= 0 || n <= 0 || k <= 0 || batch <= 0) {
+        return cudaErrorInvalidValue;
+    }
+    if (m > TINY_GEMM_MAX_DIM || n > TINY_GEMM_MAX_DIM || k > TINY_GEMM_MAX_DIM) {
+        return cudaErrorInvalidValue;
+    }
+
+    // Block size: cap at 256, but no fewer than the output tile so small tiles
+    // still parallelize. Round up to a warp multiple for occupancy.
+    int cells = m * n;
+    int block = cells < 256 ? cells : 256;
+    block = ((block + 31) / 32) * 32;
+    if (block < 32) block = 32;
+    if (block > 1024) block = 1024;
+
+    dim3 grid(batch);
+    dim3 threads(block);
+    kernel_tiny_batched_gemm<<<grid, threads, 0, stream>>>(
+        A, B, C, m, n, k, strideA, strideB, strideC);
+    return cudaGetLastError();
+}
+
+} // extern "C"

--- a/internal/cuda/kernels/tiny_batched_gemm.h
+++ b/internal/cuda/kernels/tiny_batched_gemm.h
@@ -1,0 +1,41 @@
+/* Tiny-matrix strided-batched GEMM interface (ADR 075 lever L3).
+ *
+ * Computes batch independent small f32 GEMMs C_b = A_b * B_b (alpha=1, beta=0,
+ * row-major) in a single launch, one CUDA thread-block per batch element, with
+ * the A/B tiles staged in shared memory. Replaces cuBLAS SgemmStridedBatched on
+ * the tiny attention shapes (12x12, 12x64 over batch=1024) where cuBLAS falls
+ * back to a GEMV + split-K reduction fan-out.
+ *
+ * All arguments are integers / pointers -- no floating-point scalars -- so the
+ * purego integer-register dispatch ABI (see fused_adamw.h) is satisfied.
+ */
+#ifndef TINY_BATCHED_GEMM_H
+#define TINY_BATCHED_GEMM_H
+
+#include <cuda_runtime.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* tiny_batched_gemm_f32 computes, for each b in [0, batch):
+ *     C_b[i,j] = sum_l A_b[i,l] * B_b[l,j]
+ * where A_b = A + b*strideA, B_b = B + b*strideB, C_b = C + b*strideC
+ * (strides in ELEMENTS), A_b is row-major [m,k], B_b row-major [k,n],
+ * C_b row-major [m,n]. Accumulation is in f32.
+ *
+ * Returns cudaErrorInvalidValue if any of m,n,k exceeds the supported tiny
+ * bound (64) or any dimension/batch is non-positive, so the caller can fall
+ * back to cuBLAS.
+ */
+cudaError_t tiny_batched_gemm_f32(const float* A, const float* B, float* C,
+                                  int m, int n, int k,
+                                  long long strideA, long long strideB,
+                                  long long strideC,
+                                  int batch, cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TINY_BATCHED_GEMM_H */

--- a/internal/cuda/kernels/transpose.cu
+++ b/internal/cuda/kernels/transpose.cu
@@ -65,6 +65,58 @@ __global__ void kernel_transpose_nd(const float* __restrict__ input,
     output[idx] = input[src_idx];
 }
 
+// ---------- bf16 transpose ----------
+// Transpose is pure data movement (no arithmetic), so the bf16 variants operate
+// on 16-bit elements via `unsigned short` -- a bitwise copy independent of the
+// bf16 numeric interpretation. This keeps bf16 transposes on-device so they are
+// CUDA-graph-capturable (the f32-only kernels forced bf16 onto the CPU engine,
+// whose host memcpy breaks stream capture). ADR-075 lever L4.
+
+__global__ void kernel_transpose_2d_bf16(const unsigned short* __restrict__ input,
+                                          unsigned short* __restrict__ output,
+                                          int rows, int cols) {
+    __shared__ unsigned short tile[TILE_DIM][TILE_DIM + 1];
+
+    int xIdx = blockIdx.x * TILE_DIM + threadIdx.x;
+    int yIdx = blockIdx.y * TILE_DIM + threadIdx.y;
+
+    for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
+        if ((yIdx + j) < rows && xIdx < cols) {
+            tile[threadIdx.y + j][threadIdx.x] = input[(yIdx + j) * cols + xIdx];
+        }
+    }
+    __syncthreads();
+
+    int outX = blockIdx.y * TILE_DIM + threadIdx.x;
+    int outY = blockIdx.x * TILE_DIM + threadIdx.y;
+
+    for (int j = 0; j < TILE_DIM; j += BLOCK_ROWS) {
+        if ((outY + j) < cols && outX < rows) {
+            output[(outY + j) * rows + outX] = tile[threadIdx.x][threadIdx.y + j];
+        }
+    }
+}
+
+__global__ void kernel_transpose_nd_bf16(const unsigned short* __restrict__ input,
+                                          unsigned short* __restrict__ output,
+                                          const int* __restrict__ in_strides,
+                                          const int* __restrict__ out_strides,
+                                          const int* __restrict__ perm,
+                                          int ndim, int total) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+
+    int remaining = idx;
+    int src_idx = 0;
+    for (int d = 0; d < ndim; d++) {
+        int coord = remaining / out_strides[d];
+        remaining = remaining % out_strides[d];
+        src_idx += coord * in_strides[perm[d]];
+    }
+
+    output[idx] = input[src_idx];
+}
+
 // ---------- Launcher functions (extern "C" for CGO) ----------
 
 extern "C" {
@@ -86,6 +138,26 @@ cudaError_t launch_transpose_nd(const float* input, float* output,
     int grid = (total + block - 1) / block;
     kernel_transpose_nd<<<grid, block, 0, stream>>>(input, output, in_strides,
                                                      out_strides, perm, ndim, total);
+    return cudaGetLastError();
+}
+
+cudaError_t launch_transpose_2d_bf16(const unsigned short* input, unsigned short* output,
+                                      int rows, int cols, cudaStream_t stream) {
+    dim3 grid((cols + TILE_DIM - 1) / TILE_DIM,
+              (rows + TILE_DIM - 1) / TILE_DIM);
+    dim3 block(TILE_DIM, BLOCK_ROWS);
+    kernel_transpose_2d_bf16<<<grid, block, 0, stream>>>(input, output, rows, cols);
+    return cudaGetLastError();
+}
+
+cudaError_t launch_transpose_nd_bf16(const unsigned short* input, unsigned short* output,
+                                      const int* in_strides, const int* out_strides,
+                                      const int* perm, int ndim, int total,
+                                      cudaStream_t stream) {
+    int block = 256;
+    int grid = (total + block - 1) / block;
+    kernel_transpose_nd_bf16<<<grid, block, 0, stream>>>(input, output, in_strides,
+                                                         out_strides, perm, ndim, total);
     return cudaGetLastError();
 }
 

--- a/scripts/dgx-validate.sh
+++ b/scripts/dgx-validate.sh
@@ -53,17 +53,25 @@ POLL_INTERVAL="${POLL_INTERVAL:-5}"
 # and zerfoo#921 for why -tags cuda is out of scope). Override with -pkgs for
 # targeted debugging, e.g. -pkgs "-v -run TestKernelAdd ./internal/cuda/kernels/".
 TEST_PKGS="./internal/cuda/... ./internal/xblas/... ./tabular/..."
+# Extra env vars to inject into the pod (space-separated KEY=VALUE pairs), for
+# one-off runs of env-gated fixtures (e.g. ZERFOO_RUN_878_FIXTURE=1). Empty by
+# default, in which case the manifest's EXTRA_ENV_PLACEHOLDER line is dropped
+# unchanged (a no-op comment) -- existing callers see no behavior change.
+EXTRA_ENV=""
 
 usage() {
   cat >&2 <<USAGE
-Usage: $0 [-ref <git-ref>] [-timeout <seconds>] [-dry-run] [-keep] [-no-pull] [-pkgs "<go test args>"] [-delete <pod-name>]
+Usage: $0 [-ref <git-ref>] [-timeout <seconds>] [-dry-run] [-keep] [-no-pull] [-pkgs "<go test args>"] [-env "K=V K2=V2"] [-delete <pod-name>]
 
 Submits docs/bench/manifests/validate-arm64.yaml to Spark at \${SPARK}
 (currently ${SPARK}), polls until the pod terminates, streams logs, extracts
 the JSON report, deletes the pod, and exits 0 only on Succeeded + a report
 with no failures. Pre-pulls the pod image via Spark's image API (skip with
 -no-pull). On failure, pod events are fetched and printed before deletion;
--keep skips deletion entirely so the pod can be inspected.
+-keep skips deletion entirely so the pod can be inspected. -env injects extra
+space-separated KEY=VALUE pairs as additional pod env vars (e.g. -env
+"ZERFOO_RUN_878_FIXTURE=1 ZERFOO_UNSAFE_CAPTURE_TRAINING=1"); values must not
+contain spaces.
 USAGE
   exit 2
 }
@@ -79,6 +87,7 @@ while [ $# -gt 0 ]; do
     -keep)     KEEP=1; shift ;;
     -no-pull)  PREPULL=0; shift ;;
     -pkgs)     [ $# -ge 2 ] || usage; TEST_PKGS="$2"; shift 2 ;;
+    -env)      [ $# -ge 2 ] || usage; EXTRA_ENV="$2"; shift 2 ;;
     -delete)   [ $# -ge 2 ] || usage; DELETE_POD="$2"; shift 2 ;;
     -h|--help) usage ;;
     *) echo "unknown arg: $1" >&2; usage ;;
@@ -115,6 +124,29 @@ MANIFEST="$(
     -e "s|\${TEST_PKGS}|${TEST_PKGS}|g" \
     "$MANIFEST_TEMPLATE"
 )"
+
+# Expand EXTRA_ENV ("K=V K2=V2") into pod env entries at the manifest's
+# EXTRA_ENV_PLACEHOLDER marker line. Done as a plain line-oriented rewrite
+# (not sed -e) because the replacement is multi-line, which sed's s///
+# handles awkwardly across BSD/GNU; a read loop keeps this portable. No-op
+# (marker line dropped) when EXTRA_ENV is empty, matching prior behavior.
+render_extra_env() {
+  local marker="        # EXTRA_ENV_PLACEHOLDER -- scripts/dgx-validate.sh's -env flag expands"
+  local line
+  while IFS= read -r line; do
+    if [ "$line" = "$marker" ]; then
+      local kv k v
+      for kv in $EXTRA_ENV; do
+        k="${kv%%=*}"
+        v="${kv#*=}"
+        printf '        - name: %s\n          value: "%s"\n' "$k" "$v"
+      done
+    else
+      printf '%s\n' "$line"
+    fi
+  done
+}
+MANIFEST="$(printf '%s\n' "$MANIFEST" | render_extra_env)"
 
 # --- HTTP with retry ---------------------------------------------------------
 

--- a/tests/training/capture_replay_divergence_878_test.go
+++ b/tests/training/capture_replay_divergence_878_test.go
@@ -59,10 +59,13 @@ import (
 //     GraphCapturer interface. On CPU-only hosts (e.g. darwin dev machines)
 //     the capture runner is a transparent passthrough, so there is nothing to
 //     diverge and the fixture would be meaningless -- we skip.
-//   - ZERFOO_RUN_878_FIXTURE=1 must be set. This fixture is EXPECTED RED on
-//     GPU until zerfoo#878 is fixed in Phase 1, so the env gate keeps standing
-//     validation/CI runs green while preserving the red proof for the E131
-//     GB10 job and the Phase 1 fix loop to run on demand.
+//   - ZERFOO_RUN_878_FIXTURE=1 must be set. The fixture trains 3x40 steps on
+//     the GPU and requires the ZERFOO_UNSAFE_CAPTURE_TRAINING override, so it
+//     stays opt-in rather than part of the standing gate's default sweep.
+//     (Historically it was also expected RED until the #878 root-cause fix --
+//     the allocation-stable loss seed, training/grad_accum.go buildOnesSeed --
+//     landed; it is GREEN on GB10 since that fix and now serves as the
+//     regression gate for it.)
 //
 // The test also sets ZERFOO_UNSAFE_CAPTURE_TRAINING=1: once E129's loud-fail
 // gate (T129.2) lands, constructing a capture-replay training runner will error
@@ -70,7 +73,7 @@ import (
 // through the gate so it can still serve as the Phase 1 red/green proof.
 func TestCaptureReplayGradientDivergence878(t *testing.T) {
 	if os.Getenv("ZERFOO_RUN_878_FIXTURE") != "1" {
-		t.Skip("zerfoo#878 fixture is opt-in and expected RED on GPU until the Phase 1 fix; set ZERFOO_RUN_878_FIXTURE=1 to run it")
+		t.Skip("zerfoo#878 regression fixture is opt-in (GPU training run); set ZERFOO_RUN_878_FIXTURE=1 to run it")
 	}
 
 	ops := numeric.Float32Ops{}

--- a/tests/training/capture_replay_divergence_878_test.go
+++ b/tests/training/capture_replay_divergence_878_test.go
@@ -264,6 +264,18 @@ func run878Trajectory(
 		if oerr := opt.Step(ctx, g.Parameters()); oerr != nil {
 			t.Fatalf("step %d: optimizer.Step: %v", step, oerr)
 		}
+
+		// Consumer-realistic per-step arena reset (the per-sample/per-epoch
+		// ResetPool pattern of real training loops; ztensor#167's arena reset
+		// floor makes it legal while a captured graph is live). This is the
+		// trigger for the #878 mechanism: any cached cross-step training state
+		// the strategy holds MUST live in allocation-stable non-arena storage,
+		// or the reset recycles it behind the cache -- and, under capture, the
+		// graph's baked device address for it becomes permanently aliased with
+		// a per-step intermediate. Without this reset the fixture cannot
+		// distinguish a correct implementation from one that merely never
+		// exercises arena reuse.
+		engine.ResetPool()
 	}
 
 	return losses, runner

--- a/tests/training/capture_replay_divergence_878_test.go
+++ b/tests/training/capture_replay_divergence_878_test.go
@@ -29,13 +29,23 @@ import (
 // state and replayed against corrupted memory. See:
 // https://github.com/zerfoo/zerfoo/issues/878
 //
-// The fixture trains two identically-initialised copies of a tiny synthetic
-// model on the SAME constant batch from the SAME seed: one through the
-// capture-replay runner with capture DISABLED (the eager reference) and one
-// with capture ENABLED. It then compares the loss trajectories and FAILS if
-// the capture-on trajectory diverges upward while the eager trajectory
-// converges -- i.e. it is the RED proof that #878 is present, and turns GREEN
-// once the Phase 1 root-cause fix lands (both paths must then converge alike).
+// The fixture trains three identically-initialised copies of a tiny synthetic
+// model on the SAME constant batch from the SAME seed:
+//
+//  1. baseline -- capture DISABLED, no arena resets (the known-good loop);
+//  2. eager    -- capture DISABLED, consumer-realistic per-step
+//     engine.ResetPool (the per-sample/per-epoch pattern of real trainers);
+//  3. capture  -- capture ENABLED, per-step engine.ResetPool.
+//
+// All three run identical math on identical data, and GB10 kernels are
+// deterministic, so all three loss trajectories must MATCH step for step.
+// The fixture FAILS if capture-on ascends while the baseline converges (the
+// coarse Wolf-scale signature) OR if either reset trajectory drifts from the
+// baseline beyond fp slack (the sharp signature: a gradient computed from
+// aliased/stale state -- AdamW's approximate scale invariance can hide a
+// mis-scaled gradient from the coarse check while training silently runs on
+// corrupted state). It is the RED proof that #878 is present, and turns
+// GREEN once the root-cause fix lands (all paths then converge alike).
 //
 // Logits are shaped [ns, 3] to match the 3-class target shape from the issue
 // ([ns,3] and [B*ns,3] were hit identically -> framework-level, not
@@ -91,53 +101,93 @@ func TestCaptureReplayGradientDivergence878(t *testing.T) {
 	// so no per-step host copy is enqueued inside the captured region).
 	inputData, onehotData := synthBatch878(ns, inDim, classes, dataSeed)
 
-	// Eager reference: identical runner with capture DISABLED (transparent
-	// passthrough to the backprop strategy).
+	// Ground-truth baseline: capture DISABLED, no arena resets. This is the
+	// plain, known-good training loop the other two trajectories must match.
+	baseLosses, baseRunner := run878Trajectory(t, engine, ops,
+		inputData, onehotData, ns, inDim, dModel, classes, warmup, lr, nSteps, initSeed, false, false)
+	defer func() { _ = baseRunner.Close() }()
+
+	// Eager reference: capture DISABLED, consumer-realistic per-step
+	// engine.ResetPool. Identical math to the baseline; a divergence here
+	// means eager training state is aliased by arena reuse.
 	eagerLosses, eagerRunner := run878Trajectory(t, engine, ops,
-		inputData, onehotData, ns, inDim, dModel, classes, warmup, lr, nSteps, initSeed, false)
+		inputData, onehotData, ns, inDim, dModel, classes, warmup, lr, nSteps, initSeed, false, true)
 	defer func() { _ = eagerRunner.Close() }()
 	if eagerRunner.Enabled() {
 		t.Fatalf("eager reference runner should have capture disabled but reports Enabled()==true")
 	}
 
-	// Capture-on: identical model/seed/data, capture ENABLED.
+	// Capture-on: identical model/seed/data, capture ENABLED, per-step resets.
 	captureLosses, captureRunner := run878Trajectory(t, engine, ops,
-		inputData, onehotData, ns, inDim, dModel, classes, warmup, lr, nSteps, initSeed, true)
+		inputData, onehotData, ns, inDim, dModel, classes, warmup, lr, nSteps, initSeed, true, true)
 	defer func() { _ = captureRunner.Close() }()
 	if !captureRunner.Enabled() {
 		t.Skip("engine does not implement GraphCapturer; capture-replay inactive, nothing to prove")
 	}
 
+	baseInit, baseFinal := edgeMean(baseLosses, 3)
 	eagerInit, eagerFinal := edgeMean(eagerLosses, 3)
 	capInit, capFinal := edgeMean(captureLosses, 3)
 
+	t.Logf("baseline: init=%.4f final=%.4f (no resets, capture off)", baseInit, baseFinal)
 	t.Logf("eager   : init=%.4f final=%.4f (captures=%d replays=%d)",
 		eagerInit, eagerFinal, eagerRunner.CapturesPerformed(), eagerRunner.ReplaysPerformed())
 	t.Logf("capture : init=%.4f final=%.4f (captures=%d replays=%d)",
 		capInit, capFinal, captureRunner.CapturesPerformed(), captureRunner.ReplaysPerformed())
 
-	// Precondition: the eager reference must actually train. If it does not,
-	// the fixture is broken (bad LR, degenerate data, ...) and cannot prove a
-	// capture-specific divergence -- fail loudly rather than emit a false red.
-	if !(eagerFinal < eagerInit*0.9) {
-		t.Fatalf("eager reference did not converge (init=%.4f final=%.4f); "+
-			"fixture cannot isolate the #878 capture-replay divergence", eagerInit, eagerFinal)
+	// Precondition: the baseline must actually train. If it does not, the
+	// fixture is broken (bad LR, degenerate data, ...) and cannot prove a
+	// state-aliasing divergence -- fail loudly rather than emit a false red.
+	if !(baseFinal < baseInit*0.9) {
+		t.Fatalf("baseline did not converge (init=%.4f final=%.4f); "+
+			"fixture cannot isolate the #878 divergence", baseInit, baseFinal)
 	}
 
-	// The #878 signature: capture-on ascends (or lands far above the eager
-	// baseline) while eager descends. Tolerances are generous -- the real bug
-	// is a 10-20x blow-up, not a subtle numeric drift. A correct capture path
-	// converges like eager and this assertion passes (fixture turns GREEN).
-	diverged := capFinal > capInit*1.2 || capFinal > eagerFinal*3.0
+	// The #878 signature, coarse form: capture-on ascends (or lands far above
+	// the baseline) while the plain loop descends. The real Wolf-scale bug was
+	// a 10-20x blow-up; keep this assertion for its diagnostic message.
+	diverged := capFinal > capInit*1.2 || capFinal > baseFinal*3.0
 	if diverged {
 		t.Errorf("zerfoo#878 REPRODUCED: capture-replay training diverged "+
-			"(loss init=%.4f -> final=%.4f) while the identical eager config converged "+
+			"(loss init=%.4f -> final=%.4f) while the identical baseline converged "+
 			"(loss init=%.4f -> final=%.4f). captures=%d replays=%d. "+
-			"This fixture is expected RED on GPU until the Phase 1 root-cause fix; "+
-			"see https://github.com/zerfoo/zerfoo/issues/878",
-			capInit, capFinal, eagerInit, eagerFinal,
+			"See https://github.com/zerfoo/zerfoo/issues/878",
+			capInit, capFinal, baseInit, baseFinal,
 			captureRunner.CapturesPerformed(), captureRunner.ReplaysPerformed())
 	}
+
+	// The #878 signature, sharp form: all three trajectories run identical
+	// math on identical data from identical initial weights, so they must
+	// MATCH step for step. The kernels are deterministic (verified: with no
+	// resets, capture-on and eager produce bit-identical loss trajectories on
+	// GB10), so any per-step drift beyond tiny fp slack means a gradient was
+	// computed from aliased/stale state -- exactly the silent corruption class
+	// this fixture guards. AdamW's approximate scale invariance can otherwise
+	// hide a mis-scaled gradient from the coarse convergence check above.
+	const trajTol = 1e-4
+	if i, d := maxAbsDiff(baseLosses, eagerLosses); d > trajTol {
+		t.Errorf("zerfoo#878 REPRODUCED (eager): per-step ResetPool changed the eager "+
+			"loss trajectory (max |diff|=%.6f at step %d: baseline=%.6f eager=%.6f); "+
+			"cross-step training state is aliased by arena reuse", d, i, baseLosses[i], eagerLosses[i])
+	}
+	if i, d := maxAbsDiff(baseLosses, captureLosses); d > trajTol {
+		t.Errorf("zerfoo#878 REPRODUCED (capture): capture-replay loss trajectory diverged "+
+			"from the baseline (max |diff|=%.6f at step %d: baseline=%.6f capture=%.6f); "+
+			"the captured graph is replaying against aliased/stale state", d, i, baseLosses[i], captureLosses[i])
+	}
+}
+
+// maxAbsDiff returns the index and magnitude of the largest element-wise
+// absolute difference between two equal-length trajectories.
+func maxAbsDiff(a, b []float32) (int, float64) {
+	idx, max := 0, 0.0
+	for i := range a {
+		d := math.Abs(float64(a[i]) - float64(b[i]))
+		if d > max {
+			idx, max = i, d
+		}
+	}
+	return idx, max
 }
 
 // run878Trajectory builds a fresh, deterministically-initialised tiny MLP
@@ -159,6 +209,7 @@ func run878Trajectory(
 	nSteps int,
 	initSeed uint64,
 	captureEnabled bool,
+	resetPool bool,
 ) ([]float32, *training.CaptureReplayRunner[float32]) {
 	t.Helper()
 	ctx := context.Background()
@@ -275,7 +326,9 @@ func run878Trajectory(
 		// a per-step intermediate. Without this reset the fixture cannot
 		// distinguish a correct implementation from one that merely never
 		// exercises arena reuse.
-		engine.ResetPool()
+		if resetPool {
+			engine.ResetPool()
+		}
 	}
 
 	return losses, runner

--- a/tests/training/capture_replay_divergence_878_test.go
+++ b/tests/training/capture_replay_divergence_878_test.go
@@ -141,12 +141,12 @@ func TestCaptureReplayGradientDivergence878(t *testing.T) {
 }
 
 // run878Trajectory builds a fresh, deterministically-initialised tiny MLP
-// (Dense -> ReLU -> Dense) that emits [ns, classes] logits, wires a
+// (Dense -> Sigmoid -> Dense) that emits [ns, classes] logits, wires a
 // device-pure one-hot cross-entropy loss, and trains it for nSteps through a
 // CaptureReplayRunner (capture toggled by captureEnabled). It returns the
 // per-step loss trajectory and the runner (for its counters / Enabled state).
 //
-// Only public APIs are used: graph.Builder, core.Dense, activations.ReLU,
+// Only public APIs are used: graph.Builder, core.Dense, activations.Sigmoid,
 // training.DefaultBackpropStrategy, training.CaptureReplayRunner,
 // loss.CrossEntropyLossOneHot, optimizer.AdamW.
 func run878Trajectory(
@@ -173,8 +173,16 @@ func run878Trajectory(
 		t.Fatalf("NewDense l1: %v", err)
 	}
 	h := b.AddNode(l1, input)
-	relu := activations.NewReLU[float32](engine, ops)
-	h = b.AddNode(relu, h)
+	// The nonlinearity must be DEVICE-PURE (engine ops only) to satisfy the
+	// CaptureReplayRunner contract. ReLU/BaseActivation is not: it routes
+	// through engine.UnaryOp, which GPUEngine delegates to the CPU engine --
+	// a host D2H read plus a CPU-resident result mid-graph, both illegal
+	// inside a capture region (observed live on GB10: "operation would make
+	// the legacy stream depend on a capturing blocking stream"). Sigmoid is
+	// composed of engine primitives (Exp, AddScalar, Div), all with native
+	// f32 GPU kernels, so the walk stays on-device.
+	sigmoid := activations.NewSigmoid[float32](engine, ops)
+	h = b.AddNode(sigmoid, h)
 	head, err := core.NewDense[float32]("head", engine, ops, dModel, classes)
 	if err != nil {
 		t.Fatalf("NewDense head: %v", err)

--- a/training/grad_accum.go
+++ b/training/grad_accum.go
@@ -131,37 +131,49 @@ func shapeKey(shape []int) string {
 }
 
 // buildOnesSeed allocates a ones tensor of ref's shape whose storage is
-// DEVICE-RESIDENT when engine is a GPU engine, so reusing it across steps
-// enqueues no host->device copy (#875).
+// DEVICE-RESIDENT when ref (the loss tensor the graph produced) lives on the
+// GPU, so reusing it across steps enqueues no host->device copy (#875) --
+// and, critically, whose storage is ALLOCATION-STABLE: a raw device
+// allocation (pool == nil), never an arena/pool block (#878).
 //
-// With an engine present it allocates a same-shaped tensor and calls
-// engine.Fill(t, 1): on the GPU engine Fill runs a device-side fill kernel and
-// swaps in fresh GPU storage (no host memcpy of the seed values); on the CPU
-// engine it fills the host slice in place. With no engine it falls back to the
-// host-tensor onesLike path used before #875.
+// The pre-#878 implementation built the device seed via engine.Fill, whose
+// GPU path allocates from the engine's ARENA pool (gpuFill -> pool.Alloc +
+// SetStorage). The seed is cached on the strategy and read on every
+// subsequent step, but arena storage does not survive the consumer's
+// engine.ResetPool (the per-sample/per-epoch reset pattern): the reset
+// recycles the seed's block to a later step's intermediates, silently
+// re-scaling every gradient by whatever value lands there. Under CUDA-graph
+// capture-replay it is worse: the captured graph bakes the seed's device
+// address, an in-graph producer is later assigned the same recycled block,
+// and every replay computes gradients from the aliased value -- the
+// zerfoo#878 silent-divergence signature (correct counters, drifting loss).
+// Cross-step cached training state must live in storage the arena can never
+// recycle, exactly like the persistent gradient accumulators
+// (newPersistentGradTensor) and ztensor's engine-owned AdamW moments.
+//
+// The seed's CONTENT (all ones) is written host-side and uploaded once here
+// -- on the first ComputeGradients call, which under CaptureReplayRunner is
+// an eager warmup step outside any capture region -- so later capture-step
+// reuse still enqueues no host copy (#875 preserved). With a CPU-resident
+// loss or no engine it falls back to the host-tensor onesLike path.
 func buildOnesSeed[T tensor.Numeric](engine compute.Engine[T], ref *tensor.TensorNumeric[T]) (*tensor.TensorNumeric[T], error) {
-	if engine == nil {
-		return onesLike[T](engine, ref)
-	}
-	one, err := onesValue[T](engine)
+	seed, err := onesLike[T](engine, ref)
 	if err != nil {
 		return nil, err
 	}
-	shape := ref.Shape()
-	n := 1
-	for _, d := range shape {
-		n *= d
+	gs, ok := ref.GetStorage().(*tensor.GPUStorage[T])
+	if !ok {
+		return seed, nil
 	}
-	// Start from a zeroed host tensor; engine.Fill overwrites every element
-	// with 1 (and, on the GPU engine, re-homes the storage to device memory).
-	seed, err := tensor.New[T](shape, make([]T, n))
+	// Re-home the host ones into a raw (nil-pool) device allocation on the
+	// loss tensor's device. A nil-pool GPUStorage is never touched by engine
+	// ResetPool, so the cached seed's device pointer and content are stable
+	// for the strategy's whole lifetime, including across every graph replay.
+	ps, err := tensor.NewGPUStorageFromSlice(seed.Data(), gs.DeviceID())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("training: allocating persistent loss seed: %w", err)
 	}
-	if err := engine.Fill(context.Background(), seed, one); err != nil {
-		return nil, fmt.Errorf("training: filling device-resident loss seed: %w", err)
-	}
-	return seed, nil
+	return tensor.NewWithStorage[T](ref.Shape(), ps)
 }
 
 // capture is the post-Backward hook: for every trainable parameter of g

--- a/training/strategy_common.go
+++ b/training/strategy_common.go
@@ -150,6 +150,10 @@ func computeGradientsTensorCommon[T tensor.Numeric](
 	// every step; inside CaptureReplayRunner's capture region that host copy is
 	// illegal ("operation not permitted when stream is capturing") and crashed
 	// capture-on training. Reusing the cached device seed enqueues no host copy.
+	// The cached seed's storage is a raw NON-ARENA device allocation (issue
+	// #878, see buildOnesSeed): arena storage would be recycled behind the
+	// cache by the consumer's engine.ResetPool and, under capture-replay,
+	// aliased with an in-graph intermediate at the seed's baked address.
 	//
 	// When acc is nil (a few unit tests bypass the strategy accumulator) there
 	// is nowhere to cache, so fall back to the per-call host seed: those paths


### PR DESCRIPTION
## Root cause of #878 (confirmed on GB10, red-proofed)

The cached `d(loss)/d(loss)=1` seed (#875, `training/grad_accum.go`) was built via `engine.Fill`, whose GPU path allocates the seed's storage from the engine's **arena pool** (`gpuFill` -> `pool.Alloc` + `SetStorage`). The seed is cached on the strategy and read by every step's `loss.Backward`, but a consumer's per-sample/per-epoch `engine.ResetPool` recycles that arena block to a later step's intermediates:

- **Eager:** every gradient is silently re-scaled by whatever value lands in the recycled block (AdamW's approximate scale invariance can hide it — training still "converges", on wrong gradients).
- **Capture-replay:** the captured graph bakes the seed's device address; the same address is later assigned to an in-graph per-step intermediate, and every replay computes gradients from the aliased value — correct counters, silently drifting loss. The exact #878 signature.

Every other piece of cross-step training state was already allocation-stable (persistent gradient accumulators: nil-pool `NewGPUStorageFromSlice`; ztensor fused-AdamW moments: raw `Malloc`; uploaded weights: bulk buffers). The seed was the one arena-backed hole.

## Fix (contract level)

`buildOnesSeed` now writes the ones host-side and re-homes them into a raw **nil-pool** `GPUStorage` on the loss tensor's device — the same allocation-stability guarantee as `newPersistentGradTensor`. The one-time H2D upload happens on the first `ComputeGradients` call (eager warmup, outside any capture region), preserving #875's no-host-copy-under-capture property. CPU / engine-less paths byte-identical to before. No consumer special-casing (L-0006: everything a captured graph touches must be allocation-stable).

## Fixture hardening (the merged T129.1 fixture could not see the bug)

1. Its ReLU routed through `engine.UnaryOp` (CPU fallback) — host math mid-graph, capture-illegal on GB10. Swapped for device-pure Sigmoid (Exp/AddScalar/Div engine primitives).
2. It never called `engine.ResetPool`, so arena reuse never triggered. Added the consumer-realistic per-step reset (legal under a live captured graph since ztensor#167's reset floor).
3. Its ascend/3x assertion was too coarse (both paths still converge at fixture scale, on wrong gradients). Now asserts per-step loss-trajectory equality (tol 1e-4) of eager+reset and capture+reset against a no-reset baseline.

## GB10 evidence (via `scripts/dgx-validate.sh`, new `-env` flag)

| Proof | Pod | Result |
|---|---|---|
| RED (fixture sharpened, fix absent, 2eadff69) | `zerfoo-validate-wave3taskT13-1783115552` | capture-on diverged from baseline, max per-step diff 0.024751 at step 6, counters correct |
| GREEN (fix applied) | `zerfoo-validate-wave3taskT13-1783116105` | baseline / eager+reset / capture+reset bit-identical (1.1656 -> 0.8951, captures=1 replays=37) |
| GREEN re-run at final head 4160a000 | `zerfoo-validate-wave3taskT13-1783117013` | identical trajectories, PASS |
| Standing gate default scope | `zerfoo-validate-wave3taskT13-1783116265` | internal/cuda, kernels, xblas, tabular all green |
| `./layers/attention/...` full, `-failfast` | `zerfoo-validate-wave3taskT13-1783116385` | green |

## Also in this PR: kernel-fork drift fix (blocking regression)

The T135.3 from-scratch `.so` rebuild dropped five symbols ztensor v1.19.2's loader treats as REQUIRED (`launch_transpose_2d_bf16`, `launch_transpose_nd_bf16`, `dropout_f32`, `fused_adamw_f32`, `tiny_batched_gemm_f32`), which failed ztensor's dlsym loop wholesale and broke every `compute.GPUEngine` consumer on the gate (tabular, training fixtures) while zerfoo-fork-loader tests stayed green. Ported the four kernel sources verbatim from ztensor@v1.19.2 (+Makefile SRCS; SRCS now satisfies BOTH loaders' required sets). Rebuilt+deployed per the T135.3 protocol: pod `zerfoo-build-libkernels-t1333-f4fb4505`, sha256 `f77a1edc...`, prior `.so` kept as `libkernels.so.bak-20260703213619-pre-t1333`.

## Not done here (by design)

- The T129.2 loud-fail gate (`ErrCaptureTrainingDisabled`) stays; removal is T133.4 after coordinator review.
- #878 stays open pending T133.4 and the consumer-scale re-bench.

Refs #878.