### PR TITLE
fix(inference): serialize SpeculativeGenerate through the graph mutex (CONC-H1, T142.1)

### DIFF
--- a/generate/generator.go
+++ b/generate/generator.go
@@ -252,6 +252,16 @@ func NewGenerator[T tensor.Numeric](
 // Graph returns the underlying computation graph.
 func (gen *Generator[T]) Graph() *graph.Graph[T] { return gen.graph }
 
+// LockGraph acquires the generator's graph mutex. The graph is not
+// concurrency-safe, so any caller that runs Forward on gen.Graph() outside of
+// Generate/GenerateStream (e.g. a speculative-decode path that builds its own
+// generator over this Generator's graph) must hold this lock for the
+// duration of that work to serialize with normal generation.
+func (gen *Generator[T]) LockGraph() { gen.mu.Lock() }
+
+// UnlockGraph releases the generator's graph mutex acquired by LockGraph.
+func (gen *Generator[T]) UnlockGraph() { gen.mu.Unlock() }
+
 // PJRTPlan returns the PJRT plan, or nil if PJRT is not enabled.
 func (gen *Generator[T]) PJRTPlan() *graph.PJRTPlan[T] { return gen.pjrtPlan }
 

--- a/inference/inference.go
+++ b/inference/inference.go
@@ -869,6 +869,14 @@ func (m *Model) SpeculativeGenerate(
 		NumLayers:  m.config.NumLayers,
 	}
 
+	// The target graph is not concurrency-safe and is shared with every
+	// normal (non-speculative) generation path, which serializes on this
+	// same mutex (see generate.Generator.Generate / InferenceSession.Generate).
+	// Hold it for the whole speculative run so a concurrent normal request
+	// can't call Forward on the same graph at the same time (CONC-H1).
+	m.generator.LockGraph()
+	defer m.generator.UnlockGraph()
+
 	sg := generate.NewSpeculativeGenerator(
 		draft.generator.Graph(),
 		m.generator.Graph(),

--- a/inference/speculative_concurrency_test.go
+++ b/inference/speculative_concurrency_test.go
@@ -1,0 +1,63 @@
+package inference
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestModel_SpeculativeGenerate_ConcurrentWithNormalGenerate guards against
+// CONC-H1: SpeculativeGenerate must serialize with normal Generate on the
+// same graph mutex (generate.Generator.LockGraph/UnlockGraph), because the
+// underlying *graph.Graph is not concurrency-safe. Both m.Generate (via the
+// session pool's graphMu) and m.SpeculativeGenerate (via LockGraph) run
+// Forward on the exact same target graph/node instance here, so if the
+// speculative path ever stops taking the lock, `go test -race` will catch a
+// data race on the shared fixedLogitsNode state, and — absent -race —
+// concurrent unsynchronized Forward calls could otherwise corrupt output.
+func TestModel_SpeculativeGenerate_ConcurrentWithNormalGenerate(t *testing.T) {
+	vocabSize := 8
+	target := buildTestModel(t, vocabSize, []int{6, 7, 2})
+	draft := buildTestModel(t, vocabSize, []int{6, 7, 2})
+
+	const iterations = 20
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, iterations*2)
+	resCh := make(chan string, iterations*2)
+
+	for range iterations {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			res, err := target.Generate(context.Background(), "hello world",
+				WithTemperature(0), WithMaxTokens(10))
+			errCh <- err
+			resCh <- res
+		}()
+
+		go func() {
+			defer wg.Done()
+			res, err := target.SpeculativeGenerate(context.Background(), draft, "hello world", 4,
+				WithTemperature(0), WithMaxTokens(10))
+			errCh <- err
+			resCh <- res
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	close(resCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("unexpected error from concurrent generate: %v", err)
+		}
+	}
+	for res := range resCh {
+		if res == "" {
+			t.Errorf("expected a well-formed, non-empty generation result, got empty string")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes CONC-H1 from deep-review 002 (docs/deep-reviews/002-full-codebase.md): `Model.SpeculativeGenerate` (`inference/inference.go`) built a speculative generator over the shared target graph and called `Generate` with no lock, while every normal generation path (`Generator.Generate`, `InferenceSession.Generate`) serializes on the same graph mutex. Two concurrent requests — one speculative, one normal — could run `Forward` on the same stateful `*graph.Graph` at once, corrupting output or panicking.
- Adds `LockGraph`/`UnlockGraph` accessors on `generate.Generator[T]` wrapping its existing (previously private) mutex, and wraps `SpeculativeGenerate`'s body in that lock so it serializes with every other generation path on the target model — matching the fix sketch in the review.
- Adds a regression test (`inference/speculative_concurrency_test.go`) that runs a normal `Generate` and a `SpeculativeGenerate` concurrently under `go test -race`.

## Verification

- With the fix reverted, the new test reliably reproduces both a `go test -race` data race (on the shared graph node) and corrupted/empty output — confirming the root cause and that the test actually detects it.
- With the fix applied: `go test -race -run TestModel_SpeculativeGenerate_ConcurrentWithNormalGenerate -count=5 ./inference/` passes cleanly; `go test -race ./generate/...` is fully green.
- `gofmt -l` and `go vet ./inference/... ./generate/...` are clean for the changed files.
- Note: a full-package `go test -race ./inference/...` run is very slow in this environment independent of this change (an unrelated pre-existing fixture, `TestBuildBertGraph_BertLarge`'s `makeBertTestTensors`, takes minutes under `-race` on a loaded machine); this is not caused by or related to this fix.

## Test plan

- [x] `go test -race -run TestModel_SpeculativeGenerate_ConcurrentWithNormalGenerate -count=5 ./inference/`
- [x] `go test -race ./generate/...`
- [x] `gofmt -l` / `go vet` on changed packages