### PR TITLE
fix(serve): reap executeBatch ctx-wait goroutines promptly (CONC-L1, T142.5)

### DIFF
--- a/serve/batch.go
+++ b/serve/batch.go
@@ -165,9 +165,16 @@ func (s *BatchScheduler) executeBatch(batch []pendingRequest) {
 	remaining.Store(int32(len(live)))
 	for _, pr := range live {
 		go func(ctx context.Context) {
-			<-ctx.Done()
-			if remaining.Add(-1) <= 0 {
-				once.Do(batchCancel)
+			select {
+			case <-ctx.Done():
+				if remaining.Add(-1) <= 0 {
+					once.Do(batchCancel)
+				}
+			case <-batchCtx.Done():
+				// The batch has already completed (or been canceled by a
+				// sibling request); stop waiting on this request's context
+				// so the goroutine is reaped as soon as the batch returns
+				// instead of lingering until its own context is done.
 			}
 		}(pr.ctx)
 	}

--- a/serve/batch_test.go
+++ b/serve/batch_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -238,6 +239,86 @@ func TestBatchScheduler_FirstDisconnectDoesNotCancelBatch(t *testing.T) {
 		if vals[idx] != "done:req" {
 			t.Errorf("request %d value = %q, want %q", idx, vals[idx], "done:req")
 		}
+	}
+}
+
+// TestBatchScheduler_ExecuteBatch_ReapsCtxWaitGoroutines guards against
+// CONC-L1: executeBatch spawns one ctx-wait goroutine per live request to
+// build a merged batch context. Each goroutine used to block solely on its
+// own request's ctx.Done(), so if a request's context is never
+// independently canceled (e.g. context.Background(), or a long-lived
+// streaming context that outlives the batch), the goroutine lingered long
+// after the batch itself had already completed. The fix makes each
+// goroutine also select on batchCtx.Done() so it is reaped as soon as the
+// batch returns.
+func TestBatchScheduler_ExecuteBatch_ReapsCtxWaitGoroutines(t *testing.T) {
+	const n = 6
+
+	sched := NewBatchScheduler(BatchConfig{
+		MaxBatchSize: n,
+		BatchTimeout: 200 * time.Millisecond,
+		Handler: func(_ context.Context, reqs []BatchRequest) []BatchResult {
+			results := make([]BatchResult, len(reqs))
+			for i := range reqs {
+				results[i] = BatchResult{Value: "ok"}
+			}
+			return results
+		},
+	})
+
+	sched.Start()
+	defer sched.Stop()
+
+	// Warm up so the scheduler's own steady-state goroutines are already
+	// running before we take the baseline measurement.
+	if _, err := sched.Submit(context.Background(), BatchRequest{Prompt: "warmup"}); err != nil {
+		t.Fatalf("warmup submit: %v", err)
+	}
+	runtime.Gosched()
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	// Submit n requests concurrently, all using context.Background() so
+	// nothing ever independently cancels their context. The only thing that
+	// should stop the per-request ctx-wait goroutine is the batch itself
+	// completing.
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if _, err := sched.Submit(context.Background(), BatchRequest{Prompt: "req"}); err != nil {
+				t.Errorf("submit %d: %v", idx, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// The batch handler has already returned by the time Submit unblocks its
+	// callers (results are delivered after the handler call), so the
+	// ctx-wait goroutines should be reaped almost immediately. Poll with a
+	// generous deadline; without the fix these goroutines never exit
+	// (context.Background() never fires Done()), so this will time out and
+	// fail instead of flaking.
+	deadline := time.Now().Add(2 * time.Second)
+	var final int
+	for {
+		runtime.Gosched()
+		time.Sleep(10 * time.Millisecond)
+		runtime.GC()
+		final = runtime.NumGoroutine()
+		if final <= baseline+1 { // small slack for test/runtime bookkeeping goroutines
+			break
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+	}
+
+	if final > baseline+1 {
+		t.Errorf("goroutine count did not settle back to baseline after batch completed: baseline=%d, final=%d (leaked ~%d ctx-wait goroutine(s))",
+			baseline, final, final-baseline)
 	}
 }
 


### PR DESCRIPTION
## Summary
- CONC-L1 (deep-review 002, docs/deep-reviews/002-full-codebase.md): `serve/batch.go`'s `executeBatch` spawns one ctx-wait goroutine per live request to build the merged batch context. Each goroutine previously blocked solely on its own request's `ctx.Done()`, so a request whose context never independently cancels (`context.Background()`, or a context that simply outlives the batch) left its goroutine parked long after the batch itself had already completed.
- Fix: each goroutine now also selects on `batchCtx.Done()`, so it is reaped as soon as the batch returns instead of lingering.

## Test plan
- [x] Added `TestBatchScheduler_ExecuteBatch_ReapsCtxWaitGoroutines` (serve/batch_test.go): submits a batch of requests using `context.Background()` (never independently canceled) and asserts `runtime.NumGoroutine()` settles back to baseline shortly after the batch completes. Verified this test fails against the pre-fix code (leaks exactly N goroutines) and passes with the fix.
- [x] `gofmt -l` clean, `go vet ./serve/...` clean.
- [x] `go test -count=1 ./serve/...` green.
- [x] `go test -race -count=1 -run TestBatchScheduler ./serve/` green.