### PR TITLE
fix(cli): default worker to loopback, add --tls-* flags (T140.2)

### DIFF
--- a/cmd/cli/worker.go
+++ b/cmd/cli/worker.go
@@ -10,16 +10,34 @@ import (
 	"github.com/zerfoo/zerfoo/serve/shutdown"
 )
 
+// workerNode is the subset of *distributed.WorkerNode that WorkerCommand
+// depends on. It exists so tests can substitute a fake node and observe the
+// distributed.WorkerNodeConfig (in particular the TLS field) that Run built
+// from CLI flags, without standing up a real gRPC server/coordinator pair.
+type workerNode interface {
+	Start(ctx context.Context) error
+	Close(ctx context.Context) error
+}
+
 // WorkerCommand implements the "worker" CLI command for starting a
 // distributed training worker.
 type WorkerCommand struct {
 	shutdownCoord *shutdown.Coordinator
+
+	// newWorkerNode constructs the worker node from its config. Defaults to
+	// wrapping distributed.NewWorkerNode; overridable in tests.
+	newWorkerNode func(distributed.WorkerNodeConfig) workerNode
 }
 
 // NewWorkerCommand creates a new WorkerCommand. The shutdown coordinator
 // is used to register the worker node for orderly shutdown on signal.
 func NewWorkerCommand(coord *shutdown.Coordinator) *WorkerCommand {
-	return &WorkerCommand{shutdownCoord: coord}
+	return &WorkerCommand{
+		shutdownCoord: coord,
+		newWorkerNode: func(cfg distributed.WorkerNodeConfig) workerNode {
+			return distributed.NewWorkerNode(cfg)
+		},
+	}
 }
 
 // Name implements Command.Name.
@@ -34,6 +52,7 @@ func (c *WorkerCommand) Description() string {
 // starts it, and blocks until the context is canceled (e.g. by SIGTERM).
 func (c *WorkerCommand) Run(ctx context.Context, args []string) error {
 	var coordAddr, workerAddr, workerID string
+	var tlsCert, tlsKey, tlsCA string
 	var worldSize int
 
 	for i := 0; i < len(args); i++ {
@@ -66,6 +85,24 @@ func (c *WorkerCommand) Run(ctx context.Context, args []string) error {
 			}
 			worldSize = n
 			i++
+		case "--tls-cert":
+			if i+1 >= len(args) {
+				return errors.New("--tls-cert requires a value")
+			}
+			tlsCert = args[i+1]
+			i++
+		case "--tls-key":
+			if i+1 >= len(args) {
+				return errors.New("--tls-key requires a value")
+			}
+			tlsKey = args[i+1]
+			i++
+		case "--tls-ca":
+			if i+1 >= len(args) {
+				return errors.New("--tls-ca requires a value")
+			}
+			tlsCA = args[i+1]
+			i++
 		default:
 			return fmt.Errorf("unknown flag: %s", args[i])
 		}
@@ -88,10 +125,16 @@ func (c *WorkerCommand) Run(ctx context.Context, args []string) error {
 	// workerID is available for future use (e.g. distinct worker IDs).
 	_ = workerID
 
-	node := distributed.NewWorkerNode(distributed.WorkerNodeConfig{
+	tlsConfig, err := buildTLSConfig(tlsCert, tlsKey, tlsCA)
+	if err != nil {
+		return err
+	}
+
+	node := c.newWorkerNode(distributed.WorkerNodeConfig{
 		WorkerAddress:      workerAddr,
 		CoordinatorAddress: coordAddr,
 		WorldSize:          worldSize,
+		TLS:                tlsConfig,
 	})
 
 	if err := node.Start(ctx); err != nil {
@@ -113,18 +156,89 @@ func (c *WorkerCommand) Usage() string {
 
 Start a distributed training worker.
 
+Binding --worker-address to anything other than a loopback address
+(127.0.0.0/8, ::1, or "localhost") requires TLS -- see worker_node.go's
+isLoopback / Start for the enforced contract. Single-host development can
+keep the default loopback address and skip --tls-*; a multi-host run MUST
+set --tls-cert/--tls-key/--tls-ca or Start will refuse to bind.
+
 OPTIONS:
   --coordinator-address <addr>  Coordinator gRPC address (required)
-  --worker-address <addr>       Worker gRPC listen address (required)
+  --worker-address <addr>       Worker gRPC listen address (required;
+                                 default example: 127.0.0.1:9001)
   --worker-id <id>              Worker identifier (default: hostname)
-  --world-size <n>              Total number of workers (default: auto)`
+  --world-size <n>              Total number of workers (default: auto)
+  --tls-cert <path>             PEM certificate for this worker's gRPC
+                                 server (and its outbound mTLS dial to the
+                                 coordinator). Requires --tls-key and
+                                 --tls-ca.
+  --tls-key <path>              PEM private key matching --tls-cert.
+                                 Requires --tls-cert and --tls-ca.
+  --tls-ca <path>               PEM CA certificate used to verify peer
+                                 certificates (client certs on the worker's
+                                 server side, the coordinator's cert on the
+                                 outbound dial). Requires --tls-cert and
+                                 --tls-key.
+
+Generating development certificates:
+
+  A production deployment should issue certificates from a real CA. For
+  local/dev multi-host testing, a self-signed CA plus a server cert works:
+
+    # CA key + self-signed CA cert
+    openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 \
+      -keyout ca-key.pem -out ca.pem -days 365 -nodes \
+      -subj "/O=zerfoo-dev-ca"
+
+    # Worker key + CSR, signed by the dev CA (add worker's real host/IP to
+    # -addext as needed)
+    openssl req -newkey ec -pkeyopt ec_paramgen_curve:P-256 \
+      -keyout worker-key.pem -out worker.csr -nodes \
+      -subj "/O=zerfoo-dev-worker" \
+      -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+    openssl x509 -req -in worker.csr -CA ca.pem -CAkey ca-key.pem \
+      -CAcreateserial -out worker-cert.pem -days 365 \
+      -copy_extensions copyall
+
+  Then run:
+
+    worker --coordinator-address <coord-host>:9000 \
+      --worker-address 0.0.0.0:9001 \
+      --tls-cert worker-cert.pem --tls-key worker-key.pem --tls-ca ca.pem
+
+  Repeat the CSR/sign step per host so each worker and the coordinator get
+  their own cert signed by the same CA. See distributed/tlsconfig_test.go's
+  generateTestCerts for the equivalent generated in-process for unit tests
+  (self-signed, 1h expiry -- test-only, not for real deployments).`
 }
 
 // Examples implements Command.Examples.
 func (c *WorkerCommand) Examples() []string {
 	return []string{
-		`worker --coordinator-address localhost:9000 --worker-address localhost:9001`,
-		`worker --coordinator-address 10.0.0.1:9000 --worker-address 0.0.0.0:9001 --world-size 4`,
+		`worker --coordinator-address 127.0.0.1:9000 --worker-address 127.0.0.1:9001`,
+		`worker --coordinator-address 10.0.0.1:9000 --worker-address 0.0.0.0:9001 --world-size 4 --tls-cert worker-cert.pem --tls-key worker-key.pem --tls-ca ca.pem`,
+	}
+}
+
+// buildTLSConfig validates the --tls-* flag combination and constructs a
+// distributed.TLSConfig from them. All three of cert, key, and ca must be
+// provided together (mTLS needs a CA to verify peers); providing none is
+// valid (TLS stays nil for loopback-only dev usage); providing a strict
+// subset is a usage error since the resulting configuration mismatches
+// what worker_node.go's Start() and tlsconfig.go's ServerCredentials/
+// ClientCredentials expect.
+func buildTLSConfig(certPath, keyPath, caPath string) (*distributed.TLSConfig, error) {
+	switch {
+	case certPath == "" && keyPath == "" && caPath == "":
+		return nil, nil
+	case certPath == "" || keyPath == "" || caPath == "":
+		return nil, errors.New("--tls-cert, --tls-key, and --tls-ca must all be provided together")
+	default:
+		return &distributed.TLSConfig{
+			CACertPath: caPath,
+			CertPath:   certPath,
+			KeyPath:    keyPath,
+		}, nil
 	}
 }
 

--- a/cmd/cli/worker_test.go
+++ b/cmd/cli/worker_test.go
@@ -2,8 +2,20 @@ package cli
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
+
+	"github.com/zerfoo/zerfoo/distributed"
 )
+
+// fakeWorkerNode is a workerNode stand-in that records the config it was
+// built with (via the closure in the test) and never touches the network,
+// so tests can assert on distributed.WorkerNodeConfig.TLS without standing
+// up a real gRPC server/coordinator pair.
+type fakeWorkerNode struct{}
+
+func (fakeWorkerNode) Start(context.Context) error { return nil }
+func (fakeWorkerNode) Close(context.Context) error { return nil }
 
 func TestWorkerCommand_Name(t *testing.T) {
 	cmd := NewWorkerCommand(nil)
@@ -66,6 +78,9 @@ func TestWorkerCommand_FlagRequiresValue(t *testing.T) {
 		{"worker-address", []string{"--worker-address"}},
 		{"worker-id", []string{"--worker-id"}},
 		{"world-size", []string{"--world-size"}},
+		{"tls-cert", []string{"--tls-cert"}},
+		{"tls-key", []string{"--tls-key"}},
+		{"tls-ca", []string{"--tls-ca"}},
 	}
 
 	for _, tt := range tests {
@@ -129,6 +144,152 @@ func TestParsePositiveInt(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWorkerCommand_Run_TLSFlagsPopulateWorkerNodeConfig is T140.2 coverage:
+// starting the worker CLI with --tls-cert/--tls-key/--tls-ca populated must
+// actually result in a TLS-configured distributed.WorkerNodeConfig being
+// handed to the worker node constructor, not just parsed and discarded. It
+// substitutes a fakeWorkerNode (via the newWorkerNode hook) so the assertion
+// is on the config Run() builds, without needing a live coordinator/gRPC
+// server.
+func TestWorkerCommand_Run_TLSFlagsPopulateWorkerNodeConfig(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	caPath := filepath.Join(dir, "ca.pem")
+
+	var gotCfg distributed.WorkerNodeConfig
+	cmd := NewWorkerCommand(nil)
+	cmd.newWorkerNode = func(cfg distributed.WorkerNodeConfig) workerNode {
+		gotCfg = cfg
+		return fakeWorkerNode{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Run blocks on <-ctx.Done() after Start(); pre-cancel so it returns immediately.
+
+	if err := cmd.Run(ctx, []string{
+		"--coordinator-address", "127.0.0.1:9000",
+		"--worker-address", "127.0.0.1:9001",
+		"--tls-cert", certPath,
+		"--tls-key", keyPath,
+		"--tls-ca", caPath,
+	}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	if gotCfg.TLS == nil {
+		t.Fatal("WorkerNodeConfig.TLS is nil; want it populated from --tls-cert/--tls-key/--tls-ca")
+	}
+	if gotCfg.TLS.CertPath != certPath {
+		t.Errorf("TLS.CertPath = %q, want %q", gotCfg.TLS.CertPath, certPath)
+	}
+	if gotCfg.TLS.KeyPath != keyPath {
+		t.Errorf("TLS.KeyPath = %q, want %q", gotCfg.TLS.KeyPath, keyPath)
+	}
+	if gotCfg.TLS.CACertPath != caPath {
+		t.Errorf("TLS.CACertPath = %q, want %q", gotCfg.TLS.CACertPath, caPath)
+	}
+}
+
+// TestWorkerCommand_Run_NoTLSFlags_LeavesTLSNil documents the dev-loopback
+// path: omitting all --tls-* flags must leave WorkerNodeConfig.TLS nil (the
+// loopback-without-TLS behavior worker_node.go's Start() has always allowed).
+func TestWorkerCommand_Run_NoTLSFlags_LeavesTLSNil(t *testing.T) {
+	var gotCfg distributed.WorkerNodeConfig
+	cmd := NewWorkerCommand(nil)
+	cmd.newWorkerNode = func(cfg distributed.WorkerNodeConfig) workerNode {
+		gotCfg = cfg
+		return fakeWorkerNode{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := cmd.Run(ctx, []string{
+		"--coordinator-address", "127.0.0.1:9000",
+		"--worker-address", "127.0.0.1:9001",
+	}); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	if gotCfg.TLS != nil {
+		t.Errorf("TLS = %+v, want nil when no --tls-* flags are given", gotCfg.TLS)
+	}
+}
+
+// TestWorkerCommand_Run_PartialTLSFlags_Errors ensures a partial --tls-*
+// flag combination (which would build a TLSConfig that mismatches what
+// tlsconfig.go's ServerCredentials/ClientCredentials expect) is rejected up
+// front rather than silently starting with a broken TLS configuration.
+func TestWorkerCommand_Run_PartialTLSFlags_Errors(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	caPath := filepath.Join(dir, "ca.pem")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"cert only", []string{"--tls-cert", certPath}},
+		{"key only", []string{"--tls-key", keyPath}},
+		{"ca only", []string{"--tls-ca", caPath}},
+		{"cert and key, no ca", []string{"--tls-cert", certPath, "--tls-key", keyPath}},
+		{"cert and ca, no key", []string{"--tls-cert", certPath, "--tls-ca", caPath}},
+		{"key and ca, no cert", []string{"--tls-key", keyPath, "--tls-ca", caPath}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewWorkerCommand(nil)
+			cmd.newWorkerNode = func(cfg distributed.WorkerNodeConfig) workerNode {
+				t.Fatal("newWorkerNode should not be called when TLS flags are incomplete")
+				return fakeWorkerNode{}
+			}
+
+			args := append([]string{
+				"--coordinator-address", "127.0.0.1:9000",
+				"--worker-address", "127.0.0.1:9001",
+			}, tt.args...)
+
+			if err := cmd.Run(context.Background(), args); err == nil {
+				t.Error("expected error for partial --tls-* flags")
+			}
+		})
+	}
+}
+
+func TestBuildTLSConfig(t *testing.T) {
+	t.Run("all empty returns nil config and nil error", func(t *testing.T) {
+		cfg, err := buildTLSConfig("", "", "")
+		if err != nil {
+			t.Fatalf("buildTLSConfig() error = %v, want nil", err)
+		}
+		if cfg != nil {
+			t.Errorf("buildTLSConfig() = %+v, want nil", cfg)
+		}
+	})
+
+	t.Run("all three set builds a populated config", func(t *testing.T) {
+		cfg, err := buildTLSConfig("cert.pem", "key.pem", "ca.pem")
+		if err != nil {
+			t.Fatalf("buildTLSConfig() error = %v, want nil", err)
+		}
+		if cfg == nil {
+			t.Fatal("buildTLSConfig() = nil, want a populated *distributed.TLSConfig")
+		}
+		if cfg.CertPath != "cert.pem" || cfg.KeyPath != "key.pem" || cfg.CACertPath != "ca.pem" {
+			t.Errorf("buildTLSConfig() = %+v, want CertPath=cert.pem KeyPath=key.pem CACertPath=ca.pem", cfg)
+		}
+	})
+
+	t.Run("partial set errors", func(t *testing.T) {
+		if _, err := buildTLSConfig("cert.pem", "", ""); err == nil {
+			t.Error("expected error for cert-only")
+		}
+	})
 }
 
 func TestWorkerCommand_Interface(t *testing.T) {


### PR DESCRIPTION
## Summary
- T140.1 (PR #947) made `WorkerNode.Start` refuse a non-loopback `--worker-address` bind unless `WorkerNodeConfig.TLS` is set. `cmd/cli/worker.go`'s documented example/default still shipped `--worker-address 0.0.0.0:9001` with no CLI flag to supply TLS material, so anyone following current docs hits an immediate startup error.
- Change the default/example worker address to `127.0.0.1:9001`.
- Add `--tls-cert`, `--tls-key`, `--tls-ca` flags; when all three are provided they build a `distributed.TLSConfig` and populate `WorkerNodeConfig.TLS`. A partial set (e.g. only `--tls-cert`) is rejected with a usage error instead of silently producing a broken TLS configuration.
- Document `openssl` commands for generating dev certs for multi-host runs in `Usage()`, since `distributed`'s `generateTestCerts` is test-only (1h self-signed certs, requires `*testing.T`, not exported for non-test use).
- No README/design.md changes needed -- neither documents the old `0.0.0.0` worker example (checked both).

## Test plan
- [x] `go test ./cmd/...` green
- [x] `gofmt -l cmd/cli/worker.go cmd/cli/worker_test.go` clean
- [x] `go vet ./cmd/...` clean
- [x] New tests added to `cmd/cli/worker_test.go`:
  - `TestWorkerCommand_Run_TLSFlagsPopulateWorkerNodeConfig` -- constructs the CLI command with `--tls-cert/--tls-key/--tls-ca`, substitutes a fake worker-node constructor via a new `newWorkerNode` DI hook, and asserts the resulting `distributed.WorkerNodeConfig.TLS` is populated with the exact paths passed.
  - `TestWorkerCommand_Run_NoTLSFlags_LeavesTLSNil` -- confirms the loopback-dev path is unaffected (TLS stays nil when no `--tls-*` flags given).
  - `TestWorkerCommand_Run_PartialTLSFlags_Errors` -- table test over every partial combination of the three flags, expects an error.
  - `TestBuildTLSConfig` -- direct unit coverage of the new `buildTLSConfig` helper.
  - Extended `TestWorkerCommand_FlagRequiresValue` to cover the three new flags requiring a value.