### PR TITLE
fix(gguf): check-before-multiply on tensor element-count overflow (F1, T139.1)

### DIFF
--- a/model/gguf/loader.go
+++ b/model/gguf/loader.go
@@ -26,6 +26,44 @@ func isEmbeddingShape(shape []int) bool {
 	return len(shape) == 2 && shape[0] > embeddingVocabThreshold
 }
 
+// maxTensorElements is the element-count cap enforced during GGUF tensor
+// loading. It bounds the allocation size computed from file-controlled
+// dimensions so a corrupt or malicious file cannot force an oversized (or,
+// via overflow, negative) allocation.
+const maxTensorElements = 1 << 34
+
+// computeNumElements multiplies a tensor's GGUF dimensions into a total
+// element count, validating each dimension and checking for int64 overflow
+// BEFORE multiplying rather than after.
+//
+// This ordering matters: the previous implementation (duplicated across four
+// call sites) multiplied first and then checked "numElements > maxTensorElements",
+// which has two bugs. First, the running product can land on exactly
+// maxTensorElements (not rejected by a strict ">"), after which a further
+// dimension multiply overflows int64 to a negative value that also fails the
+// "> maxTensorElements" test -- so the negative element count silently passes
+// validation and later panics deep in allocation code. Second, checking after
+// the multiply means the overflow has already happened by the time it is
+// detected. Checking "numElements > maxTensorElements/d" before multiplying
+// makes the overflow structurally impossible to reach (deep-review 002,
+// finding F1).
+func computeNumElements(name string, dimensions []uint64) (int64, error) {
+	var numElements int64 = 1
+	for _, d := range dimensions {
+		if d == 0 {
+			return 0, fmt.Errorf("tensor %q: zero dimension is not allowed", name)
+		}
+		if d > math.MaxInt32 {
+			return 0, fmt.Errorf("tensor %q: dimension %d exceeds maximum (%d)", name, d, int64(math.MaxInt32))
+		}
+		if numElements > maxTensorElements/int64(d) {
+			return 0, fmt.Errorf("tensor %q: total elements exceeds maximum (%d)", name, int64(maxTensorElements))
+		}
+		numElements *= int64(d)
+	}
+	return numElements, nil
+}
+
 // pleNativeKQuantEnabled reports whether ZERFOO_GEMMA4_PLE_NATIVE_Q4K=1 is set.
 // When enabled, Q4_K / Q5_K / Q6_K embedding-shaped tensors keep their native
 // K-quant storage instead of being re-quantized to Q4_0 at load time.
@@ -52,15 +90,9 @@ func LoadTensors(f *File, r io.ReadSeeker) (map[string]*tensor.TensorNumeric[flo
 		ti := &f.Tensors[i]
 
 		// Compute number of elements with overflow checks.
-		var numElements int64 = 1
-		for _, d := range ti.Dimensions {
-			if d > math.MaxInt32 {
-				return nil, fmt.Errorf("tensor %q: dimension %d exceeds maximum (%d)", ti.Name, d, int64(math.MaxInt32))
-			}
-			numElements *= int64(d)
-			if numElements > 1<<34 {
-				return nil, fmt.Errorf("tensor %q: total elements %d exceeds maximum (%d)", ti.Name, numElements, int64(1<<34))
-			}
+		numElements, err := computeNumElements(ti.Name, ti.Dimensions)
+		if err != nil {
+			return nil, err
 		}
 
 		// Convert dimensions to int for tensor API.

--- a/model/gguf/loader_mmap.go
+++ b/model/gguf/loader_mmap.go
@@ -2,7 +2,6 @@ package gguf
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/zerfoo/ztensor/tensor"
 )
@@ -21,15 +20,9 @@ func LoadTensorsMmap(f *File, mapped []byte) (map[string]*tensor.TensorNumeric[f
 		ti := &f.Tensors[i]
 
 		// Compute number of elements with overflow checks.
-		var numElements int64 = 1
-		for _, d := range ti.Dimensions {
-			if d > math.MaxInt32 {
-				return nil, fmt.Errorf("tensor %q: dimension %d exceeds maximum (%d)", ti.Name, d, int64(math.MaxInt32))
-			}
-			numElements *= int64(d)
-			if numElements > 1<<34 {
-				return nil, fmt.Errorf("tensor %q: total elements %d exceeds maximum (%d)", ti.Name, numElements, int64(1<<34))
-			}
+		numElements, err := computeNumElements(ti.Name, ti.Dimensions)
+		if err != nil {
+			return nil, err
 		}
 
 		// Convert dimensions to int for tensor API.

--- a/model/gguf/overflow_test.go
+++ b/model/gguf/overflow_test.go
@@ -1,0 +1,229 @@
+package gguf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// attackDimensions is the exact tensor shape from deep-review 002, finding F1:
+// two dimensions that multiply to exactly 1<<34 (passing the old strict ">"
+// cap check), followed by a third dimension whose multiply overflows int64
+// to a negative value that also passes "> 1<<34". Every call site must
+// reject this shape with an error instead of computing a negative element
+// count that later panics in allocation code.
+var attackDimensions = []uint64{131072, 131072, 2147483647}
+
+// TestComputeNumElements_AttackShape verifies the shared helper rejects the
+// F1 attack shape directly, and does so BEFORE the overflow would occur
+// (i.e. it must not rely on ever observing a negative product).
+func TestComputeNumElements_AttackShape(t *testing.T) {
+	n, err := computeNumElements("test.attack", attackDimensions)
+	if err == nil {
+		t.Fatalf("expected error for attack shape, got numElements=%d", n)
+	}
+	if n != 0 {
+		t.Errorf("numElements = %d on error, want 0", n)
+	}
+}
+
+// TestComputeNumElements_ExactCapBoundary verifies the check-before-multiply
+// rewrite still allows a legitimate product that lands exactly on the cap
+// (1<<34), which is the boundary the old strict ">" check also allowed --
+// confirming the new predicate is not stricter than necessary.
+func TestComputeNumElements_ExactCapBoundary(t *testing.T) {
+	n, err := computeNumElements("test.exact_cap", []uint64{131072, 131072})
+	if err != nil {
+		t.Fatalf("computeNumElements: unexpected error at exact cap: %v", err)
+	}
+	if n != 1<<34 {
+		t.Errorf("numElements = %d, want %d", n, int64(1<<34))
+	}
+}
+
+// TestComputeNumElements_OneOverCap verifies a product one element over the
+// cap is rejected.
+func TestComputeNumElements_OneOverCap(t *testing.T) {
+	_, err := computeNumElements("test.over_cap", []uint64{131072, 131073})
+	if err == nil {
+		t.Fatal("expected error for total elements > 1<<34")
+	}
+}
+
+// TestComputeNumElements_ZeroDimension verifies a zero-sized dimension is
+// rejected rather than silently collapsing the tensor to zero elements.
+func TestComputeNumElements_ZeroDimension(t *testing.T) {
+	_, err := computeNumElements("test.zero_dim", []uint64{4096, 0})
+	if err == nil {
+		t.Fatal("expected error for zero dimension")
+	}
+}
+
+// TestComputeNumElements_DimensionExceedsMaxInt32 verifies a single dimension
+// above math.MaxInt32 is rejected.
+func TestComputeNumElements_DimensionExceedsMaxInt32(t *testing.T) {
+	_, err := computeNumElements("test.huge_dim", []uint64{1 << 32})
+	if err == nil {
+		t.Fatal("expected error for dimension exceeding MaxInt32")
+	}
+}
+
+// TestComputeNumElements_LegitimateShapes is a table test of realistic
+// tensor shapes drawn from common model architectures. None of these should
+// be affected by the check-before-multiply rewrite -- the new predicate is
+// strictly tighter than the old one only at the two failure modes above, and
+// every shape here stays comfortably under the cap.
+func TestComputeNumElements_LegitimateShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		dimensions []uint64
+		want       int64
+	}{
+		{"scalar (rank 0)", []uint64{}, 1},
+		{"1D bias", []uint64{4096}, 4096},
+		{"small dense weight", []uint64{4096, 4096}, 4096 * 4096},
+		{"attention qkv proj", []uint64{4096, 12288}, 4096 * 12288},
+		{"ffn up proj", []uint64{4096, 14336}, 4096 * 14336},
+		{"llama-3 vocab embedding", []uint64{128256, 4096}, 128256 * 4096},
+		{"gemma-4-edge PLE embedding", []uint64{262144, 256}, 262144 * 256},
+		{"3D conv-like kernel", []uint64{64, 3, 3}, 64 * 3 * 3},
+		{"large single dim near MaxInt32", []uint64{1 << 20}, 1 << 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := computeNumElements("test."+tt.name, tt.dimensions)
+			if err != nil {
+				t.Fatalf("computeNumElements: unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("numElements = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadTensors_AttackShape confirms the LoadTensors (heap, single-file)
+// call site returns an error -- not a panic -- for the exact F1 attack
+// shape.
+func TestLoadTensors_AttackShape(t *testing.T) {
+	tensors := []TensorInfo{{
+		Name:       "test.attack",
+		Dimensions: attackDimensions,
+		Type:       GGMLTypeF32,
+		Offset:     0,
+	}}
+	r := buildGGUFWithTensors(t, tensors, nil)
+	f, err := Parse(r)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Fatalf("LoadTensors panicked instead of returning an error: %v", rec)
+		}
+	}()
+
+	_, err = LoadTensors(f, r)
+	if err == nil {
+		t.Fatal("expected error for F1 attack shape, got nil")
+	}
+}
+
+// TestLoadTensorsMmap_AttackShape confirms the LoadTensorsMmap call site
+// (the default mmap load path) returns an error -- not a panic -- for the
+// exact F1 attack shape.
+func TestLoadTensorsMmap_AttackShape(t *testing.T) {
+	gf := &File{
+		DataOffset: 0,
+		Tensors: []TensorInfo{{
+			Name:       "test.attack",
+			Dimensions: attackDimensions,
+			Type:       GGMLTypeF32,
+			Offset:     0,
+		}},
+	}
+	mapped := make([]byte, 64)
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Fatalf("LoadTensorsMmap panicked instead of returning an error: %v", rec)
+		}
+	}()
+
+	_, err := LoadTensorsMmap(gf, mapped)
+	if err == nil {
+		t.Fatal("expected error for F1 attack shape, got nil")
+	}
+}
+
+// TestLoadTensorsMmapSplit_AttackShape confirms the split-file mmap load
+// site returns an error -- not a panic -- for the exact F1 attack shape.
+func TestLoadTensorsMmapSplit_AttackShape(t *testing.T) {
+	shard := &File{DataOffset: 0}
+	sf := &SplitFile{
+		File: &File{
+			Tensors: []TensorInfo{{
+				Name:       "test.attack",
+				Dimensions: attackDimensions,
+				Type:       GGMLTypeF32,
+				Offset:     0,
+			}},
+		},
+		Shards:     []*File{shard},
+		ShardIndex: map[string]int{"test.attack": 0},
+	}
+	mappedShards := [][]byte{make([]byte, 64)}
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Fatalf("LoadTensorsMmapSplit panicked instead of returning an error: %v", rec)
+		}
+	}()
+
+	_, err := LoadTensorsMmapSplit(sf, mappedShards)
+	if err == nil {
+		t.Fatal("expected error for F1 attack shape, got nil")
+	}
+}
+
+// TestLoadTensorsSplit_AttackShape confirms the split-file heap load site
+// returns an error -- not a panic -- for the exact F1 attack shape.
+func TestLoadTensorsSplit_AttackShape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shard0.gguf")
+	if err := os.WriteFile(path, make([]byte, 64), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	shard := &File{DataOffset: 0}
+	sf := &SplitFile{
+		File: &File{
+			Tensors: []TensorInfo{{
+				Name:       "test.attack",
+				Dimensions: attackDimensions,
+				Type:       GGMLTypeF32,
+				Offset:     0,
+			}},
+		},
+		Shards:     []*File{shard},
+		ShardIndex: map[string]int{"test.attack": 0},
+	}
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Fatalf("LoadTensorsSplit panicked instead of returning an error: %v", rec)
+		}
+	}()
+
+	_, err = LoadTensorsSplit(sf, []*os.File{r})
+	if err == nil {
+		t.Fatal("expected error for F1 attack shape, got nil")
+	}
+}

--- a/model/gguf/split_file.go
+++ b/model/gguf/split_file.go
@@ -2,7 +2,6 @@ package gguf
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -147,15 +146,9 @@ func LoadTensorsMmapSplit(sf *SplitFile, mappedShards [][]byte) (map[string]*ten
 		shard := sf.Shards[shardIdx]
 		mapped := mappedShards[shardIdx]
 
-		var numElements int64 = 1
-		for _, d := range ti.Dimensions {
-			if d > math.MaxInt32 {
-				return nil, fmt.Errorf("tensor %q: dimension %d exceeds maximum (%d)", ti.Name, d, int64(math.MaxInt32))
-			}
-			numElements *= int64(d)
-			if numElements > 1<<34 {
-				return nil, fmt.Errorf("tensor %q: total elements %d exceeds maximum (%d)", ti.Name, numElements, int64(1<<34))
-			}
+		numElements, err := computeNumElements(ti.Name, ti.Dimensions)
+		if err != nil {
+			return nil, err
 		}
 
 		shape := make([]int, len(ti.Dimensions))
@@ -216,15 +209,9 @@ func LoadTensorsSplit(sf *SplitFile, readers []*os.File) (map[string]*tensor.Ten
 		shard := sf.Shards[shardIdx]
 		r := readers[shardIdx]
 
-		var numElements int64 = 1
-		for _, d := range ti.Dimensions {
-			if d > math.MaxInt32 {
-				return nil, fmt.Errorf("tensor %q: dimension %d exceeds maximum", ti.Name, d)
-			}
-			numElements *= int64(d)
-			if numElements > 1<<34 {
-				return nil, fmt.Errorf("tensor %q: total elements %d exceeds maximum", ti.Name, numElements)
-			}
+		numElements, err := computeNumElements(ti.Name, ti.Dimensions)
+		if err != nil {
+			return nil, err
 		}
 
 		shape := make([]int, len(ti.Dimensions))


### PR DESCRIPTION
## Summary

Fixes F1 from deep-review 002 (`docs/deep-reviews/002-full-codebase.md`): a GGUF element-count integer-overflow that bypasses the size cap and can crash any process loading a malicious/corrupt model file.

- The overflow guard duplicated across four call sites (`model/gguf/loader.go`, `loader_mmap.go`, `split_file.go` x2) multiplied dimensions into `numElements` and only checked `numElements > 1<<34` *after* the multiply, using strict `>`.
- A crafted tensor shape (e.g. `Dimensions = [131072, 131072, 2147483647]`) lands the running product on exactly `1<<34` (passes the strict `>` check), then a further dimension multiply overflows `int64` to a negative value that also passes the same check.
- The negative `numElements` then flows into `TensorByteSize` (which returns a negative byte size with a nil error) and into `make([]byte, negativeSize)`, which panics with `makeslice: len out of range`.

## Fix

Extracted the four duplicated loops into one shared `computeNumElements(name string, dimensions []uint64) (int64, error)` helper (`model/gguf/loader.go`) that:
- rejects a zero dimension,
- rejects a dimension exceeding `math.MaxInt32`,
- checks `numElements > maxTensorElements/d` **before** multiplying, so the overflow is structurally unreachable.

All four call sites (`LoadTensors`, `LoadTensorsMmap`, `LoadTensorsMmapSplit`, `LoadTensorsSplit`) now call the shared helper instead of duplicating the loop.

## Test plan

- [x] `TestComputeNumElements_AttackShape` -- the exact F1 attack shape (`[131072, 131072, 2147483647]`) returns an error from the shared helper.
- [x] `TestLoadTensors_AttackShape`, `TestLoadTensorsMmap_AttackShape`, `TestLoadTensorsMmapSplit_AttackShape`, `TestLoadTensorsSplit_AttackShape` -- the attack shape returns an error (not a panic, verified via `recover()`) at all four call sites.
- [x] `TestComputeNumElements_ExactCapBoundary` -- a legitimate product landing exactly on `1<<34` still passes (predicate is not stricter than necessary).
- [x] `TestComputeNumElements_LegitimateShapes` -- table test of realistic tensor shapes (dense weights, attention/FFN projections, vocab/PLE embeddings, 3D kernels, scalar/1D tensors) all pass unchanged.
- [x] `TestComputeNumElements_ZeroDimension`, `TestComputeNumElements_OneOverCap`, `TestComputeNumElements_DimensionExceedsMaxInt32` -- new rejection paths.
- [x] Existing regression tests (`TestLoadTensors_DimensionExceedsMaxInt32`, `TestLoadTensors_TotalElementsOverflow`, `TestLoadTensors_ValidLargeDimensions`) still pass unchanged.
- [x] `gofmt -l` clean on all touched files; `go vet ./model/gguf/...` clean.
- [x] `go test ./model/...` green; `go build ./...` green.

Does not merge -- opening for review per T139.1.
