### PR TITLE
fix(gguf): bounds-check tensor offset before mmap slice (F2, T139.2)

### DIFF
--- a/model/gguf/loader_mmap.go
+++ b/model/gguf/loader_mmap.go
@@ -48,13 +48,16 @@ func LoadTensorsMmap(f *File, mapped []byte) (map[string]*tensor.TensorNumeric[f
 		}
 
 		// Slice into the mmap'd region at the tensor's offset.
+		if ti.Offset > math.MaxInt64 {
+			return nil, fmt.Errorf("tensor %q: offset out of range", ti.Name)
+		}
 		offset := f.DataOffset + int64(ti.Offset)
-		end := offset + int64(dataSize)
-		if end > int64(len(mapped)) {
-			return nil, fmt.Errorf("tensor %q: mmap region too small (need offset %d + %d bytes, have %d)",
+		sz := int64(dataSize)
+		if offset < 0 || sz < 0 || offset > int64(len(mapped)) || sz > int64(len(mapped))-offset {
+			return nil, fmt.Errorf("tensor %q: offset+size out of mmap range (need offset %d + %d bytes, have %d)",
 				ti.Name, offset, dataSize, len(mapped))
 		}
-		raw := mapped[offset:end]
+		raw := mapped[offset : offset+sz]
 
 		// Ternary tensors are decoded eagerly because MmapStorage does not
 		// support the TQ2_0 quantization type. The copy is cheap since

--- a/model/gguf/loader_mmap_test.go
+++ b/model/gguf/loader_mmap_test.go
@@ -277,6 +277,54 @@ func TestLoadTensorsMmap_OutOfBounds(t *testing.T) {
 	}
 }
 
+// TestLoadTensorsMmap_HugeOffsetSignedConversion verifies that a
+// maliciously large tensor offset (which would wrap to a negative int64
+// after conversion from uint64) is rejected with an error instead of
+// panicking with a slice-bounds-out-of-range error (F2).
+func TestLoadTensorsMmap_HugeOffsetSignedConversion(t *testing.T) {
+	mapped := make([]byte, 100)
+	gf := &File{
+		DataOffset: 50,
+		Tensors: []TensorInfo{
+			{
+				Name:       "evil",
+				Dimensions: []uint64{4},
+				Type:       GGMLTypeF32,
+				Offset:     0x8000000000000000,
+			},
+		},
+	}
+
+	_, err := LoadTensorsMmap(gf, mapped)
+	if err == nil {
+		t.Fatal("expected error for huge offset, got nil")
+	}
+}
+
+// TestLoadTensorsMmap_OffsetPlusSizeOverflow verifies that an offset which
+// is itself in range but whose offset+size sum overflows/exceeds the mapped
+// region is rejected rather than causing a panic (F2 offset+dataSize variant).
+func TestLoadTensorsMmap_OffsetPlusSizeOverflow(t *testing.T) {
+	mapped := make([]byte, 100)
+	gf := &File{
+		DataOffset: 50,
+		Tensors: []TensorInfo{
+			{
+				Name:       "evil2",
+				Dimensions: []uint64{4},
+				Type:       GGMLTypeF32,
+				// math.MaxInt64 - DataOffset(50) + dataSize(16) overflows past len(mapped).
+				Offset: uint64(math.MaxInt64) - 40,
+			},
+		},
+	}
+
+	_, err := LoadTensorsMmap(gf, mapped)
+	if err == nil {
+		t.Fatal("expected error for offset+size overflow, got nil")
+	}
+}
+
 func TestLoadTensorsMmap_TQ2_0(t *testing.T) {
 	// Create ternary data: 8 values {-1, 0, 1, 1, 0, -1, 1, 0}.
 	values := []int8{-1, 0, 1, 1, 0, -1, 1, 0}

--- a/model/gguf/split_file.go
+++ b/model/gguf/split_file.go
@@ -168,13 +168,16 @@ func LoadTensorsMmapSplit(sf *SplitFile, mappedShards [][]byte) (map[string]*ten
 			return nil, fmt.Errorf("tensor %q: %w", ti.Name, err)
 		}
 
+		if ti.Offset > math.MaxInt64 {
+			return nil, fmt.Errorf("tensor %q: offset out of range", ti.Name)
+		}
 		offset := shard.DataOffset + int64(ti.Offset)
-		end := offset + int64(dataSize)
-		if end > int64(len(mapped)) {
-			return nil, fmt.Errorf("tensor %q: mmap region too small in shard %d (need offset %d + %d bytes, have %d)",
+		sz := int64(dataSize)
+		if offset < 0 || sz < 0 || offset > int64(len(mapped)) || sz > int64(len(mapped))-offset {
+			return nil, fmt.Errorf("tensor %q: offset+size out of mmap range in shard %d (need offset %d + %d bytes, have %d)",
 				ti.Name, shardIdx, offset, dataSize, len(mapped))
 		}
-		raw := mapped[offset:end]
+		raw := mapped[offset : offset+sz]
 
 		// Ternary tensors decoded eagerly (MmapStorage doesn't support TQ2_0).
 		if ti.Type == GGMLTypeTQ2_0 {

--- a/model/gguf/split_file_test.go
+++ b/model/gguf/split_file_test.go
@@ -307,6 +307,64 @@ func TestLoadTensorsMmapSplit(t *testing.T) {
 	}
 }
 
+// TestLoadTensorsMmapSplit_HugeOffsetSignedConversion verifies that a
+// maliciously large tensor offset in a shard (which would wrap to a
+// negative int64 after conversion from uint64) is rejected with an error
+// instead of panicking with a slice-bounds-out-of-range error (F2, split
+// shard variant).
+func TestLoadTensorsMmapSplit_HugeOffsetSignedConversion(t *testing.T) {
+	shard := &File{
+		DataOffset: 50,
+		Tensors: []TensorInfo{
+			{
+				Name:       "evil",
+				Dimensions: []uint64{4},
+				Type:       GGMLTypeF32,
+				Offset:     0x8000000000000000,
+			},
+		},
+	}
+	sf := &SplitFile{
+		File:       shard,
+		Shards:     []*File{shard},
+		ShardIndex: map[string]int{"evil": 0},
+	}
+	mappedShards := [][]byte{make([]byte, 100)}
+
+	_, err := LoadTensorsMmapSplit(sf, mappedShards)
+	if err == nil {
+		t.Fatal("expected error for huge offset, got nil")
+	}
+}
+
+// TestLoadTensorsMmapSplit_OffsetPlusSizeOverflow verifies that an offset
+// which is itself in range but whose offset+size sum exceeds the mapped
+// shard region is rejected rather than causing a panic.
+func TestLoadTensorsMmapSplit_OffsetPlusSizeOverflow(t *testing.T) {
+	shard := &File{
+		DataOffset: 50,
+		Tensors: []TensorInfo{
+			{
+				Name:       "evil2",
+				Dimensions: []uint64{4},
+				Type:       GGMLTypeF32,
+				Offset:     uint64(math.MaxInt64) - 40,
+			},
+		},
+	}
+	sf := &SplitFile{
+		File:       shard,
+		Shards:     []*File{shard},
+		ShardIndex: map[string]int{"evil2": 0},
+	}
+	mappedShards := [][]byte{make([]byte, 100)}
+
+	_, err := LoadTensorsMmapSplit(sf, mappedShards)
+	if err == nil {
+		t.Fatal("expected error for offset+size overflow, got nil")
+	}
+}
+
 func TestLoadTensorsSplit_Heap(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Fixes F2 from `docs/deep-reviews/002-full-codebase.md`: `ti.Offset` is a
file-controlled `uint64` that was cast straight to `int64` with no
unsigned-range check. A crafted tensor offset such as
`0x8000000000000000` wraps to a large negative `int64`, so the sole
existing guard (`end > int64(len(mapped))`) never trips (a negative
`end` is never greater than `len(mapped)`), and `mapped[offset:end]`
panics with a slice-bounds error instead of returning a load error.
This is the default mmap load path.

## Changes

- `model/gguf/loader_mmap.go` (`LoadTensorsMmap`): reject `ti.Offset >
  math.MaxInt64` up front, then validate `offset` and `offset+size`
  are both non-negative and within `len(mapped)` before slicing.
- `model/gguf/split_file.go` (`LoadTensorsMmapSplit`): identical fix
  for the split-shard loader (duplicate code path).
- Added regression tests at both sites covering the wrap-to-negative
  case and the offset-in-range-but-offset+size-overflows case;
  existing legitimate-offset tests continue to pass unchanged.

## Test plan

- [x] `go test ./model/...` green
- [x] `gofmt`/`go vet` clean on changed files (pre-existing unrelated
      gofmt drift in `split_file.go` left untouched, confirmed present
      on base branch)
- [x] Reverted the fix locally and confirmed the new tests panic with
      `slice bounds out of range [:-9223372036854775742]` exactly as
      described in the review, then confirmed the fix converts this to
      a clean error