### PR TITLE
fix(ci): add least-privilege permissions blocks to PR-triggered workflows (CICD-1, T144.1)

### DIFF
--- a/.github/workflows/arm64-build.yml
+++ b/.github/workflows/arm64-build.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
 concurrency:
   group: arm64-build-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/golden-staleness.yml
+++ b/.github/workflows/golden-staleness.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
   workflow_dispatch: {}
+permissions:
+  contents: read
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `ci.yml`, `arm64-build.yml`, and `golden-staleness.yml` ran with no explicit `permissions:` block, so jobs inherited the repo/org default `GITHUB_TOKEN` scope (write-all if the org default is legacy) despite building/running PR-submitted code (CWE-732).
- Added `permissions: contents: read` at the workflow level to all three, matching the pattern already used in `benchmark.yml`, `codeql.yml`, and `release-please.yml`.
- No job in any of the three workflows writes to the repo, comments on PRs, or pushes tags/releases, so `contents: read` is sufficient everywhere -- no per-job scoping to a broader permission was needed.

Ref: docs/deep-reviews/002-full-codebase.md, CICD-1.

## Test plan
- [x] YAML parses cleanly for all three modified workflows (`python3 -c "import yaml; yaml.safe_load(open(f))"` for each)
- [x] Diffed each workflow to confirm no job needs write/broader scope (no `gh`, no `git push`/`git tag`, no PR-comment steps)
- [ ] CI runs green on this PR (will confirm once checks complete)