### PR TITLE
fix(serve): bound RateLimiter memory via scheduled cleanup + size cap (CONC-M1, T142.3)

### DIFF
--- a/serve/security/network.go
+++ b/serve/security/network.go
@@ -10,14 +10,40 @@ import (
 	"time"
 )
 
+// defaultMaxBuckets caps the number of distinct client IPs a RateLimiter
+// tracks at once. It is a backstop against unbounded memory growth (CONC-M1)
+// for the case where the periodic Cleanup ticker cannot keep pace with the
+// rate of distinct new IPs (e.g. a spoofed-source flood). Once the cap is
+// reached, the least-recently-seen entry is evicted to make room for a new
+// one; see evictOldestLocked.
+const defaultMaxBuckets = 100_000
+
 // RateLimiter implements a token-bucket rate limiter keyed by client IP.
+//
+// Left unmanaged, rl.buckets grows one permanent entry per distinct client
+// IP ever seen (CONC-M1). Two mitigations are applied:
+//
+//  1. Start launches a background goroutine that calls Cleanup every
+//     cleanTTL, evicting entries that have been idle for at least cleanTTL.
+//  2. maxBuckets hard-caps the map size as a backstop: once reached, the
+//     oldest entry is evicted before a new one is inserted, so growth stays
+//     bounded even if Cleanup cannot keep up.
+//
+// Server wires Start/Stop automatically via WithRateLimiter/Close. Callers
+// that use RateLimiter directly must call Start to enable scheduled cleanup
+// and Stop during shutdown to avoid leaking the ticker goroutine.
 type RateLimiter struct {
 	mu             sync.Mutex
 	buckets        map[string]*bucket
 	rate           float64 // tokens per second
 	burst          int     // maximum tokens
 	cleanTTL       time.Duration
+	maxBuckets     int             // hard cap on tracked IPs; 0 disables the cap
 	trustedProxies map[string]bool // IPs allowed to set X-Forwarded-For / X-Real-IP
+
+	started bool
+	stopCh  chan struct{}
+	wg      sync.WaitGroup
 }
 
 type bucket struct {
@@ -26,14 +52,84 @@ type bucket struct {
 }
 
 // NewRateLimiter creates a rate limiter allowing rate requests/second
-// with a burst capacity of burst.
+// with a burst capacity of burst. Call Start to begin the background
+// cleanup loop that keeps rl.buckets from growing unbounded (CONC-M1).
 func NewRateLimiter(rate float64, burst int) *RateLimiter {
 	return &RateLimiter{
-		buckets:  make(map[string]*bucket),
-		rate:     rate,
-		burst:    burst,
-		cleanTTL: 10 * time.Minute,
+		buckets:    make(map[string]*bucket),
+		rate:       rate,
+		burst:      burst,
+		cleanTTL:   10 * time.Minute,
+		maxBuckets: defaultMaxBuckets,
 	}
+}
+
+// SetMaxBuckets overrides the hard cap on the number of distinct client IPs
+// tracked at once. A value <= 0 disables the cap entirely (not recommended
+// in production; see CONC-M1).
+func (rl *RateLimiter) SetMaxBuckets(n int) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.maxBuckets = n
+}
+
+// Start begins the background cleanup loop, which calls Cleanup every
+// cleanTTL so rl.buckets does not grow unbounded under sustained traffic
+// from many distinct client IPs (CONC-M1). Start is idempotent: calling it
+// on an already-started limiter is a no-op. Call Stop during shutdown to
+// stop the loop and release its goroutine.
+func (rl *RateLimiter) Start() {
+	rl.mu.Lock()
+	if rl.started {
+		rl.mu.Unlock()
+		return
+	}
+	interval := rl.cleanTTL
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	stopCh := make(chan struct{})
+	rl.stopCh = stopCh
+	rl.started = true
+	rl.mu.Unlock()
+
+	rl.wg.Add(1)
+	go rl.cleanupLoop(interval, stopCh)
+}
+
+// cleanupLoop periodically calls Cleanup until stopCh is closed.
+func (rl *RateLimiter) cleanupLoop(interval time.Duration, stopCh chan struct{}) {
+	defer rl.wg.Done()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			rl.Cleanup()
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+// Stop halts the background cleanup loop started by Start and waits for its
+// goroutine to exit. It is safe to call even if Start was never called, and
+// safe to call multiple times. After Stop returns, Start may be called
+// again to resume scheduled cleanup.
+func (rl *RateLimiter) Stop() {
+	rl.mu.Lock()
+	if !rl.started {
+		rl.mu.Unlock()
+		return
+	}
+	rl.started = false
+	stopCh := rl.stopCh
+	rl.mu.Unlock()
+
+	close(stopCh)
+	rl.wg.Wait()
 }
 
 // SetTrustedProxies configures the set of proxy IPs whose
@@ -76,6 +172,9 @@ func (rl *RateLimiter) Allow(ip string) bool {
 	now := time.Now()
 	b, ok := rl.buckets[ip]
 	if !ok {
+		if rl.maxBuckets > 0 && len(rl.buckets) >= rl.maxBuckets {
+			rl.evictOldestLocked()
+		}
 		b = &bucket{tokens: float64(rl.burst), lastSee: now}
 		rl.buckets[ip] = b
 	}
@@ -92,6 +191,26 @@ func (rl *RateLimiter) Allow(ip string) bool {
 	}
 	b.tokens--
 	return true
+}
+
+// evictOldestLocked removes the single least-recently-seen bucket entry.
+// It is the size-cap backstop against unbounded growth (CONC-M1) for when
+// the periodic Cleanup ticker cannot keep pace with the rate of distinct
+// new client IPs. Callers must hold rl.mu.
+func (rl *RateLimiter) evictOldestLocked() {
+	var oldestIP string
+	var oldestTime time.Time
+	found := false
+	for ip, b := range rl.buckets {
+		if !found || b.lastSee.Before(oldestTime) {
+			oldestIP = ip
+			oldestTime = b.lastSee
+			found = true
+		}
+	}
+	if found {
+		delete(rl.buckets, oldestIP)
+	}
 }
 
 // Cleanup removes stale entries older than the configured TTL.

--- a/serve/security/network_test.go
+++ b/serve/security/network_test.go
@@ -1,9 +1,12 @@
 package security
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func TestRateLimiterAllow(t *testing.T) {
@@ -37,6 +40,120 @@ func TestRateLimiterCleanup(t *testing.T) {
 	rl.mu.Unlock()
 	if n != 0 {
 		t.Fatalf("expected 0 buckets after cleanup, got %d", n)
+	}
+}
+
+// TestRateLimiterSizeCapBackstop is a regression test for CONC-M1: without a
+// cap, rl.buckets grows one permanent entry per distinct client IP ever
+// seen. It simulates sustained traffic from far more distinct IPs than the
+// configured cap and asserts the map never grows past it, even though no
+// cleanup ever runs (no Start, no Cleanup call) -- the cap is a standalone
+// backstop, not merely a side effect of scheduled cleanup.
+func TestRateLimiterSizeCapBackstop(t *testing.T) {
+	rl := NewRateLimiter(10, 5)
+	rl.SetMaxBuckets(50)
+
+	for i := 0; i < 1000; i++ {
+		rl.Allow(fmt.Sprintf("10.%d.%d.%d", i/65536, (i/256)%256, i%256))
+	}
+
+	rl.mu.Lock()
+	n := len(rl.buckets)
+	rl.mu.Unlock()
+
+	if n > 50 {
+		t.Fatalf("bucket map grew past the configured cap: got %d entries, want <= 50", n)
+	}
+	if n == 0 {
+		t.Fatal("expected some buckets to remain after traffic")
+	}
+}
+
+// TestRateLimiterBackgroundCleanupBounded is a regression test for CONC-M1:
+// Cleanup existed but was never scheduled, so rl.buckets grew unbounded
+// under sustained traffic from many distinct client IPs. It drives traffic
+// from many distinct IPs, starts the background cleanup loop, then advances
+// past cleanTTL and confirms the bucket count shrinks back down instead of
+// growing without bound.
+func TestRateLimiterBackgroundCleanupBounded(t *testing.T) {
+	rl := NewRateLimiter(10, 5)
+	rl.cleanTTL = 30 * time.Millisecond
+	rl.Start()
+	defer rl.Stop()
+
+	// Sustained traffic from many distinct client IPs.
+	for i := 0; i < 500; i++ {
+		rl.Allow(fmt.Sprintf("192.168.%d.%d", i/256, i%256))
+	}
+
+	rl.mu.Lock()
+	grown := len(rl.buckets)
+	rl.mu.Unlock()
+	if grown == 0 {
+		t.Fatal("expected buckets to be populated after traffic")
+	}
+
+	// With no further traffic, every existing bucket becomes stale once
+	// cleanTTL elapses; the background ticker should sweep them all without
+	// any manual Cleanup call.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		rl.mu.Lock()
+		n := len(rl.buckets)
+		rl.mu.Unlock()
+		if n == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("bucket map did not shrink after cleanTTL elapsed: still has %d entries (grew to %d)", n, grown)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestRateLimiterStartStopNoGoroutineLeak confirms the background cleanup
+// ticker goroutine started by Start is fully reaped by Stop, that Start and
+// Stop are each idempotent, and that Start/Stop can be safely repeated
+// (e.g. across server restarts in tests) without accumulating goroutines.
+func TestRateLimiterStartStopNoGoroutineLeak(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	rl := NewRateLimiter(10, 5)
+	rl.cleanTTL = 5 * time.Millisecond
+	rl.Start()
+	rl.Start() // idempotent: must not spawn a second ticker goroutine
+
+	time.Sleep(20 * time.Millisecond) // let a few ticks fire
+
+	rl.Stop()
+	rl.Stop() // idempotent: must not panic or block
+
+	if !waitForGoroutineCountAtMost(before, 2*time.Second) {
+		t.Fatalf("cleanup goroutine leaked after Stop: before=%d after=%d", before, runtime.NumGoroutine())
+	}
+
+	// Repeat the cycle to confirm no accumulation across restarts.
+	rl.Start()
+	time.Sleep(10 * time.Millisecond)
+	rl.Stop()
+
+	if !waitForGoroutineCountAtMost(before, 2*time.Second) {
+		t.Fatalf("cleanup goroutine leaked after restart: before=%d after=%d", before, runtime.NumGoroutine())
+	}
+}
+
+// waitForGoroutineCountAtMost polls runtime.NumGoroutine until it is <= want
+// or timeout elapses, to avoid flaking on transient scheduler goroutines.
+func waitForGoroutineCountAtMost(want int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if runtime.NumGoroutine() <= want {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/serve/server.go
+++ b/serve/server.go
@@ -160,6 +160,12 @@ func NewServer(m *inference.Model, opts ...ServerOption) *Server {
 	if s.collector == nil {
 		s.collector = runtime.Nop()
 	}
+	// Start the rate limiter's background cleanup loop so its per-IP bucket
+	// map does not grow unbounded under sustained traffic from many distinct
+	// client IPs (CONC-M1). Close stops it again.
+	if s.rateLimiter != nil {
+		s.rateLimiter.Start()
+	}
 	// Auto-wire batch handler to use GenerateBatch when a BatchScheduler
 	// is attached but no handler has been configured.
 	if s.batch != nil && s.batch.config.Handler == nil {
@@ -419,6 +425,9 @@ func (s *Server) recoveryMiddleware(next http.HandlerFunc) http.HandlerFunc {
 func (s *Server) Close(_ context.Context) error {
 	if s.batch != nil {
 		s.batch.Stop()
+	}
+	if s.rateLimiter != nil {
+		s.rateLimiter.Stop()
 	}
 	return nil
 }

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -1833,6 +1833,7 @@ func TestRateLimitMiddleware(t *testing.T) {
 	// Allow 2 requests with burst=2, rate=0 (no refill).
 	rl := security.NewRateLimiter(0, 2)
 	srv := NewServer(m, WithRateLimiter(rl))
+	defer srv.Close(context.Background())
 	handler := srv.Handler()
 
 	// First two requests should succeed.


### PR DESCRIPTION
## Summary
- `serve/security/network.go`: `RateLimiter.Cleanup` existed but was never scheduled outside tests, so `rl.buckets` grew one permanent entry per distinct client IP under sustained traffic (CONC-M1, deep-review 002).
- Add `Start`/`Stop` on `RateLimiter`: `Start` launches a background goroutine that calls `Cleanup` every `cleanTTL`; `Stop` halts it and waits for the goroutine to exit. Both are idempotent and safe to call repeatedly (e.g. across server restarts in tests).
- Add a `maxBuckets` size-cap backstop (default 100k, configurable via `SetMaxBuckets`): once the map is full, `Allow` evicts the least-recently-seen entry before inserting a new one, bounding memory even if the ticker can't keep pace.
- `serve/server.go`: `NewServer` now calls `rateLimiter.Start()` when a `RateLimiter` is attached via `WithRateLimiter`, and `Server.Close` calls `rateLimiter.Stop()`.

## Test plan
- [x] `TestRateLimiterSizeCapBackstop` — 1000 distinct IPs against a cap of 50, map never exceeds the cap.
- [x] `TestRateLimiterBackgroundCleanupBounded` — 500 distinct IPs, then advances past `cleanTTL` and confirms the background ticker sweeps all stale buckets without a manual `Cleanup` call.
- [x] `TestRateLimiterStartStopNoGoroutineLeak` — confirms the ticker goroutine is fully reaped after `Stop`, `Start`/`Stop` are idempotent, and repeated Start/Stop cycles don't accumulate goroutines.
- [x] `gofmt -l` clean on all touched files; `go vet ./...` clean.
- [x] `go test ./serve/...` and `go test -race -run 'TestRateLimiter|TestRateLimitMiddleware' ./serve/...` green.