### PR TITLE
fix(serve): close model-delete TOCTOU and WaitGroup-misuse race (CONC-H2, T142.2)

### DIFF
--- a/serve/classify.go
+++ b/serve/classify.go
@@ -66,8 +66,12 @@ func NewClassifyMetrics(c runtime.Collector) *ClassifyMetrics {
 }
 
 func (s *Server) handleClassify(w http.ResponseWriter, r *http.Request) {
-	s.inflight.Add(1)
-	defer s.inflight.Done()
+	s.modelMu.RLock()
+	defer s.modelMu.RUnlock()
+	if s.unloaded.Load() {
+		writeError(w, http.StatusNotFound, "model not available")
+		return
+	}
 
 	if s.classifier == nil {
 		writeError(w, http.StatusNotImplemented, "text classification is not configured")

--- a/serve/guard.go
+++ b/serve/guard.go
@@ -29,19 +29,19 @@ func WithGuardEvaluator(e GuardEvaluator) ServerOption {
 
 // GuardRequest is the request body for POST /v1/guard.
 type GuardRequest struct {
-	Model  string              `json:"model"`
+	Model  string                 `json:"model"`
 	Input  guardian.GuardianInput `json:"input"`
-	Risks  []string            `json:"risks"`
-	Format string              `json:"format,omitempty"`
-	Think  bool                `json:"think,omitempty"`
+	Risks  []string               `json:"risks"`
+	Format string                 `json:"format,omitempty"`
+	Think  bool                   `json:"think,omitempty"`
 }
 
 // GuardResponse is the response body for POST /v1/guard.
 type GuardResponse struct {
-	Model     string         `json:"model"`
-	Flagged   bool           `json:"flagged"`
-	Verdicts  []VerdictData  `json:"verdicts"`
-	LatencyMs int64          `json:"latency_ms"`
+	Model     string        `json:"model"`
+	Flagged   bool          `json:"flagged"`
+	Verdicts  []VerdictData `json:"verdicts"`
+	LatencyMs int64         `json:"latency_ms"`
 }
 
 // VerdictData holds a single risk verdict in the API response.
@@ -54,9 +54,9 @@ type VerdictData struct {
 
 // GuardBatchRequest is the request body for POST /v1/guard/batch.
 type GuardBatchRequest struct {
-	Model  string                  `json:"model"`
+	Model  string                   `json:"model"`
 	Inputs []guardian.GuardianInput `json:"inputs"`
-	Risks  []string                `json:"risks"`
+	Risks  []string                 `json:"risks"`
 }
 
 // GuardBatchResponse is the response body for POST /v1/guard/batch.
@@ -75,7 +75,7 @@ type GuardBatchResult struct {
 
 // GuardScanRequest is the request body for POST /v1/guard/scan.
 type GuardScanRequest struct {
-	Model string                `json:"model"`
+	Model string                 `json:"model"`
 	Input guardian.GuardianInput `json:"input"`
 }
 
@@ -103,8 +103,12 @@ func NewGuardMetrics(c runtime.Collector) *GuardMetrics {
 }
 
 func (s *Server) handleGuard(w http.ResponseWriter, r *http.Request) {
-	s.inflight.Add(1)
-	defer s.inflight.Done()
+	s.modelMu.RLock()
+	defer s.modelMu.RUnlock()
+	if s.unloaded.Load() {
+		writeError(w, http.StatusNotFound, "model not available")
+		return
+	}
 
 	if s.guardEvaluator == nil {
 		writeError(w, http.StatusNotImplemented, "guardian evaluation is not configured")
@@ -182,8 +186,12 @@ func (s *Server) handleGuard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGuardBatch(w http.ResponseWriter, r *http.Request) {
-	s.inflight.Add(1)
-	defer s.inflight.Done()
+	s.modelMu.RLock()
+	defer s.modelMu.RUnlock()
+	if s.unloaded.Load() {
+		writeError(w, http.StatusNotFound, "model not available")
+		return
+	}
 
 	if s.guardEvaluator == nil {
 		writeError(w, http.StatusNotImplemented, "guardian evaluation is not configured")
@@ -264,8 +272,12 @@ func (s *Server) handleGuardBatch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGuardScan(w http.ResponseWriter, r *http.Request) {
-	s.inflight.Add(1)
-	defer s.inflight.Done()
+	s.modelMu.RLock()
+	defer s.modelMu.RUnlock()
+	if s.unloaded.Load() {
+		writeError(w, http.StatusNotFound, "model not available")
+		return
+	}
 
 	if s.guardEvaluator == nil {
 		writeError(w, http.StatusNotImplemented, "guardian evaluation is not configured")

--- a/serve/handlers.go
+++ b/serve/handlers.go
@@ -16,8 +16,12 @@ import (
 // --- Handlers ---
 
 func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
-	s.inflight.Add(1)
-	defer s.inflight.Done()
+	s.modelMu.RLock()
+	defer s.modelMu.RUnlock()
+	if s.unloaded.Load() {
+		writeError(w, http.StatusNotFound, "model not available")
+		return
+	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, 10<<20) // 10 MB
 	var req ChatCompletionRequest
@@ -169,8 +173,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
-	s.inflight.Add(1)
-	defer s.inflight.Done()
+	s.modelMu.RLock()
+	defer s.modelMu.RUnlock()
+	if s.unloaded.Load() {
+		writeError(w, http.StatusNotFound, "model not available")
+		return
+	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, 10<<20) // 10 MB
 	var req CompletionRequest
@@ -327,9 +335,24 @@ func (s *Server) handleModelDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reject new requests, drain in-flight ones, then close.
+	// Take the write side of modelMu: this blocks until every handler
+	// currently holding RLock (i.e. every in-flight request that already
+	// passed its unloaded check) has released it, then excludes any new
+	// RLock acquisition until unloaded is set and the model is closed. This
+	// closes both CONC-H2 races structurally: no handler can observe a model
+	// that Close() is concurrently tearing down, and there is no
+	// WaitGroup-style counter for a request to race against.
+	s.modelMu.Lock()
+	defer s.modelMu.Unlock()
+
+	// Re-check under the lock: a concurrent delete may have already won the
+	// race between the initial unloaded.Load() above and acquiring the lock.
+	if s.unloaded.Load() {
+		writeError(w, http.StatusNotFound, "model '"+id+"' not found")
+		return
+	}
+
 	s.unloaded.Store(true)
-	s.inflight.Wait()
 	_ = s.model.Close()
 
 	writeJSON(w, http.StatusOK, ModelDeleteResponse{
@@ -340,8 +363,12 @@ func (s *Server) handleModelDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
-	s.inflight.Add(1)
-	defer s.inflight.Done()
+	s.modelMu.RLock()
+	defer s.modelMu.RUnlock()
+	if s.unloaded.Load() {
+		writeError(w, http.StatusNotFound, "model not available")
+		return
+	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, 10<<20) // 10 MB
 	var req EmbeddingRequest

--- a/serve/model_delete_race_test.go
+++ b/serve/model_delete_race_test.go
@@ -1,0 +1,192 @@
+package serve
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zerfoo/ztensor/graph"
+	"github.com/zerfoo/ztensor/tensor"
+	"github.com/zerfoo/ztensor/types"
+)
+
+// blockingLogitsNode behaves like fixedLogitsNode but blocks on its first
+// Forward call until the test releases it. This lets a test pin a chat
+// completion request inside the model's forward pass for a controlled
+// window, so a concurrent DELETE /v1/models/{id} can be interleaved
+// deterministically instead of relying on timing luck.
+type blockingLogitsNode struct {
+	graph.NoParameters[float32]
+	vocabSize     int
+	tokenSequence []int
+	callCount     int
+	started       chan struct{}
+	release       chan struct{}
+	once          sync.Once
+}
+
+func (n *blockingLogitsNode) OpType() string                     { return "BlockingLogits" }
+func (n *blockingLogitsNode) Attributes() map[string]interface{} { return nil }
+func (n *blockingLogitsNode) OutputShape() []int                 { return []int{1, 1, n.vocabSize} }
+
+func (n *blockingLogitsNode) Backward(_ context.Context, _ types.BackwardMode, _ *tensor.TensorNumeric[float32], _ ...*tensor.TensorNumeric[float32]) ([]*tensor.TensorNumeric[float32], error) {
+	return nil, nil
+}
+
+func (n *blockingLogitsNode) Forward(_ context.Context, inputs ...*tensor.TensorNumeric[float32]) (*tensor.TensorNumeric[float32], error) {
+	n.once.Do(func() {
+		close(n.started)
+		<-n.release
+	})
+
+	seqLen := 1
+	if len(inputs) > 0 {
+		shape := inputs[0].Shape()
+		if len(shape) >= 2 {
+			seqLen = shape[1]
+		}
+	}
+	data := make([]float32, seqLen*n.vocabSize)
+	for pos := range seqLen {
+		targetToken := n.tokenSequence[n.callCount%len(n.tokenSequence)]
+		offset := pos * n.vocabSize
+		for j := range n.vocabSize {
+			data[offset+j] = -10.0
+		}
+		if targetToken >= 0 && targetToken < n.vocabSize {
+			data[offset+targetToken] = 10.0
+		}
+		if pos == seqLen-1 {
+			n.callCount++
+		}
+	}
+	return tensor.New([]int{1, seqLen, n.vocabSize}, data)
+}
+
+// TestModelDelete_DrainsInFlightRequest_NoUseAfterClose is a regression test
+// for CONC-H2: serve/handlers.go used to call s.inflight.Add(1) at handler
+// entry with no recheck of s.unloaded, racing DELETE /v1/models/{id}'s
+// s.unloaded.Store(true) -> s.inflight.Wait() -> s.model.Close() sequence.
+// A request could Add(1) after Wait() had already returned (use-after-close
+// on the now-closed model), or Add(1) could land exactly as the WaitGroup
+// counter transitioned 1->0 during Wait (WaitGroup misuse panic).
+//
+// This test pins a chat completion request inside the model's forward pass
+// (holding the handler's RLock), fires a concurrent delete, and asserts:
+//   - the delete cannot proceed past acquiring the write lock until the
+//     in-flight request finishes (drain semantics preserved),
+//   - the in-flight request completes successfully against the still-open
+//     model (no use-after-close),
+//   - the delete succeeds afterward with no panic anywhere in the chain.
+func TestModelDelete_DrainsInFlightRequest_NoUseAfterClose(t *testing.T) {
+	node := &blockingLogitsNode{
+		vocabSize:     8,
+		tokenSequence: []int{6, 7, 2}, // foo, bar, EOS
+		started:       make(chan struct{}),
+		release:       make(chan struct{}),
+	}
+	mdl := buildModelWithNode(t, node)
+	srv := NewServer(mdl)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	chatDone := make(chan struct{})
+	var chatStatus int
+	go func() {
+		defer close(chatDone)
+		resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json",
+			`{"model":"test-model","messages":[{"role":"user","content":"hi"}]}`)
+		chatStatus = resp.StatusCode
+		_ = resp.Body.Close()
+	}()
+
+	select {
+	case <-node.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for chat completion to enter the forward pass")
+	}
+
+	deleteDone := make(chan struct{})
+	var deleteStatus int
+	go func() {
+		defer close(deleteDone)
+		resp := doDelete(t, ts.URL+"/v1/models/test-model")
+		deleteStatus = resp.StatusCode
+		_ = resp.Body.Close()
+	}()
+
+	// The delete must not be able to complete while the chat request still
+	// holds the model RLock — this is the drain guarantee CONC-H2 broke.
+	select {
+	case <-deleteDone:
+		t.Fatal("delete completed before the in-flight chat request finished draining")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(node.release)
+
+	select {
+	case <-chatDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for chat completion to finish")
+	}
+	if chatStatus != http.StatusOK {
+		t.Errorf("chat completion status = %d, want 200 (must observe the model before close, not after)", chatStatus)
+	}
+
+	select {
+	case <-deleteDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for delete to finish")
+	}
+	if deleteStatus != http.StatusOK {
+		t.Errorf("delete status = %d, want 200", deleteStatus)
+	}
+}
+
+// TestConcurrentDeleteAndChatCompletions_NoRace hammers a server with many
+// concurrent chat completion requests racing a single model delete. Under
+// the old sync.WaitGroup-based implementation this could either panic with
+// "sync: WaitGroup misuse: Add called concurrently with Wait" (caught by
+// recoveryMiddleware and surfaced as a 500) or let a request proceed against
+// a closed model. With the RWMutex-based fix, every response must be either
+// 200 (request won the race and ran against the still-open model) or 404
+// (request lost the race to the delete) — never a 500, and no data race
+// under `go test -race`.
+func TestConcurrentDeleteAndChatCompletions_NoRace(t *testing.T) {
+	mdl := buildTestModel(t)
+	srv := NewServer(mdl)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	const n = 50
+	statuses := make([]int, n)
+
+	var wg sync.WaitGroup
+	wg.Add(n + 1)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json",
+				`{"model":"test-model","messages":[{"role":"user","content":"hi"}]}`)
+			statuses[i] = resp.StatusCode
+			_ = resp.Body.Close()
+		}(i)
+	}
+	go func() {
+		defer wg.Done()
+		resp := doDelete(t, ts.URL+"/v1/models/test-model")
+		_ = resp.Body.Close()
+	}()
+
+	wg.Wait()
+
+	for i, status := range statuses {
+		if status != http.StatusOK && status != http.StatusNotFound {
+			t.Errorf("request %d: status = %d, want 200 or 404 (500 would indicate a recovered panic from the raced delete)", i, status)
+		}
+	}
+}

--- a/serve/server.go
+++ b/serve/server.go
@@ -26,15 +26,20 @@ var openapiSpec []byte
 
 // Server wraps a loaded model and serves OpenAI-compatible HTTP endpoints.
 type Server struct {
-	model           *inference.Model
-	draftModel      *inference.Model // optional; enables speculative decoding
-	mux             *http.ServeMux
-	batch           *BatchScheduler // optional; nil means direct calls
-	unloaded        atomic.Bool     // true after DELETE /v1/models/:id
-	inflight        sync.WaitGroup  // tracks in-flight inference requests
-	transcriber     Transcriber     // optional; enables /v1/audio/transcriptions
-	classifier      Classifier      // optional; enables /v1/classify
-	guardEvaluator  GuardEvaluator  // optional; enables /v1/guard endpoints
+	model      *inference.Model
+	draftModel *inference.Model // optional; enables speculative decoding
+	mux        *http.ServeMux
+	batch      *BatchScheduler // optional; nil means direct calls
+	unloaded   atomic.Bool     // true after DELETE /v1/models/:id
+	// modelMu serializes handler access to model against DELETE /v1/models/:id.
+	// Handlers that touch the model take RLock for the duration of their work;
+	// delete takes Lock before flipping unloaded and closing the model. This
+	// makes both the use-after-close and the "Add after Wait started" races
+	// structurally impossible (see CONC-H2).
+	modelMu         sync.RWMutex
+	transcriber     Transcriber    // optional; enables /v1/audio/transcriptions
+	classifier      Classifier     // optional; enables /v1/classify
+	guardEvaluator  GuardEvaluator // optional; enables /v1/guard endpoints
 	logger          log.Logger
 	metrics         *ServerMetrics
 	classifyMetrics *ClassifyMetrics


### PR DESCRIPTION
## Summary
- CONC-H2 (deep-review 002): serve/handlers.go handlers called s.inflight.Add(1) unconditionally at entry with no recheck of s.unloaded, racing DELETE /v1/models/{id}'s unloaded.Store(true) -> inflight.Wait() -> model.Close() sequence. A request could Add(1) after Wait() had already returned (use-after-close on the closed model), or land exactly as the WaitGroup counter transitioned 1->0 during Wait (panic: sync: WaitGroup misuse: Add called concurrently with Wait).
- Replaced the Add/Wait/Close WaitGroup pattern with an RWMutex (Server.modelMu): every handler that touches the model takes RLock for the duration of its work and rechecks unloaded once inside the lock; delete takes Lock before flipping unloaded and closing. Both interleavings are now structurally impossible rather than depending on a fast-enough recheck.
- The fix applies to all seven call sites that shared the drain guarantee: chat completions, completions, embeddings (handlers.go), the three guard endpoints (guard.go), and classify (classify.go) -- the review only enumerated handlers.go:19,172,343, but all of them shared the same s.inflight WaitGroup and were exposed to the identical race.

## Test plan
- TestModelDelete_DrainsInFlightRequest_NoUseAfterClose -- pins a chat completion inside the model's forward pass (blocking node), fires a concurrent delete, and asserts the delete cannot complete until the in-flight request drains, the in-flight request still succeeds (200, not a closed model), and delete then succeeds.
- TestConcurrentDeleteAndChatCompletions_NoRace -- 50 concurrent chat completions racing one delete; asserts every response is 200 or 404, never a 500 (which would indicate a recovered panic).
- go test -race -count=1 ./serve/... green.
- gofmt -l and go vet ./serve/... clean on touched files.