### PR TITLE
fix(serve): validate LoRA adapter name against traversal (SERVE-2, T143.1)

### DIFF
--- a/serve/adapter.go
+++ b/serve/adapter.go
@@ -2,11 +2,18 @@ package serve
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/zerfoo/zerfoo/inference/lora"
 )
+
+// adapterNameRe restricts adapter names to a safe charset so that
+// filesystem-hostile input (path separators, "..", NUL bytes, etc.) is
+// rejected before it ever reaches filepath.Join.
+var adapterNameRe = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 
 // AdapterCacheHandle wraps a lora.AdapterCache with the directory
 // where adapter GGUF files are stored.
@@ -40,9 +47,26 @@ func ParseModelAdapter(model string) (baseModel, adapterName string) {
 
 // resolveAdapter loads an adapter by name from the cache, or from disk if not cached.
 // Returns the adapter or an error if the adapter cannot be found or loaded.
+//
+// The name is attacker-controlled (parsed from the request's "model" field by
+// ParseModelAdapter), so it is validated against an anchored charset and the
+// resulting path is checked for directory containment before any filesystem
+// access. Without this, a name like "../../../../etc/passwd" would survive
+// filepath.Join (which cleans "../" segments) and let a request open any
+// file on disk that the process can read.
 func (h *AdapterCacheHandle) resolveAdapter(name string) (*lora.Adapter, error) {
+	if !adapterNameRe.MatchString(name) {
+		return nil, fmt.Errorf("invalid adapter name %q", name)
+	}
+
 	path := filepath.Join(h.dir, name+".gguf")
-	adapter, err := h.cache.GetOrLoad(name, path)
+	clean := filepath.Clean(path)
+	dirPrefix := filepath.Clean(h.dir) + string(os.PathSeparator)
+	if !strings.HasPrefix(clean, dirPrefix) {
+		return nil, fmt.Errorf("adapter path escapes directory")
+	}
+
+	adapter, err := h.cache.GetOrLoad(name, clean)
 	if err != nil {
 		return nil, fmt.Errorf("loading adapter %q: %w", name, err)
 	}

--- a/serve/adapter_test.go
+++ b/serve/adapter_test.go
@@ -1,11 +1,15 @@
 package serve
 
 import (
+	"bytes"
+	"encoding/binary"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/zerfoo/zerfoo/inference/lora"
+	"github.com/zerfoo/zerfoo/model/gguf"
 )
 
 func TestAdapterCacheHandle_ResolveAdapter_MissingFile(t *testing.T) {
@@ -36,6 +40,159 @@ func TestAdapterCacheHandle_ResolveAdapter_InvalidGGUF(t *testing.T) {
 	_, err := h.resolveAdapter("bad")
 	if err == nil {
 		t.Fatal("expected error for invalid GGUF, got nil")
+	}
+}
+
+// --- SERVE-2: LoRA adapter-name path traversal fixtures and tests ---
+//
+// resolveAdapter must reject any adapter name that is not a plain
+// alphanumeric/underscore/hyphen token *before* touching the filesystem, and
+// must never resolve to a path outside h.dir even if the regex gate were
+// somehow bypassed. These tests plant a "secret" GGUF file outside the
+// configured adapter directory and confirm that no crafted name can reach it.
+
+// bwTest wraps binary.Write for test fixture construction.
+func bwTest(t *testing.T, buf *bytes.Buffer, data any) {
+	t.Helper()
+	if err := binary.Write(buf, binary.LittleEndian, data); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeGGUFString(t *testing.T, buf *bytes.Buffer, s string) {
+	t.Helper()
+	bwTest(t, buf, uint64(len(s)))
+	buf.WriteString(s)
+}
+
+// writeLoRAGGUFFile writes a minimal-but-real GGUF v3 file with LoRA
+// metadata and a single F32 tensor pair to path, mirroring the fixture
+// builder in inference/lora/adapter_test.go so that resolveAdapter can be
+// exercised against a real, loadable adapter rather than a mock.
+func writeLoRAGGUFFile(t *testing.T, path string, rank uint32, alpha float32) {
+	t.Helper()
+
+	const layerName = "model.layers.0.self_attn.q_proj"
+	const inDim, outDim = 8, 16
+	aData := make([]float32, int(rank)*inDim)
+	bData := make([]float32, outDim*int(rank))
+	for i := range aData {
+		aData[i] = 0.1
+	}
+	for i := range bData {
+		bData[i] = 0.2
+	}
+
+	type tensorEntry struct {
+		name string
+		dims []uint64
+		data []float32
+	}
+	tensors := []tensorEntry{
+		{name: "lora_a." + layerName, dims: []uint64{uint64(inDim), uint64(rank)}, data: aData},
+		{name: "lora_b." + layerName, dims: []uint64{uint64(rank), uint64(outDim)}, data: bData},
+	}
+
+	var buf bytes.Buffer
+	bwTest(t, &buf, gguf.Magic)
+	bwTest(t, &buf, uint32(3)) // version
+	bwTest(t, &buf, uint64(len(tensors)))
+	bwTest(t, &buf, uint64(2)) // metadata count
+
+	writeGGUFString(t, &buf, "lora.rank")
+	bwTest(t, &buf, gguf.TypeUint32)
+	bwTest(t, &buf, rank)
+	writeGGUFString(t, &buf, "lora.alpha")
+	bwTest(t, &buf, gguf.TypeFloat32)
+	bwTest(t, &buf, alpha)
+
+	var offset uint64
+	for _, te := range tensors {
+		writeGGUFString(t, &buf, te.name)
+		bwTest(t, &buf, uint32(len(te.dims)))
+		for _, d := range te.dims {
+			bwTest(t, &buf, d)
+		}
+		bwTest(t, &buf, uint32(gguf.GGMLTypeF32))
+		bwTest(t, &buf, offset)
+		offset += uint64(len(te.data) * 4)
+	}
+
+	pos := buf.Len()
+	const alignment = 32
+	padded := (pos + alignment - 1) / alignment * alignment
+	for range padded - pos {
+		buf.WriteByte(0)
+	}
+
+	for _, te := range tensors {
+		for _, v := range te.data {
+			bwTest(t, &buf, math.Float32bits(v))
+		}
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAdapterCacheHandle_ResolveAdapter_ValidNameLoadsRealFixture(t *testing.T) {
+	dir := t.TempDir()
+	writeLoRAGGUFFile(t, filepath.Join(dir, "my-adapter.gguf"), 4, 8.0)
+
+	h := &AdapterCacheHandle{
+		cache: lora.NewAdapterCache(2),
+		dir:   dir,
+	}
+
+	adapter, err := h.resolveAdapter("my-adapter")
+	if err != nil {
+		t.Fatalf("resolveAdapter(%q) = %v, want success", "my-adapter", err)
+	}
+	if adapter.Rank != 4 {
+		t.Errorf("Rank = %d, want 4", adapter.Rank)
+	}
+}
+
+func TestAdapterCacheHandle_ResolveAdapter_PathTraversalRejected(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "adapters")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plant a real, loadable adapter GGUF *outside* the configured adapter
+	// directory. If any crafted name below successfully resolves, this is
+	// the file it would have opened.
+	secretPath := filepath.Join(base, "secret.gguf")
+	writeLoRAGGUFFile(t, secretPath, 4, 8.0)
+
+	maliciousNames := []string{
+		"../secret",
+		"../../secret",
+		"../../../../../../etc/passwd",
+		"a/../../secret",
+		"/etc/passwd",
+		"..",
+		"./../secret",
+		"secret\x00.gguf",
+	}
+
+	for _, name := range maliciousNames {
+		t.Run(name, func(t *testing.T) {
+			h := &AdapterCacheHandle{
+				cache: lora.NewAdapterCache(2),
+				dir:   dir,
+			}
+
+			_, err := h.resolveAdapter(name)
+			if err == nil {
+				t.Fatalf("resolveAdapter(%q) succeeded, want error", name)
+			}
+			if h.cache.Size() != 0 {
+				t.Errorf("resolveAdapter(%q): cache poisoned by traversal, size = %d, want 0", name, h.cache.Size())
+			}
+		})
 	}
 }
 

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -252,6 +254,67 @@ func TestHandleChatCompletions_InvalidJSON(t *testing.T) {
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// TestHandleChatCompletions_AdapterPathTraversalRejected is the API-level
+// regression test for SERVE-2: a request whose "model" field encodes a LoRA
+// adapter name with path-traversal sequences must be rejected with a
+// 400-class error, and must never open a file outside the configured
+// adapter directory.
+func TestHandleChatCompletions_AdapterPathTraversalRejected(t *testing.T) {
+	mdl := buildTestModel(t)
+
+	base := t.TempDir()
+	dir := filepath.Join(base, "adapters")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plant a real, loadable adapter GGUF outside the adapter directory.
+	// If the traversal succeeded, this is the file it would open.
+	writeLoRAGGUFFile(t, filepath.Join(base, "secret.gguf"), 4, 8.0)
+
+	srv := NewServer(mdl, WithAdapterCache(dir, 5))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body := `{"messages":[{"role":"user","content":"hello"}],"model":"base:../secret","max_tokens":5}`
+	resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400; body = %s", resp.StatusCode, b)
+	}
+	if srv.adapterCache.cache.Size() != 0 {
+		t.Errorf("adapter cache poisoned by traversal name, size = %d, want 0", srv.adapterCache.cache.Size())
+	}
+}
+
+// TestHandleChatCompletions_AdapterValidNameLoads confirms the traversal fix
+// does not regress the legitimate path: a real adapter with a well-formed
+// name still resolves via the adapter cache and the request completes.
+func TestHandleChatCompletions_AdapterValidNameLoads(t *testing.T) {
+	mdl := buildTestModel(t)
+
+	dir := t.TempDir()
+	writeLoRAGGUFFile(t, filepath.Join(dir, "my-adapter.gguf"), 4, 8.0)
+
+	srv := NewServer(mdl, WithAdapterCache(dir, 5))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	body := `{"messages":[{"role":"user","content":"hello"}],"model":"test-model:my-adapter","max_tokens":5}`
+	resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, b)
+	}
+	if srv.adapterCache.cache.Size() != 1 {
+		t.Errorf("adapter cache size = %d, want 1 (legitimate adapter should load)", srv.adapterCache.cache.Size())
 	}
 }
 


### PR DESCRIPTION
## Summary
- `resolveAdapter` used the request-controlled adapter name unvalidated in `filepath.Join(h.dir, name+".gguf")`. `filepath.Join` cleans embedded `../` sequences, so a `model` field like `"base:../../../../etc/passwd"` escaped the configured adapter directory and opened (and cached) an arbitrary `.gguf`-readable file on disk. Gated on `WithAdapterCache` being configured; reached from both the chat and completions handlers.
- Fix: reject any adapter name that doesn't match `^[A-Za-z0-9_-]{1,64}$` before touching the filesystem, then re-verify the joined path's directory containment as defense in depth -- mirroring the existing traversal guard in `model/registry/pull.go`'s `downloadFile`.

## Test plan
- [x] `TestAdapterCacheHandle_ResolveAdapter_PathTraversalRejected` -- table of 8 crafted adapter names (`../secret`, `../../../../../../etc/passwd`, `/etc/passwd`, embedded NUL, etc.) against a real planted "secret" GGUF outside the adapter dir; all rejected, cache never poisoned.
- [x] `TestAdapterCacheHandle_ResolveAdapter_ValidNameLoadsRealFixture` -- a legitimate adapter name still resolves and loads a real (synthetic but valid) LoRA GGUF fixture.
- [x] `TestHandleChatCompletions_AdapterPathTraversalRejected` -- full API-level request with `model: "base:../secret"` returns 400 and never opens the planted file outside the adapter dir.
- [x] `TestHandleChatCompletions_AdapterValidNameLoads` -- full API-level request with a legitimate adapter name still returns 200 and populates the cache.
- [x] Pre-existing adapter tests (`TestChatCompletions_WithAdapter`, `TestParseModelAdapter`, etc.) still pass.
- [x] `gofmt -l` clean, `go vet ./serve/...` clean, `go build ./...` clean, `go test ./serve/...` green.

Root cause and fix verified against deep-review 002 (`docs/deep-reviews/002-full-codebase.md`, SERVE-2).