### PR TITLE
fix(cuda): remove CWD-relative dlopen candidates for the kernel library (CUDA-1, T141.1)

### DIFF
--- a/docs/bench/manifests/validate-arm64.yaml
+++ b/docs/bench/manifests/validate-arm64.yaml
@@ -27,7 +27,9 @@
 # file or directory" for any missing hostPath, observed live 2026-07-02):
 #   /usr/local/cuda        CUDA 13 runtime libs (loaded via purego/dlopen)
 #   /opt/zerfoo/lib        tanh-fixed sm_121 libkernels.so; resolved by
-#                          internal/cuda/purego.go kernelLibPaths[2]
+#                          internal/cuda/purego.go trustedKernelLibPath (the
+#                          sole kernelLibPaths entry as of CUDA-1, T141.1 --
+#                          no CWD-relative or bare-soname candidates)
 # Model parity: MODELS_DIR points at an in-container path that is absent by
 # default, so the parity stage skips cleanly. To run parity, provision GGUF
 # files on the host and re-add a models hostPath mount (path must pre-exist).

--- a/internal/cuda/purego.go
+++ b/internal/cuda/purego.go
@@ -2,6 +2,8 @@ package cuda
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -161,11 +163,64 @@ const (
 	rtldGlobal = 0x100
 )
 
+// trustedKernelLibPath is the vetted, absolute production location for the
+// custom kernels shared library. Standard installs and every DGX Spark
+// manifest (docs/bench/manifests/*.yaml) mount libkernels.so here.
+const trustedKernelLibPath = "/opt/zerfoo/lib/libkernels.so"
+
+// kernelLibPathOverrideEnv names an environment variable that, if set to a
+// vetted absolute path, is tried before trustedKernelLibPath. It exists so
+// dev builds that need a non-standard install location don't have to patch
+// this file. See vetKernelLibOverride for the safety checks applied.
+const kernelLibPathOverrideEnv = "ZERFOO_KERNEL_LIB_PATH"
+
 // kernelLibPaths lists paths to try for the custom kernels shared library.
-var kernelLibPaths = []string{
-	"libkernels.so",
-	"./libkernels.so",
-	"/opt/zerfoo/lib/libkernels.so",
+//
+// SECURITY: every entry here MUST be an absolute path. dlopen executes a
+// shared object's ELF constructors at load time, so a bare soname (resolved
+// via the default loader search path) or a CWD-relative entry lets an
+// attacker who can write into the process's working directory (or influence
+// LD_LIBRARY_PATH) achieve code execution the moment CUDA initializes.
+// This list previously included "libkernels.so" and "./libkernels.so" --
+// see docs/deep-reviews/002-full-codebase.md CUDA-1 and
+// docs/adr/094-untrusted-boundary-security-hardening.md. Do not reintroduce
+// a relative or bare-soname candidate; TestKernelLibPathsAreAbsolute enforces
+// this.
+var kernelLibPaths = buildKernelLibPaths()
+
+// buildKernelLibPaths assembles the dlopen candidate list: an optional
+// vetted override first, then the trusted absolute default.
+func buildKernelLibPaths() []string {
+	paths := make([]string, 0, 2)
+	if override := os.Getenv(kernelLibPathOverrideEnv); override != "" {
+		if vetted, ok := vetKernelLibOverride(override); ok {
+			paths = append(paths, vetted)
+		}
+		// An invalid override is silently ignored (not fatal): we fall
+		// through to the trusted default rather than refusing to start.
+	}
+	paths = append(paths, trustedKernelLibPath)
+	return paths
+}
+
+// vetKernelLibOverride validates that path is safe to hand to dlopen: it
+// must be an absolute path (never CWD-relative or a bare soname), it must
+// exist, and it must not be world-writable -- a world-writable "trusted"
+// path is just as hijackable as a CWD-relative one, since any local user
+// could replace its contents with a malicious library whose ELF
+// constructors run on the next dlopen.
+func vetKernelLibOverride(path string) (string, bool) {
+	if !filepath.IsAbs(path) {
+		return "", false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", false
+	}
+	if info.Mode().Perm()&0o002 != 0 {
+		return "", false
+	}
+	return path, true
 }
 
 // DlopenKernels loads the custom kernels shared library (libkernels.so)

--- a/internal/cuda/purego_test.go
+++ b/internal/cuda/purego_test.go
@@ -1,6 +1,8 @@
 package cuda
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 )
@@ -95,6 +97,104 @@ func TestDlopenPathValid(t *testing.T) {
 		t.Fatal("expected non-zero handle")
 	}
 	dlcloseImpl(h)
+}
+
+// TestKernelLibPathsAreAbsolute is the CUDA-1 regression guard
+// (docs/deep-reviews/002-full-codebase.md, docs/adr/094-*): dlopen executes a
+// shared object's ELF constructors at load time, so any bare-soname or
+// CWD-relative candidate in the kernel dlopen search list is a local
+// code-execution primitive. Every candidate must be an absolute path.
+func TestKernelLibPathsAreAbsolute(t *testing.T) {
+	if len(kernelLibPaths) == 0 {
+		t.Fatal("expected kernelLibPaths to contain at least the trusted default")
+	}
+	for _, p := range kernelLibPaths {
+		if !filepath.IsAbs(p) {
+			t.Fatalf("kernelLibPaths contains a non-absolute (CWD-relative or bare-soname) entry: %q", p)
+		}
+	}
+}
+
+// TestKernelLibPathsContainsTrustedDefault pins the trusted production path
+// so a future edit cannot silently drop it.
+func TestKernelLibPathsContainsTrustedDefault(t *testing.T) {
+	found := false
+	for _, p := range kernelLibPaths {
+		if p == trustedKernelLibPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected kernelLibPaths to contain trusted default %q, got %v", trustedKernelLibPath, kernelLibPaths)
+	}
+}
+
+func TestVetKernelLibOverrideRejectsRelativePath(t *testing.T) {
+	if _, ok := vetKernelLibOverride("libkernels.so"); ok {
+		t.Fatal("expected bare soname to be rejected")
+	}
+	if _, ok := vetKernelLibOverride("./libkernels.so"); ok {
+		t.Fatal("expected CWD-relative path to be rejected")
+	}
+	if _, ok := vetKernelLibOverride("../libkernels.so"); ok {
+		t.Fatal("expected relative parent path to be rejected")
+	}
+}
+
+func TestVetKernelLibOverrideRejectsMissingFile(t *testing.T) {
+	if _, ok := vetKernelLibOverride("/tmp/libnonexistent_test_xyzzy_kernellib.so"); ok {
+		t.Fatal("expected nonexistent absolute path to be rejected")
+	}
+}
+
+func TestVetKernelLibOverrideRejectsWorldWritable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libkernels.so")
+	if err := os.WriteFile(path, []byte("stub"), 0o666); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatalf("failed to chmod test fixture world-writable: %v", err)
+	}
+	if _, ok := vetKernelLibOverride(path); ok {
+		t.Fatal("expected world-writable absolute path to be rejected")
+	}
+}
+
+func TestVetKernelLibOverrideAcceptsSafeAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libkernels.so")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	vetted, ok := vetKernelLibOverride(path)
+	if !ok {
+		t.Fatal("expected safe absolute, non-world-writable path to be accepted")
+	}
+	if vetted != path {
+		t.Fatalf("expected vetted path %q, got %q", path, vetted)
+	}
+}
+
+func TestBuildKernelLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(kernelLibPathOverrideEnv, "./libkernels.so")
+	paths := buildKernelLibPaths()
+	if len(paths) != 1 || paths[0] != trustedKernelLibPath {
+		t.Fatalf("expected invalid override to fall through to trusted default only, got %v", paths)
+	}
+}
+
+func TestBuildKernelLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libkernels.so")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(kernelLibPathOverrideEnv, path)
+	paths := buildKernelLibPaths()
+	if len(paths) != 2 || paths[0] != path || paths[1] != trustedKernelLibPath {
+		t.Fatalf("expected [override, trustedDefault], got %v", paths)
+	}
 }
 
 func TestDlopenImplWithLibSystem(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes CUDA-1 (docs/deep-reviews/002-full-codebase.md): `internal/cuda/purego.go`'s `kernelLibPaths` included a bare `"libkernels.so"` and a CWD-relative `"./libkernels.so"` dlopen candidate. Since `dlopen` executes a shared object's ELF constructors at load time, a file planted in the process's working directory got code execution the moment CUDA initialized.
- `kernelLibPaths` now contains only the vetted absolute production path `/opt/zerfoo/lib/libkernels.so` (already the mount path in every DGX Spark bench manifest).
- Added an optional `ZERFOO_KERNEL_LIB_PATH` env var for dev builds needing a non-standard install location; it is only used if `os.Stat` confirms the path is absolute, existing, and not world-writable, otherwise the loader silently falls back to the trusted default.
- Confirmed no README/CONTRIBUTING/design.md dev-workflow docs referenced dropping `libkernels.so` in the CWD, so no migration notes were needed beyond correcting a stale `kernelLibPaths[2]` index comment in `docs/bench/manifests/validate-arm64.yaml`.
- `internal/cuda/purego.go` has no build tags (compiles on darwin and linux); confirmed no darwin-specific breakage.

## Test plan
- [x] `go build ./...` (full repo)
- [x] `go vet ./...` (full repo, clean)
- [x] `go test -count=1 ./internal/cuda/...` green on darwin
- [x] New tests: `TestKernelLibPathsAreAbsolute`, `TestKernelLibPathsContainsTrustedDefault`, `TestVetKernelLibOverrideRejectsRelativePath`, `TestVetKernelLibOverrideRejectsMissingFile`, `TestVetKernelLibOverrideRejectsWorldWritable`, `TestVetKernelLibOverrideAcceptsSafeAbsolutePath`, `TestBuildKernelLibPathsFallsBackOnInvalidOverride`, `TestBuildKernelLibPathsUsesValidOverrideFirst`

Refs: docs/deep-reviews/002-full-codebase.md CUDA-1, docs/adr/094-untrusted-boundary-security-hardening.md, docs/plan.md T141.1