### PR TITLE
fix(ci): pin mutable govulncheck/pip installs to exact versions (CICD-2, T144.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Vulnerability check
         continue-on-error: true  # bbolt GO-2026-4923 has no fix (v1.4.3 is latest); re-enable when fixed
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
           govulncheck ./...
       - name: Unit tests
         run: go test -short ./... -race -timeout 300s

--- a/.github/workflows/golden-staleness.yml
+++ b/.github/workflows/golden-staleness.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install PyTorch + numpy
-        run: pip install torch numpy --index-url https://download.pytorch.org/whl/cpu
+        run: pip install torch==2.12.1 numpy==2.5.0 --index-url https://download.pytorch.org/whl/cpu
       - name: Regenerate golden files
         run: python3 tests/golden/generate_golden.py
       - name: Check for drift


### PR DESCRIPTION
## Summary
- `ci.yml:38` installed `govulncheck@latest`, resolving whatever release happens to be current at CI-run time and executing it in-build. Pinned to `v1.5.0` (latest tagged release on golang/vuln; verified real by `go install golang.org/x/vuln/cmd/govulncheck@v1.5.0` succeeding locally and running against the current vuln DB).
- `golden-staleness.yml:15` ran `pip install torch numpy` with no version pins, against the CPU wheel index. Pinned to `torch==2.12.1` and `numpy==2.5.0` (latest stable PyPI releases; confirmed both ship `cp312` Linux x86_64 wheels matching the workflow's `python-version: '3.12'` setup, and neither release is yanked).

Fixes CICD-2 from `docs/deep-reviews/002-full-codebase.md`.

## Test plan
- [ ] CI run on this PR exercises both changed steps (`Vulnerability check` in ci.yml, `Install PyTorch + numpy` in golden-staleness.yml is schedule/workflow_dispatch only, so verify manually via `workflow_dispatch` if needed)
- [x] Verified `govulncheck@v1.5.0` installs and runs locally
- [x] Verified `torch==2.12.1` and `numpy==2.5.0` wheels exist for `cp312`/linux x86_64 and are not yanked