### PR TITLE
fix(registry): verify blob digest on OCI pull (OCI-1, T139.4)

### DIFF
--- a/model/registry/oci.go
+++ b/model/registry/oci.go
@@ -202,6 +202,13 @@ func (r *Registry) Pull(ctx context.Context, ref string, destPath string) error 
 		return fmt.Errorf("download blob: %w", err)
 	}
 
+	// Verify the blob content matches the requested digest before writing
+	// anything to disk. Without this check a malicious or MITM'd registry
+	// could serve arbitrary bytes for any digest.
+	if sum := sha256Digest(data); sum != ggufLayer.Digest {
+		return fmt.Errorf("oci: blob digest mismatch: got %s want %s", sum, ggufLayer.Digest)
+	}
+
 	if err := os.WriteFile(destPath, data, 0o600); err != nil {
 		return fmt.Errorf("write model file: %w", err)
 	}

--- a/model/registry/oci_test.go
+++ b/model/registry/oci_test.go
@@ -260,6 +260,69 @@ func TestRegistry_Pull(t *testing.T) {
 	}
 }
 
+// TestRegistry_Pull_DigestMismatch verifies that Pull rejects a blob whose
+// content does not hash to the digest recorded in the manifest, and that it
+// does not write anything to disk in that case (OCI-1).
+func TestRegistry_Pull_DigestMismatch(t *testing.T) {
+	mock := newMockOCIRegistry()
+	server := httptest.NewServer(mock.handler())
+	defer server.Close()
+
+	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+
+	repo := "models/evil"
+	tag := "v1"
+
+	// Simulate a malicious/MITM'd registry: the manifest claims a digest
+	// that does not match the bytes actually stored under it.
+	tamperedData := []byte("trojaned-gguf-bytes")
+	claimedDigest := sha256Digest([]byte("expected-original-bytes"))
+
+	mock.mu.Lock()
+	mock.blobs[claimedDigest] = tamperedData
+	mock.mu.Unlock()
+
+	manifest := Manifest{
+		SchemaVersion: 2,
+		MediaType:     MediaTypeOCIManifest,
+		Config: Descriptor{
+			MediaType: MediaTypeModelConfig,
+			Digest:    sha256Digest([]byte("{}")),
+			Size:      2,
+		},
+		Layers: []Descriptor{
+			{
+				MediaType: MediaTypeGGUF,
+				Digest:    claimedDigest,
+				Size:      int64(len(tamperedData)),
+			},
+		},
+	}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	mock.mu.Lock()
+	mock.manifests[repo+"/"+tag] = manifestData
+	mock.mu.Unlock()
+
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, "pulled-model.gguf")
+
+	err = reg.Pull(context.Background(), "registry.example.com/"+repo+":"+tag, destPath)
+	if err == nil {
+		t.Fatal("Pull should reject a blob with a mismatched digest")
+	}
+	if !strings.Contains(err.Error(), "digest mismatch") {
+		t.Errorf("error should mention digest mismatch, got: %v", err)
+	}
+
+	if _, statErr := os.Stat(destPath); !os.IsNotExist(statErr) {
+		t.Error("Pull must not write the file to disk when the digest does not match")
+	}
+}
+
 func TestRegistry_Tags(t *testing.T) {
 	mock := newMockOCIRegistry()
 	server := httptest.NewServer(mock.handler())


### PR DESCRIPTION
## Summary
- Fixes OCI-1 from deep-review 002 (docs/deep-reviews/002-full-codebase.md): `Registry.Pull` in `model/registry/oci.go` requested a content-addressed layer by digest but never recomputed `sha256(data)` to verify it before writing to disk.
- A malicious or MITM'd registry could serve arbitrary bytes for any digest, and the client would accept and persist them unchecked.
- `Pull` now computes `sha256Digest(data)` immediately after `getBlob` returns and rejects the download with `oci: blob digest mismatch: got %s want %s` before any bytes are written to `destPath`.

## Test plan
- [x] Added `TestRegistry_Pull_DigestMismatch`: a manifest layer claims a digest for tampered blob bytes; `Pull` now returns an error mentioning "digest mismatch" and the destination file is never created.
- [x] Existing `TestRegistry_Pull` (push then pull round-trip) continues to pass, confirming no regression for a matching digest.
- [x] `gofmt -l model/registry` clean; `go vet ./model/registry/...` clean.
- [x] `go test ./model/registry/...` green (all tests pass).