### PR TITLE
fix(distributed): authenticate coordinator worker registration (DIST-2, T140.3)

### DIFF
--- a/distributed/coordinator/coordinator.go
+++ b/distributed/coordinator/coordinator.go
@@ -10,9 +10,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/zerfoo/zerfoo/distributed"
 	"github.com/zerfoo/zerfoo/distributed/pb"
 	"github.com/zerfoo/ztensor/log"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 // Coordinator implements the pb.CoordinatorServer interface.
@@ -31,6 +36,15 @@ type Coordinator struct {
 	timeout     time.Duration
 	stopCh      chan struct{}
 	stopOnce    sync.Once
+
+	// tls, when set via SetTLS, secures the coordinator's gRPC server the
+	// same way T140.1 secures the worker (distributed.TLSConfig.
+	// ServerCredentials). When nil, Start refuses to bind any non-loopback
+	// address -- see isLoopback. When tls.CACertPath is set (mutual TLS),
+	// every RPC is additionally gated on a verified client certificate via
+	// authInterceptor, closing DIST-2 (unauthenticated worker registration
+	// / peer-list disclosure).
+	tls *distributed.TLSConfig
 }
 
 // WorkerInfo holds information about a worker in the cluster.
@@ -67,8 +81,30 @@ func NewCoordinator(out io.Writer, timeout time.Duration) *Coordinator {
 	return c
 }
 
-// Start starts the coordinator service on the given address.
+// Start starts the coordinator service on the given address. A routable
+// (non-loopback) address requires TLS -- either via SetTLS or by passing
+// TLS credentials through SetServerOptions -- and Start refuses to bind
+// otherwise (DIST-2: the coordinator must not run unauthenticated on a
+// network-reachable address, mirroring WorkerNode.Start's isLoopback gate).
 func (c *Coordinator) Start(address string) error {
+	if c.tls != nil {
+		creds, err := c.tls.ServerCredentials()
+		if err != nil {
+			return fmt.Errorf("coordinator tls: %w", err)
+		}
+		c.serverOpts = append(c.serverOpts, grpc.Creds(creds))
+
+		// Mutual TLS (a CA cert configured) lets us verify the caller's
+		// identity; gate every RPC on a verified client certificate so
+		// RegisterWorker never discloses the peer list to an unauthenticated
+		// caller, even if the transport-level handshake were misconfigured.
+		if c.tls.CACertPath != "" {
+			c.serverOpts = append(c.serverOpts, grpc.ChainUnaryInterceptor(authInterceptor))
+		}
+	} else if !isLoopback(address) {
+		return errors.New("coordinator: refusing non-loopback bind without TLS; call SetTLS or bind 127.0.0.1")
+	}
+
 	// Use context-aware listener per linter guidance.
 	lc := net.ListenConfig{}
 	lis, err := lc.Listen(context.Background(), "tcp", address)
@@ -81,10 +117,86 @@ func (c *Coordinator) Start(address string) error {
 	return nil
 }
 
+// SetTLS configures mutual TLS for the coordinator's gRPC server, mirroring
+// WorkerNodeConfig.TLS from T140.1. Must be called before Start. Set
+// tls.CACertPath to require and verify a client certificate on every RPC
+// (see authInterceptor) -- without it, connections are encrypted but not
+// authenticated, and RegisterWorker remains open to any TLS client.
+func (c *Coordinator) SetTLS(tls *distributed.TLSConfig) {
+	c.tls = tls
+}
+
 // SetServerOptions sets gRPC server options (e.g. TLS credentials)
 // that will be applied when the server starts. Must be called before Start.
+//
+// Deprecated: prefer SetTLS, which also gates RegisterWorker on a verified
+// client certificate (DIST-2). SetServerOptions is retained for callers
+// that need to pass arbitrary gRPC server options directly.
 func (c *Coordinator) SetServerOptions(opts ...grpc.ServerOption) {
 	c.serverOpts = opts
+}
+
+// authInterceptor rejects any unary RPC whose peer did not present a
+// verified TLS client certificate. It is installed automatically by Start
+// whenever the coordinator is configured with mutual TLS (SetTLS with
+// CACertPath set), closing DIST-2 for every coordinator RPC -- including
+// RegisterWorker's peer-list disclosure -- not just RegisterWorker alone.
+func authInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	if !peerAuthenticated(ctx) {
+		return nil, grpcstatus.Error(codes.Unauthenticated, "coordinator: rpc requires a verified client certificate")
+	}
+
+	return handler(ctx, req)
+}
+
+// peerAuthenticated reports whether ctx carries a peer that completed a TLS
+// handshake with at least one verified certificate chain (i.e. the peer
+// presented a client certificate signed by a CA the server trusts).
+func peerAuthenticated(ctx context.Context) bool {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.AuthInfo == nil {
+		return false
+	}
+
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return false
+	}
+
+	return len(tlsInfo.State.VerifiedChains) > 0
+}
+
+// isLoopback reports whether addr's host is restricted to the local
+// loopback interface (127.0.0.0/8 or ::1), including the "localhost"
+// hostname. Any other host -- a routable IP, a non-loopback hostname, or an
+// empty host (e.g. ":9001", which binds all interfaces) -- is treated as
+// non-loopback and fails closed by returning false. Mirrors
+// distributed.isLoopback (worker_node.go) for the coordinator's own bind.
+func isLoopback(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// No "host:port" structure found (e.g. a bare host); fall back to
+		// treating the whole string as the host.
+		host = addr
+	}
+
+	if host == "" {
+		// ":PORT" binds every interface, which is not loopback.
+		return false
+	}
+
+	if host == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Unresolved/non-IP hostname: fail closed rather than guess whether
+		// it resolves to loopback.
+		return false
+	}
+
+	return ip.IsLoopback()
 }
 
 // start starts the coordinator service on the given listener.

--- a/distributed/coordinator_tls_test.go
+++ b/distributed/coordinator_tls_test.go
@@ -1,0 +1,144 @@
+package distributed_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/zerfoo/zerfoo/distributed"
+	"github.com/zerfoo/zerfoo/distributed/coordinator"
+	"github.com/zerfoo/zerfoo/distributed/pb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// TestCoordinator_RegisterWorker_RejectsUnauthenticatedCaller is DIST-2
+// regression coverage: a coordinator configured with mutual TLS (SetTLS with
+// CACertPath set) must reject a caller that presents no TLS credentials at
+// all before RegisterWorker ever returns the peer list. This is the attack
+// the review calls out -- an unauthenticated network caller enumerating
+// every worker address in the cluster via a plaintext RegisterWorker call.
+func TestCoordinator_RegisterWorker_RejectsUnauthenticatedCaller(t *testing.T) {
+	dir := t.TempDir()
+	caCert, cert, key := distributed.GenerateTestCerts(t, dir)
+
+	tlsCfg := &distributed.TLSConfig{
+		CACertPath: caCert,
+		CertPath:   cert,
+		KeyPath:    key,
+	}
+
+	coord := coordinator.NewCoordinator(&syncWriter{}, 30*time.Second)
+	coord.SetTLS(tlsCfg)
+	if err := coord.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	t.Cleanup(coord.GracefulStop)
+
+	conn, err := grpc.NewClient(coord.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	client := pb.NewCoordinatorClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.RegisterWorker(ctx, &pb.RegisterWorkerRequest{WorkerId: "attacker", Address: "10.0.0.1:9001"})
+	if err == nil {
+		t.Fatalf("RegisterWorker() with no TLS credentials succeeded and returned peers=%v; want the handshake to reject it", resp.GetPeers())
+	}
+	if resp != nil {
+		t.Errorf("RegisterWorker() returned a non-nil response %v alongside error %v; want nil response on rejection", resp, err)
+	}
+	if got := status.Code(err); got != codes.Unavailable && got != codes.Unauthenticated {
+		t.Errorf("RegisterWorker() error code = %v, want Unavailable (TLS handshake failure) or Unauthenticated, got err = %v", got, err)
+	}
+}
+
+// TestCoordinator_RegisterWorker_TLSPairCompletesRegistration is DIST-2
+// regression coverage for the positive path: two callers that present valid
+// client certificates signed by the configured CA can register and receive
+// the correct peer list, proving the mTLS gate authenticates rather than
+// simply blocking all traffic.
+func TestCoordinator_RegisterWorker_TLSPairCompletesRegistration(t *testing.T) {
+	dir := t.TempDir()
+	caCert, cert, key := distributed.GenerateTestCerts(t, dir)
+
+	tlsCfg := &distributed.TLSConfig{
+		CACertPath: caCert,
+		CertPath:   cert,
+		KeyPath:    key,
+	}
+
+	coord := coordinator.NewCoordinator(&syncWriter{}, 30*time.Second)
+	coord.SetTLS(tlsCfg)
+	if err := coord.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start coordinator: %v", err)
+	}
+	t.Cleanup(coord.GracefulStop)
+
+	clientCreds, err := tlsCfg.ClientCredentials()
+	if err != nil {
+		t.Fatalf("client credentials: %v", err)
+	}
+
+	conn, err := grpc.NewClient(coord.Addr().String(), grpc.WithTransportCredentials(clientCreds))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	client := pb.NewCoordinatorClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp1, err := client.RegisterWorker(ctx, &pb.RegisterWorkerRequest{WorkerId: "w0", Address: "127.0.0.1:9001"})
+	if err != nil {
+		t.Fatalf("RegisterWorker(w0) with a valid client cert: %v, want nil", err)
+	}
+	if resp1.GetRank() != 0 {
+		t.Errorf("RegisterWorker(w0).Rank = %d, want 0", resp1.GetRank())
+	}
+	if got, want := resp1.GetPeers(), []string{"127.0.0.1:9001"}; len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("RegisterWorker(w0).Peers = %v, want %v", got, want)
+	}
+
+	resp2, err := client.RegisterWorker(ctx, &pb.RegisterWorkerRequest{WorkerId: "w1", Address: "127.0.0.1:9002"})
+	if err != nil {
+		t.Fatalf("RegisterWorker(w1) with a valid client cert: %v, want nil", err)
+	}
+	if resp2.GetRank() != 1 {
+		t.Errorf("RegisterWorker(w1).Rank = %d, want 1", resp2.GetRank())
+	}
+	wantPeers := []string{"127.0.0.1:9001", "127.0.0.1:9002"}
+	gotPeers := resp2.GetPeers()
+	if len(gotPeers) != len(wantPeers) {
+		t.Fatalf("RegisterWorker(w1).Peers = %v, want %v", gotPeers, wantPeers)
+	}
+	for i, addr := range wantPeers {
+		if gotPeers[i] != addr {
+			t.Errorf("RegisterWorker(w1).Peers[%d] = %q, want %q", i, gotPeers[i], addr)
+		}
+	}
+}
+
+// TestCoordinator_Start_RefusesNonLoopbackWithoutTLS is DIST-2 regression
+// coverage mirroring TestWorkerNode_Start_RefusesNonLoopbackWithoutTLS: a
+// coordinator bound to a routable address with no TLS configured must
+// refuse to start.
+func TestCoordinator_Start_RefusesNonLoopbackWithoutTLS(t *testing.T) {
+	coord := coordinator.NewCoordinator(&syncWriter{}, 30*time.Second)
+
+	err := coord.Start("0.0.0.0:0")
+	if err == nil {
+		coord.GracefulStop()
+		t.Fatal("expected Start to refuse a non-loopback bind without TLS, got nil error")
+	}
+	if got := err.Error(); got == "" {
+		t.Error("expected a descriptive error")
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes DIST-2 from `docs/deep-reviews/002-full-codebase.md`: the coordinator's gRPC server ran unauthenticated unless a caller invoked `SetServerOptions` (no such caller existed in production code). `RegisterWorker` trusted any caller to claim a rank and returned the full peer list, letting an unauthenticated network attacker enumerate every worker address in the cluster.
- Mirrors T140.1's worker-side fix (PR #947): `Coordinator` gains `SetTLS(*distributed.TLSConfig)`. `Start()` wires `TLSConfig.ServerCredentials()` into the coordinator's `grpc.NewServer()`, and refuses to bind a non-loopback address when TLS is not configured (same `isLoopback` host check used by the worker).
- When mutual TLS is configured (`CACertPath` set), `Start()` installs a `ChainUnaryInterceptor` that rejects any RPC whose peer did not present a verified client certificate -- so `RegisterWorker` never discloses the peer list to an unauthenticated caller, even if the transport-level TLS setup were somehow misconfigured.
- Loopback binds without TLS keep working unchanged for single-host dev use (existing tests/CLI callers using `localhost`/`127.0.0.1` are unaffected).

## Test plan

- [x] `TestCoordinator_RegisterWorker_RejectsUnauthenticatedCaller` -- a coordinator started with `SetTLS` rejects a plaintext (no-TLS) `RegisterWorker` call before any peer list is returned.
- [x] `TestCoordinator_RegisterWorker_TLSPairCompletesRegistration` -- two callers presenting valid client certs signed by the configured CA register successfully and receive the correct peer list.
- [x] `TestCoordinator_Start_RefusesNonLoopbackWithoutTLS` -- binding `0.0.0.0` without TLS is refused.
- [x] `go test ./distributed/...` green (including pre-existing `TestReaper_TimesOutWorker`, run x10 with no flake observed).
- [x] `gofmt -l` clean, `go vet ./distributed/...` clean, `golangci-lint run ./distributed/...` shows only pre-existing, unrelated findings in `distributed/fsdp` and `distributed/nccl.go`.