### PR TITLE
fix(serve): cap /v1/embeddings input array size (SERVE-3, T143.3)

### DIFF
--- a/serve/handlers.go
+++ b/serve/handlers.go
@@ -362,6 +362,11 @@ func (s *Server) handleModelDelete(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// maxEmbeddingsBatch is the maximum number of inputs in a single embeddings
+// request. Without a cap, a 10 MB body of short strings can drive tens of
+// thousands of synchronous Embed calls (SERVE-3).
+const maxEmbeddingsBatch = 256
+
 func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 	s.modelMu.RLock()
 	defer s.modelMu.RUnlock()
@@ -403,6 +408,11 @@ func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 
 	if len(inputs) == 0 {
 		writeError(w, http.StatusBadRequest, "input is required")
+		return
+	}
+
+	if len(inputs) > maxEmbeddingsBatch {
+		writeError(w, http.StatusBadRequest, "input exceeds maximum batch size of 256")
 		return
 	}
 

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -796,6 +796,80 @@ func TestHandleEmbeddings_BatchInput(t *testing.T) {
 	}
 }
 
+// buildEmbeddingTestModel builds a test model with embedding weights set,
+// so /v1/embeddings can complete a real (non-500) round trip.
+func buildEmbeddingTestModel(t *testing.T) *inference.Model {
+	t.Helper()
+	mdl := buildTestModel(t)
+	const vocabSize = 8
+	const hiddenSize = 4
+	weights := make([]float32, vocabSize*hiddenSize)
+	for i := range weights {
+		weights[i] = float32(i%7) * 0.1
+	}
+	mdl.SetEmbeddingWeights(weights, hiddenSize)
+	return mdl
+}
+
+// TestHandleEmbeddings_MaxBatchBoundary verifies that a request with exactly
+// maxEmbeddingsBatch inputs is accepted (SERVE-3).
+func TestHandleEmbeddings_MaxBatchBoundary(t *testing.T) {
+	mdl := buildEmbeddingTestModel(t)
+	srv := NewServer(mdl)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	inputs := make([]string, maxEmbeddingsBatch)
+	for i := range inputs {
+		inputs[i] = "hello world"
+	}
+	reqBody, err := json.Marshal(EmbeddingRequest{Model: "test-model", Input: inputs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := doPost(t, ts.URL+"/v1/embeddings", "application/json", string(reqBody))
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d for %d inputs, want 200; body: %s", resp.StatusCode, maxEmbeddingsBatch, data)
+	}
+
+	var result EmbeddingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(result.Data) != maxEmbeddingsBatch {
+		t.Errorf("data length = %d, want %d", len(result.Data), maxEmbeddingsBatch)
+	}
+}
+
+// TestHandleEmbeddings_ExceedMaxBatch verifies that a request with more than
+// maxEmbeddingsBatch inputs is rejected with 400 before any Embed call runs
+// (SERVE-3: caps element count to avoid tens of thousands of synchronous
+// Embed calls from a single oversized request).
+func TestHandleEmbeddings_ExceedMaxBatch(t *testing.T) {
+	mdl := buildEmbeddingTestModel(t)
+	srv := NewServer(mdl)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	inputs := make([]string, maxEmbeddingsBatch+1)
+	for i := range inputs {
+		inputs[i] = "hello world"
+	}
+	reqBody, err := json.Marshal(EmbeddingRequest{Model: "test-model", Input: inputs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := doPost(t, ts.URL+"/v1/embeddings", "application/json", string(reqBody))
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
 // --- Model Info ---
 
 func TestHandleModelInfo(t *testing.T) {


### PR DESCRIPTION
## Summary
- SERVE-3 (deep-review 002): `/v1/embeddings` had no cap on the input array size while `/v1/classify` and `/v1/guard/batch` cap at 256 -- a 10 MB body of short strings could drive tens of thousands of synchronous `Embed` calls.
- Adds `maxEmbeddingsBatch = 256`, mirroring `maxClassifyBatch`/`maxGuardBatch`, and rejects oversized input arrays with a 400.

## Test plan
- [x] `TestHandleEmbeddings_MaxBatchBoundary`: 256 inputs succeeds (200, full batch of embeddings returned)
- [x] `TestHandleEmbeddings_ExceedMaxBatch`: 257 inputs rejected (400)
- [x] `gofmt -l` clean
- [x] `go vet ./serve/...` clean
- [x] `go test ./serve/...` green