### PR TITLE
fix(serve): eliminate KeyStore Revoked/ExpiresAt data race (CONC-M2, T142.4)

### DIFF
--- a/serve/security/apikey.go
+++ b/serve/security/apikey.go
@@ -165,13 +165,24 @@ func (s *KeyStore) Create(id string, scopes []Scope, expiresAt time.Time) (rawKe
 }
 
 // Lookup finds a key by its raw value. Returns nil if not found.
+//
+// The returned APIKey is a value copy taken under the KeyStore lock, not the
+// live record. Revoke/Rotate mutate the live record's Revoked/ExpiresAt
+// fields under s.mu; handing out the shared pointer would let callers read
+// those fields lock-free (a data race, and a window where a concurrently
+// revoked key still authorizes). Callers get a stable snapshot instead.
 func (s *KeyStore) Lookup(rawKey string) *APIKey {
 	h := sha256.Sum256([]byte(rawKey))
 	hash := hex.EncodeToString(h[:])
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.backend.Load(hash)
+	k := s.backend.Load(hash)
+	if k == nil {
+		return nil
+	}
+	cp := *k
+	return &cp
 }
 
 // Revoke marks a key as revoked by its ID.

--- a/serve/security/apikey_test.go
+++ b/serve/security/apikey_test.go
@@ -2,6 +2,8 @@ package security
 
 import (
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -145,4 +147,105 @@ func TestKeyStoreCreateEmptyID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty ID")
 	}
+}
+
+// TestKeyStoreLookupRaceConcurrentRevoke reproduces CONC-M2: a reader
+// pattern shaped exactly like authMiddleware (server.go) -- Lookup, then
+// Valid()/HasScope() with no lock held -- running concurrently with Revoke,
+// which mutates the live APIKey record's Revoked/RevokedAt fields under
+// KeyStore's mutex.
+//
+// Before the fix, Lookup returned the shared *APIKey stored in the backend,
+// so this raced under `go test -race`: Revoke's locked write to k.Revoked
+// raced with this goroutine's lock-free k.Valid() read of the same field.
+// Lookup now returns a value copy taken under the read lock, so the reader
+// never touches the live, concurrently-mutated struct.
+func TestKeyStoreLookupRaceConcurrentRevoke(t *testing.T) {
+	ks := NewKeyStore()
+	raw, _, err := ks.Create("race-key", []Scope{ScopeInference}, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const iterations = 500
+	var wg sync.WaitGroup
+
+	// Writer: repeatedly revoke, mimicking an admin revoking a key while
+	// live traffic is in flight for it.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = ks.Revoke("race-key")
+		}
+	}()
+
+	// Reader: the authMiddleware pattern -- Lookup, then read Valid()/
+	// HasScope() with no lock held.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			key := ks.Lookup(raw)
+			if key == nil {
+				continue
+			}
+			_ = key.Valid(time.Now())
+			_ = key.HasScope(ScopeInference)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestKeyStoreLookupRaceConcurrentRotate is the Rotate analogue of
+// TestKeyStoreLookupRaceConcurrentRevoke: Rotate revokes the old record and
+// publishes a new raw key/record under the same ID, concurrently with
+// authMiddleware-style Lookup+Valid()/HasScope() reads.
+//
+// The current raw key is published via atomic.Value so the reader picks up
+// rotations without racing on the Go string variable itself -- any race
+// here must come from the KeyStore, not from this test's bookkeeping.
+func TestKeyStoreLookupRaceConcurrentRotate(t *testing.T) {
+	ks := NewKeyStore()
+	raw, _, err := ks.Create("rotate-race-key", []Scope{ScopeInference}, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var currentRaw atomic.Value
+	currentRaw.Store(raw)
+
+	const iterations = 500
+	var wg sync.WaitGroup
+
+	// Writer: repeatedly rotate, mimicking an admin rotating a key while
+	// live traffic is in flight for it.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			newRaw, _, err := ks.Rotate("rotate-race-key", time.Time{})
+			if err != nil {
+				return
+			}
+			currentRaw.Store(newRaw)
+		}
+	}()
+
+	// Reader: the authMiddleware pattern -- Lookup, then read Valid()/
+	// HasScope() with no lock held.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			key := ks.Lookup(currentRaw.Load().(string))
+			if key == nil {
+				continue
+			}
+			_ = key.Valid(time.Now())
+			_ = key.HasScope(ScopeInference)
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

- Fixes CONC-M2 from deep-review 002 (`docs/deep-reviews/002-full-codebase.md`): `authMiddleware` (`serve/server.go:282-288`) read `key.Valid()`/`key.HasScope()` lock-free on a `*APIKey` returned by `KeyStore.Lookup`, while `Revoke`/`Rotate` (`serve/security/apikey.go:186,205`) mutated `Revoked`/`RevokedAt` on that same shared struct under `KeyStore.mu` -- a genuine `go test -race` data race, plus a brief window post-revoke where the revoked key could still authorize.
- Chose the "value copy from `Lookup`" option over `atomic.Bool`: `APIKey` is JSON-marshaled for persistence by the bbolt backend (`serve/security/apikey_bbolt.go`), and `atomic.Bool` has no exported fields, so it would silently break the persisted `Revoked` flag across restarts. `Lookup` now takes the snapshot under `s.mu.RLock()` and hands callers a private copy; `Revoke`/`Rotate` continue to mutate the live record under `s.mu.Lock()`, and nobody outside the lock touches the live struct's mutable fields.

## Test plan

- [x] Added `TestKeyStoreLookupRaceConcurrentRevoke` and `TestKeyStoreLookupRaceConcurrentRotate` (`serve/security/apikey_test.go`), which drive the exact `authMiddleware` pattern (`Lookup` then lock-free `Valid()`/`HasScope()`) concurrently with `Revoke`/`Rotate`.
- [x] Confirmed both tests reproduce the CONC-M2 race under `go test -race` against the pre-fix `Lookup` (temporarily reverted apikey.go): write at `apikey.go:186`/`205` vs. read at `apikey.go:45`.
- [x] Both tests pass clean under `go test -race` with the fix applied.
- [x] `gofmt -l` clean, `go vet ./serve/...` clean.
- [x] `go test -race -count=1 ./serve/...` green (all packages, including `serve/security`).