### PR TITLE
fix(serve): bound error-metric label cardinality via route normalization (SERVE-1, T143.2)

### DIFF
--- a/serve/metrics.go
+++ b/serve/metrics.go
@@ -90,9 +90,51 @@ func (m *ServerMetrics) RecordRequest(tokens int, latency time.Duration) {
 // RecordError increments the errors_total counter for the given endpoint and
 // HTTP status code. Labels are encoded in the counter name so that the
 // Prometheus exposition can emit them as {endpoint="...",status_code="..."}.
+//
+// Callers MUST pass an already-bounded endpoint label (e.g. the output of
+// normalizeRoute), never a raw, attacker-controlled request path: RecordError
+// is invoked from logMiddleware, which runs before authMiddleware, so an
+// unauthenticated caller could otherwise mint one permanent counter entry per
+// distinct path it sends (SERVE-1: metric label cardinality DoS).
 func (m *ServerMetrics) RecordError(endpoint string, statusCode int) {
 	name := "errors_total{endpoint=\"" + endpoint + "\",status_code=\"" + strconv.Itoa(statusCode) + "\"}"
 	m.collector.Counter(name).Inc()
+}
+
+// knownRoutes is the fixed set of registered route paths that get their own
+// metric label. It MUST be kept in sync with the routes registered on s.mux
+// in server.go's newServer setup. Anything not in this set (including
+// nonexistent paths probed pre-auth) collapses to the single "other" label.
+var knownRoutes = map[string]struct{}{
+	"/v1/chat/completions":     {},
+	"/v1/completions":          {},
+	"/v1/embeddings":           {},
+	"/v1/audio/transcriptions": {},
+	"/v1/classify":             {},
+	"/v1/guard":                {},
+	"/v1/guard/batch":          {},
+	"/v1/guard/scan":           {},
+	"/v1/models":               {},
+	"/healthz":                 {},
+	"/readyz":                  {},
+	"/openapi.yaml":            {},
+	"/metrics":                 {},
+}
+
+// normalizeRoute maps a request path to a bounded, fixed set of metric
+// labels. This prevents pre-auth requests to arbitrary or nonexistent paths
+// from creating unbounded permanent counter entries (SERVE-1): every path
+// that is not one of the server's registered routes collapses to "other",
+// and the parameterized /v1/models/{id...} route collapses to a single
+// "/v1/models/{id}" label rather than echoing the attacker-chosen id.
+func normalizeRoute(p string) string {
+	if _, ok := knownRoutes[p]; ok {
+		return p
+	}
+	if strings.HasPrefix(p, "/v1/models/") {
+		return "/v1/models/{id}"
+	}
+	return "other"
 }
 
 // IncActiveRequests increments the active request count and updates the gauge.

--- a/serve/metrics_test.go
+++ b/serve/metrics_test.go
@@ -255,6 +255,98 @@ func TestServerMetrics_RecordError(t *testing.T) {
 	}
 }
 
+// TestNormalizeRoute pins the bounded set of metric labels normalizeRoute
+// produces. Every registered server route (serve/server.go's mux setup) must
+// map to its own label; anything else -- including path-traversal attempts
+// and probes under /v1/models/{id...} -- must collapse into a fixed,
+// non-attacker-controlled label (SERVE-1).
+func TestNormalizeRoute(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/v1/chat/completions", "/v1/chat/completions"},
+		{"/v1/completions", "/v1/completions"},
+		{"/v1/embeddings", "/v1/embeddings"},
+		{"/v1/audio/transcriptions", "/v1/audio/transcriptions"},
+		{"/v1/classify", "/v1/classify"},
+		{"/v1/guard", "/v1/guard"},
+		{"/v1/guard/batch", "/v1/guard/batch"},
+		{"/v1/guard/scan", "/v1/guard/scan"},
+		{"/v1/models", "/v1/models"},
+		{"/v1/models/some-id", "/v1/models/{id}"},
+		{"/v1/models/another-id", "/v1/models/{id}"},
+		{"/healthz", "/healthz"},
+		{"/readyz", "/readyz"},
+		{"/openapi.yaml", "/openapi.yaml"},
+		{"/metrics", "/metrics"},
+		{"/v1/aaaa", "other"},
+		{"/v1/aaab", "other"},
+		{"/v1/guardx", "other"},
+		{"/nonexistent", "other"},
+		{"", "other"},
+	}
+	for _, tc := range tests {
+		if got := normalizeRoute(tc.path); got != tc.want {
+			t.Errorf("normalizeRoute(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestLogMiddleware_ErrorMetricCardinalityBounded is the regression test for
+// SERVE-1: logMiddleware runs before authMiddleware, so an unauthenticated
+// attacker hitting many distinct nonexistent paths must not create one
+// permanent counter entry per path. It should collapse into a single
+// "other" label, while a legitimate registered route keeps its own label.
+func TestLogMiddleware_ErrorMetricCardinalityBounded(t *testing.T) {
+	mdl := buildTestModel(t)
+	c := runtime.NewInMemory()
+	srv := NewServer(mdl, WithMetrics(c))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// Unauthenticated attacker probes many distinct nonexistent /v1/* paths.
+	for i := 0; i < 25; i++ {
+		resp := doGet(t, ts.URL+"/v1/"+strings.Repeat("a", i+1))
+		_ = resp.Body.Close()
+	}
+	// ...and many distinct nonexistent paths outside /v1/ entirely.
+	for i := 0; i < 25; i++ {
+		resp := doGet(t, ts.URL+"/"+strings.Repeat("x", i+1))
+		_ = resp.Body.Close()
+	}
+
+	// A legitimate route hit with a bad payload should still get its own
+	// distinct label rather than being folded into "other".
+	resp := doPost(t, ts.URL+"/v1/completions", "application/json", `not json`)
+	_ = resp.Body.Close()
+
+	snap := c.Snapshot()
+
+	otherCount := 0
+	for name := range snap.Counters {
+		if strings.HasPrefix(name, `errors_total{endpoint="other"`) {
+			otherCount++
+		}
+	}
+	if otherCount != 1 {
+		t.Errorf("distinct errors_total counter entries with endpoint=\"other\" = %d, want 1 (bounded regardless of how many distinct attacker paths were probed)", otherCount)
+	}
+
+	completionsKey := `errors_total{endpoint="/v1/completions",status_code="400"}`
+	if got := snap.Counters[completionsKey]; got != 1 {
+		t.Errorf("%s = %d, want 1 (legitimate routes must keep their own distinct label)", completionsKey, got)
+	}
+
+	// No raw attacker-controlled path should ever have leaked into a counter
+	// name; only the bounded route/other labels are permitted.
+	for name := range snap.Counters {
+		if strings.Contains(name, "aaaaaaaaaaaaaaaaaaaaaaaaa") || strings.Contains(name, "xxxxxxxxxxxxxxxxxxxxxxxxx") {
+			t.Errorf("counter name %q leaked a raw attacker-controlled path", name)
+		}
+	}
+}
+
 func TestServerMetrics_ActiveRequests(t *testing.T) {
 	c := runtime.NewInMemory()
 	m := NewServerMetrics(c)

--- a/serve/server.go
+++ b/serve/server.go
@@ -361,9 +361,13 @@ func (s *Server) logMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(rec, r)
 		latency := time.Since(start).Milliseconds()
 
-		// Record error metrics for non-2xx responses.
+		// Record error metrics for non-2xx responses. The path is normalized
+		// to a bounded label set before recording: logMiddleware runs before
+		// authMiddleware, so an unauthenticated caller must never be able to
+		// mint an unbounded number of permanent counter entries by probing
+		// distinct paths (SERVE-1).
 		if rec.status >= 400 {
-			s.metrics.RecordError(r.URL.Path, rec.status)
+			s.metrics.RecordError(normalizeRoute(r.URL.Path), rec.status)
 		}
 
 		modelID := ""


### PR DESCRIPTION
## Summary
- Fixes SERVE-1 (docs/deep-reviews/002-full-codebase.md): `RecordError` encoded the raw, attacker-controlled `r.URL.Path` into a permanent counter name. `logMiddleware` (server.go) calls `RecordError` before `authMiddleware` runs, so an unauthenticated caller hitting many distinct nonexistent paths could create unbounded permanent counter entries whenever a real metrics collector is wired (the shipped default Nop collector doesn't grow, but the fix must hold regardless of collector).
- Adds `normalizeRoute` in `serve/metrics.go`, mapping a request path to the server's actual registered route set (`/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/audio/transcriptions`, `/v1/classify`, `/v1/guard`, `/v1/guard/batch`, `/v1/guard/scan`, `/v1/models`, `/healthz`, `/readyz`, `/openapi.yaml`, `/metrics` -- see `serve/server.go`'s mux registration). The parameterized `/v1/models/{id...}` route collapses to a fixed `/v1/models/{id}` label instead of echoing the attacker-chosen id. Everything else collapses to `other`.
- `server.go`'s `logMiddleware` now records `s.metrics.RecordError(normalizeRoute(r.URL.Path), rec.status)` instead of the raw path.

## Test plan
- [x] `TestNormalizeRoute` (serve/metrics_test.go) -- pins every registered route to its own label, `/v1/models/{id}` for path-parameterized ids, and `other` for anything unmatched.
- [x] `TestLogMiddleware_ErrorMetricCardinalityBounded` (serve/metrics_test.go) -- end-to-end through `Handler()`: 25 distinct nonexistent `/v1/*` paths + 25 distinct nonexistent non-`/v1` paths collapse into exactly one `errors_total{endpoint="other",...}` counter entry, while a legitimate route (`/v1/completions` with a bad body) keeps its own distinct label; also asserts no raw attacker path substring leaks into any counter name.
- [x] `gofmt -l` clean, `go vet ./serve/...` clean, `go test ./serve/...` green.