### PR TITLE
fix(distributed): wire mTLS into worker gRPC server, refuse non-loopback without TLS (DIST-1, T140.1)

### DIFF
--- a/distributed/worker_node.go
+++ b/distributed/worker_node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 
 	"github.com/zerfoo/zerfoo/serve/health"
@@ -21,6 +22,11 @@ type WorkerNodeConfig struct {
 	Logger             log.Logger
 	Collector          metrics.Collector
 	HealthServer       *health.Server
+	// TLS, when set, secures the worker's own gRPC server (mutual TLS via
+	// TLSConfig.ServerCredentials) and the worker's outbound connection to
+	// the coordinator (via TLSConfig.ClientCredentials). When nil, Start
+	// refuses to bind any non-loopback WorkerAddress -- see isLoopback.
+	TLS *TLSConfig
 }
 
 // WorkerNode encapsulates a distributed training worker. It manages
@@ -61,7 +67,18 @@ func (wn *WorkerNode) Start(_ context.Context) error {
 		return errors.New("worker node already started")
 	}
 
-	srv := grpc.NewServer()
+	var opts []grpc.ServerOption
+	if wn.config.TLS != nil {
+		creds, err := wn.config.TLS.ServerCredentials()
+		if err != nil {
+			return fmt.Errorf("worker tls: %w", err)
+		}
+		opts = append(opts, grpc.Creds(creds))
+	} else if !isLoopback(wn.config.WorkerAddress) {
+		return errors.New("worker: refusing non-loopback bind without TLS; set TLS or bind 127.0.0.1")
+	}
+
+	srv := grpc.NewServer(opts...)
 	sm := NewServerManager(srv, nil)
 	nm := NewNetworkManager(nil, nil)
 
@@ -71,6 +88,7 @@ func (wn *WorkerNode) Start(_ context.Context) error {
 		NetworkManager: nm,
 		Logger:         wn.config.Logger,
 		Collector:      wn.config.Collector,
+		TLS:            wn.config.TLS,
 	})
 
 	if err := strategy.Init(0, wn.config.WorldSize, wn.config.CoordinatorAddress); err != nil {
@@ -161,3 +179,35 @@ var _ InternalStrategy[float32] = (*GrpcStrategy[float32])(nil)
 
 // Generic type alias for external use.
 type NumericStrategy[T tensor.Numeric] = InternalStrategy[T]
+
+// isLoopback reports whether addr's host is restricted to the local loopback
+// interface (127.0.0.0/8 or ::1), including the "localhost" hostname. Any
+// other host -- a routable IP, a non-loopback hostname, or an empty host
+// (e.g. ":9001", which binds all interfaces) -- is treated as non-loopback
+// and fails closed by returning false.
+func isLoopback(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// No "host:port" structure found (e.g. a bare host); fall back to
+		// treating the whole string as the host.
+		host = addr
+	}
+
+	if host == "" {
+		// ":PORT" binds every interface, which is not loopback.
+		return false
+	}
+
+	if host == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Unresolved/non-IP hostname: fail closed rather than guess whether
+		// it resolves to loopback.
+		return false
+	}
+
+	return ip.IsLoopback()
+}

--- a/distributed/worker_node_tls_test.go
+++ b/distributed/worker_node_tls_test.go
@@ -1,0 +1,170 @@
+package distributed_test
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zerfoo/zerfoo/distributed"
+	"github.com/zerfoo/zerfoo/distributed/coordinator"
+	"github.com/zerfoo/zerfoo/distributed/pb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// reserveLoopbackAddr grabs an ephemeral loopback port, returns its address
+// string, and releases the listener so the caller (typically a WorkerNode)
+// can rebind it.
+func reserveLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve loopback address: %v", err)
+	}
+	addr := lis.Addr().String()
+	if err := lis.Close(); err != nil {
+		t.Fatalf("failed to release reserved listener: %v", err)
+	}
+	return addr
+}
+
+// TestWorkerNode_Start_RefusesNonLoopbackWithoutTLS is DIST-1 regression
+// coverage: a worker bound to a routable (non-loopback) address with no TLS
+// configuration must refuse to start rather than run an unauthenticated
+// gRPC server. The refusal must happen before any coordinator dial is
+// attempted -- there is no reachable coordinator in this test, so a slow
+// failure would indicate the check fired too late (e.g. after a 10s
+// registration timeout) rather than up front.
+func TestWorkerNode_Start_RefusesNonLoopbackWithoutTLS(t *testing.T) {
+	wn := distributed.NewWorkerNode(distributed.WorkerNodeConfig{
+		WorkerAddress:      "0.0.0.0:0",
+		CoordinatorAddress: "127.0.0.1:1", // deliberately unreachable; must never be dialed
+		WorldSize:          1,
+	})
+
+	start := time.Now()
+	err := wn.Start(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected Start to refuse a non-loopback bind without TLS, got nil error")
+	}
+	if !strings.Contains(err.Error(), "refusing non-loopback bind without TLS") {
+		t.Errorf("Start() error = %q, want it to mention refusing a non-loopback bind without TLS", err.Error())
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Start() took %v to refuse; expected an immediate rejection before any coordinator dial", elapsed)
+	}
+	if wn.Rank() != -1 {
+		t.Error("expected worker to remain unstarted after a refused Start")
+	}
+}
+
+// TestWorkerNode_Start_LoopbackWithoutTLS_Starts is DIST-1 regression
+// coverage: single-host / dev usage (loopback bind, no TLS configured) must
+// keep working exactly as before this fix.
+func TestWorkerNode_Start_LoopbackWithoutTLS_Starts(t *testing.T) {
+	coord := coordinator.NewCoordinator(&syncWriter{}, 30*time.Second)
+	if err := coord.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	t.Cleanup(coord.GracefulStop)
+
+	workerAddr := reserveLoopbackAddr(t)
+
+	wn := distributed.NewWorkerNode(distributed.WorkerNodeConfig{
+		WorkerAddress:      workerAddr,
+		CoordinatorAddress: coord.Addr().String(),
+		WorldSize:          1,
+	})
+
+	if err := wn.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v, want nil for a loopback bind without TLS", err)
+	}
+	t.Cleanup(func() { _ = wn.Close(context.Background()) })
+
+	if wn.Rank() != 0 {
+		t.Errorf("Rank() = %d, want 0 for the sole registered worker", wn.Rank())
+	}
+}
+
+// TestWorkerNode_Start_TLS_AcceptsValidClientCert is DIST-1 regression
+// coverage for the mTLS path: a worker configured with TLS starts its gRPC
+// server with server credentials wired in, and a client presenting a cert
+// signed by the configured CA is accepted. A client with no credentials at
+// all must be rejected, proving the credentials are actually enforced
+// rather than silently optional.
+func TestWorkerNode_Start_TLS_AcceptsValidClientCert(t *testing.T) {
+	dir := t.TempDir()
+	caCert, cert, key := distributed.GenerateTestCerts(t, dir)
+
+	tlsCfg := &distributed.TLSConfig{
+		CACertPath: caCert,
+		CertPath:   cert,
+		KeyPath:    key,
+	}
+
+	coordCreds, err := tlsCfg.ServerCredentials()
+	if err != nil {
+		t.Fatalf("coordinator server credentials: %v", err)
+	}
+	coord := coordinator.NewCoordinator(&syncWriter{}, 30*time.Second)
+	coord.SetServerOptions(grpc.Creds(coordCreds))
+	if err := coord.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	t.Cleanup(coord.GracefulStop)
+
+	workerAddr := reserveLoopbackAddr(t)
+
+	wn := distributed.NewWorkerNode(distributed.WorkerNodeConfig{
+		WorkerAddress:      workerAddr,
+		CoordinatorAddress: coord.Addr().String(),
+		WorldSize:          1,
+		TLS:                tlsCfg,
+	})
+
+	if err := wn.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v, want nil for a TLS-configured worker", err)
+	}
+	t.Cleanup(func() { _ = wn.Close(context.Background()) })
+
+	clientCreds, err := tlsCfg.ClientCredentials()
+	if err != nil {
+		t.Fatalf("client credentials: %v", err)
+	}
+
+	t.Run("valid client cert is accepted", func(t *testing.T) {
+		conn, err := grpc.NewClient(workerAddr, grpc.WithTransportCredentials(clientCreds))
+		if err != nil {
+			t.Fatalf("grpc.NewClient: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		client := pb.NewDistributedServiceClient(conn)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if _, err := client.Barrier(ctx, &pb.BarrierRequest{Rank: 0}); err != nil {
+			t.Errorf("Barrier() with a valid client cert: %v, want nil", err)
+		}
+	})
+
+	t.Run("unauthenticated client is rejected", func(t *testing.T) {
+		conn, err := grpc.NewClient(workerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			t.Fatalf("grpc.NewClient: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		client := pb.NewDistributedServiceClient(conn)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if _, err := client.Barrier(ctx, &pb.BarrierRequest{Rank: 0}); err == nil {
+			t.Error("Barrier() with no client credentials succeeded; want the mTLS handshake to reject it")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes DIST-1 from `docs/deep-reviews/002-full-codebase.md`: `distributed/worker_node.go` created its gRPC server with `grpc.NewServer()` and zero options, so the worker's `AllReduce`/`Barrier`/`Broadcast` service accepted unauthenticated, unencrypted connections from any host that could reach the bound address. The mTLS builder in `distributed/tlsconfig.go` (`ServerCredentials`/`ClientCredentials`, `RequireAndVerifyClientCert`) was correct but had no caller anywhere in the codebase.
- `WorkerNodeConfig` gains a `TLS *TLSConfig` field. When set, `Start()` wires `TLSConfig.ServerCredentials()` into the worker's own `grpc.NewServer()` via `grpc.Creds(...)`, and threads the same config into `GrpcStrategyConfig.TLS` (a previously-dead field) so the worker's outbound connection to the coordinator also uses `TLSConfig.ClientCredentials()` instead of the `insecure.NewCredentials()` fallback.
- When `TLS` is nil, `Start()` now refuses to bind a non-loopback `WorkerAddress`, via a new `isLoopback(addr string) bool` helper (checks `127.0.0.0/8`, `::1`, and the `localhost` hostname; a bind-all address like `0.0.0.0:9001` or an empty host like `:9001` fails closed). Loopback binds without TLS keep working unchanged for single-host dev use, per ADR-094 rule 3 ("the distributed wire fails closed, not open").

## Scope

This PR is T140.1 only (the worker's own gRPC server + the config plumbing needed to make TLS wiring possible). Deliberately left for follow-up tasks:
- **T140.2**: `cmd/cli/worker.go` `--tls-cert`/`--tls-key`/`--tls-ca` flags, and updating the shipped example/default away from `0.0.0.0:9001` to a loopback default. Note: with this PR merged, that example would now fail to start (by design, per the fail-closed policy) until T140.2 adds the flags or the example is updated to loopback.
- **T140.3**: the coordinator's separate auth gap (DIST-2) is untouched; the coordinator already exposes `SetServerOptions` for TLS creds (used in existing tests), but nothing wires it by default.

## Test plan

- [x] New tests in `distributed/worker_node_tls_test.go`:
  - `TestWorkerNode_Start_RefusesNonLoopbackWithoutTLS` -- a `0.0.0.0:0` bind with no TLS config refuses to start with a clear error, and fails fast (before any coordinator dial -- verified via elapsed time and an intentionally unreachable coordinator address).
  - `TestWorkerNode_Start_LoopbackWithoutTLS_Starts` -- a loopback bind with no TLS config still starts against a real coordinator, unchanged from prior behavior.
  - `TestWorkerNode_Start_TLS_AcceptsValidClientCert` -- a TLS-configured worker (self-signed test CA generated via the existing `distributed.GenerateTestCerts` helper) starts, accepts a client presenting a cert signed by the configured CA (`Barrier` RPC succeeds), and rejects a client with no credentials at all (`Barrier` RPC fails).
- [x] `go test ./distributed/... -run 'TestWorkerNode|TestTLSConfig|TestMultiWorkerAllReduce_TLS' -v` -- all pass.
- [x] `go test ./distributed/... -p 1` -- green (see note below).
- [x] `gofmt -l` and `go vet ./distributed/...` clean on changed files.
- [x] `go build ./...` -- clean.

Note: `distributed/coordinator`'s `TestReaper_TimesOutWorker` is a pre-existing timing-sensitive flake unrelated to this change -- it intermittently fails only when run with default package-level parallelism alongside the ~33s `distributed` package suite (confirmed reproducible on `main` before this change too, and consistently green under `-p 1`).