### PR TITLE
fix(gguf): cap tensor dimension count at 8 (F3, T139.3)

### DIFF
--- a/model/gguf/parser.go
+++ b/model/gguf/parser.go
@@ -12,6 +12,16 @@ import (
 // Magic is the GGUF file magic number ("GGUF" in little-endian).
 const Magic uint32 = 0x46554747 // "GGUF" in little-endian
 
+// maxTensorDims is the maximum number of dimensions a single tensor may
+// declare. Real model tensors never exceed 4 dimensions (attention weights
+// are the deepest common case); 8 leaves generous headroom while still
+// bounding the file-controlled numDims value read below. Without this cap, a
+// crafted or corrupt GGUF file can set numDims to an arbitrarily large
+// uint32 (e.g. ~4 billion), forcing `make([]uint64, numDims)` to attempt a
+// multi-gigabyte allocation before a single dimension value has even been
+// validated -- a denial-of-service vector (deep-review 002, finding F3).
+const maxTensorDims = 8
+
 // GGUF metadata value types.
 const (
 	TypeUint8   uint32 = 0
@@ -34,20 +44,20 @@ type GGMLType uint32
 
 // Common GGML tensor types.
 const (
-	GGMLTypeF32  GGMLType = 0
-	GGMLTypeF16  GGMLType = 1
-	GGMLTypeQ4_0 GGMLType = 2
-	GGMLTypeQ4_1 GGMLType = 3
-	GGMLTypeQ5_0 GGMLType = 6
-	GGMLTypeQ5_1 GGMLType = 7
-	GGMLTypeQ8_0 GGMLType = 8
-	GGMLTypeQ8_1 GGMLType = 9
-	GGMLTypeQ2_K GGMLType = 10
-	GGMLTypeQ3_K GGMLType = 11
-	GGMLTypeQ4_K GGMLType = 12
-	GGMLTypeQ5_K GGMLType = 13
-	GGMLTypeQ6_K GGMLType = 14
-	GGMLTypeQ8_K  GGMLType = 15
+	GGMLTypeF32     GGMLType = 0
+	GGMLTypeF16     GGMLType = 1
+	GGMLTypeQ4_0    GGMLType = 2
+	GGMLTypeQ4_1    GGMLType = 3
+	GGMLTypeQ5_0    GGMLType = 6
+	GGMLTypeQ5_1    GGMLType = 7
+	GGMLTypeQ8_0    GGMLType = 8
+	GGMLTypeQ8_1    GGMLType = 9
+	GGMLTypeQ2_K    GGMLType = 10
+	GGMLTypeQ3_K    GGMLType = 11
+	GGMLTypeQ4_K    GGMLType = 12
+	GGMLTypeQ5_K    GGMLType = 13
+	GGMLTypeQ6_K    GGMLType = 14
+	GGMLTypeQ8_K    GGMLType = 15
 	GGMLTypeIQ2_XXS GGMLType = 16 // Importance-weighted 2-bit (E8 lattice codebook)
 	GGMLTypeIQ3_S   GGMLType = 21 // Importance-weighted 3-bit with sub-block scales
 	GGMLTypeIQ4_NL  GGMLType = 25 // Non-linear 4-bit with lookup table
@@ -131,6 +141,9 @@ func Parse(r io.ReadSeeker) (*File, error) {
 		var numDims uint32
 		if err := binary.Read(r, binary.LittleEndian, &numDims); err != nil {
 			return nil, fmt.Errorf("tensor[%d] ndims: %w", i, err)
+		}
+		if numDims > maxTensorDims {
+			return nil, fmt.Errorf("tensor[%d] %q: dimension count %d exceeds maximum (%d)", i, name, numDims, maxTensorDims)
 		}
 
 		dims := make([]uint64, numDims)

--- a/model/gguf/parser_test.go
+++ b/model/gguf/parser_test.go
@@ -307,9 +307,9 @@ func TestGetUint32_WrongType(t *testing.T) {
 func TestParse_TensorCountOverflow(t *testing.T) {
 	var buf bytes.Buffer
 	bw(&buf, Magic)
-	bw(&buf, uint32(3))           // version
-	bw(&buf, uint64(100_001))     // tensor count exceeds limit
-	bw(&buf, uint64(0))           // metadata kv count
+	bw(&buf, uint32(3))       // version
+	bw(&buf, uint64(100_001)) // tensor count exceeds limit
+	bw(&buf, uint64(0))       // metadata kv count
 	_, err := Parse(bytes.NewReader(buf.Bytes()))
 	if err == nil {
 		t.Fatal("expected error for tensor count > 100000")
@@ -319,11 +319,106 @@ func TestParse_TensorCountOverflow(t *testing.T) {
 func TestParse_MetadataKVCountOverflow(t *testing.T) {
 	var buf bytes.Buffer
 	bw(&buf, Magic)
-	bw(&buf, uint32(3))           // version
-	bw(&buf, uint64(0))           // tensor count
-	bw(&buf, uint64(1_000_001))   // metadata kv count exceeds limit
+	bw(&buf, uint32(3))         // version
+	bw(&buf, uint64(0))         // tensor count
+	bw(&buf, uint64(1_000_001)) // metadata kv count exceeds limit
 	_, err := Parse(bytes.NewReader(buf.Bytes()))
 	if err == nil {
 		t.Fatal("expected error for metadata kv count > 1000000")
+	}
+}
+
+// TestParse_TensorDimsExceedsMax verifies a crafted tensor declaring more
+// than maxTensorDims dimensions is rejected with an error (deep-review 002,
+// finding F3) rather than allocating an unbounded []uint64 or crashing
+// later in shape-dependent code.
+func TestParse_TensorDimsExceedsMax(t *testing.T) {
+	tensors := []TensorInfo{{
+		Name:       "attack.too_many_dims",
+		Dimensions: make([]uint64, maxTensorDims+1), // 9 dims, all zero-valued
+		Type:       GGMLTypeF32,
+		Offset:     0,
+	}}
+	r := buildSyntheticGGUF(t, nil, tensors)
+	_, err := Parse(r)
+	if err == nil {
+		t.Fatal("expected error for tensor with more than maxTensorDims dimensions")
+	}
+}
+
+// TestParse_TensorDimsHugeCount verifies the numDims cap rejects a
+// file-controlled dimension count before attempting to allocate or read any
+// per-dimension values -- the actual F3 attack shape, where a corrupt file
+// declares an enormous numDims (e.g. near uint32 max) that would otherwise
+// force `make([]uint64, numDims)` to attempt a multi-gigabyte allocation.
+func TestParse_TensorDimsHugeCount(t *testing.T) {
+	var buf bytes.Buffer
+	bw(&buf, Magic)
+	bw(&buf, uint32(3)) // version
+	bw(&buf, uint64(1)) // tensor count
+	bw(&buf, uint64(0)) // metadata kv count
+	writeTestString(&buf, "attack.huge_ndims")
+	bw(&buf, uint32(0xFFFFFFFF)) // numDims: ~4 billion, no dimension data follows
+
+	_, err := Parse(bytes.NewReader(buf.Bytes()))
+	if err == nil {
+		t.Fatal("expected error for tensor with huge (file-controlled) dimension count")
+	}
+}
+
+// TestParse_TensorDimsAtMax verifies exactly maxTensorDims dimensions is
+// still accepted -- the cap must not be stricter than documented.
+func TestParse_TensorDimsAtMax(t *testing.T) {
+	dims := make([]uint64, maxTensorDims)
+	for i := range dims {
+		dims[i] = 2
+	}
+	tensors := []TensorInfo{{
+		Name:       "test.at_max_dims",
+		Dimensions: dims,
+		Type:       GGMLTypeF32,
+		Offset:     0,
+	}}
+	r := buildSyntheticGGUF(t, nil, tensors)
+	f, err := Parse(r)
+	if err != nil {
+		t.Fatalf("Parse: unexpected error at exactly maxTensorDims dimensions: %v", err)
+	}
+	if len(f.Tensors) != 1 || len(f.Tensors[0].Dimensions) != maxTensorDims {
+		t.Fatalf("Tensors[0].Dimensions length = %d, want %d", len(f.Tensors[0].Dimensions), maxTensorDims)
+	}
+}
+
+// TestParse_TensorDimsLegitimateShapes verifies real-world tensor ranks
+// (1D bias through 4D conv-like kernels) all parse cleanly and are
+// unaffected by the maxTensorDims cap.
+func TestParse_TensorDimsLegitimateShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		dims []uint64
+	}{
+		{"1D bias", []uint64{4096}},
+		{"2D dense weight", []uint64{4096, 4096}},
+		{"3D conv-like kernel", []uint64{64, 3, 3}},
+		{"4D conv kernel", []uint64{64, 32, 3, 3}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tensors := []TensorInfo{{
+				Name:       "test." + tt.name,
+				Dimensions: tt.dims,
+				Type:       GGMLTypeF32,
+				Offset:     0,
+			}}
+			r := buildSyntheticGGUF(t, nil, tensors)
+			f, err := Parse(r)
+			if err != nil {
+				t.Fatalf("Parse: unexpected error: %v", err)
+			}
+			if len(f.Tensors) != 1 || len(f.Tensors[0].Dimensions) != len(tt.dims) {
+				t.Fatalf("Dimensions = %v, want length %d", f.Tensors[0].Dimensions, len(tt.dims))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- `model/gguf/parser.go` read a file-controlled `numDims` (uint32) per tensor and immediately did `make([]uint64, numDims)` before validating a single dimension value -- a corrupt or malicious GGUF file could force a multi-gigabyte allocation attempt (deep-review 002, finding F3, docs/deep-reviews/002-full-codebase.md).
- Added `maxTensorDims = 8` and a bounds check right after `numDims` is read, before the slice is allocated -- the earliest possible point in the parse.
- `TensorInfo` is constructed only in `parser.go` (confirmed via repo-wide grep), so the cap belongs solely at parse time; no change needed to `computeNumElements` (loader.go, T139.1/F1) since malformed dimension counts can no longer reach it.

## Test plan
- [x] `TestParse_TensorDimsExceedsMax` -- 9-dim tensor rejected
- [x] `TestParse_TensorDimsHugeCount` -- numDims near uint32 max rejected before any dimension bytes are read
- [x] `TestParse_TensorDimsAtMax` -- exactly 8 dims still accepted (boundary)
- [x] `TestParse_TensorDimsLegitimateShapes` -- 1D/2D/3D/4D real-model shapes parse fine
- [x] `gofmt -l`, `go vet ./model/...` clean
- [x] `go test ./model/...` green