### PR TITLE
fix(cuda): prefer absolute vendor-library paths across native loaders (CUDA-2, T141.2)

### DIFF
--- a/internal/cublas/cublas_purego.go
+++ b/internal/cublas/cublas_purego.go
@@ -2,6 +2,7 @@ package cublas
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"unsafe"
 
@@ -51,10 +52,44 @@ var (
 	errCblasLoad error
 )
 
-// cuBLAS library paths to try.
-var cublasLibPaths = []string{
-	"libcublas.so.12",
-	"libcublas.so",
+// cublasLibPathOverrideEnv names an environment variable that, if set to a
+// vetted absolute path, is tried before trustedCublasLibPaths. See
+// cuda.VetAbsoluteLibPath for the safety checks applied.
+const cublasLibPathOverrideEnv = "ZERFOO_CUBLAS_LIB_PATH"
+
+// trustedCublasLibPaths mirror the CUDA toolkit install location zerfoo's
+// own deployments use (docs/bench/manifests/*.yaml mount /usr/local/cuda
+// read-only and set LD_LIBRARY_PATH=/usr/local/cuda/lib64). Trying these
+// absolute paths first means dlopen never has to consult
+// LD_LIBRARY_PATH/RPATH at all on a host that matches this convention.
+var trustedCublasLibPaths = []string{
+	"/usr/local/cuda/lib64/libcublas.so.12",
+	"/usr/local/cuda/lib64/libcublas.so",
+}
+
+// cuBLAS library paths to try, in order.
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): the trailing
+// bare-soname entries are a DOCUMENTED residual trust assumption, not an
+// oversight -- see the equivalent comment on cudartPaths in
+// internal/cuda/purego.go for the full rationale (cuBLAS ships as part of
+// the CUDA toolkit, a third-party install whose location genuinely varies
+// across hosts, unlike zerfoo's own libkernels.so). We try the trusted
+// zerfoo-deployment path (and any vetted operator override) first, and
+// only fall back to a bare soname when no trusted absolute install is
+// found.
+var cublasLibPaths = buildCublasLibPaths()
+
+func buildCublasLibPaths() []string {
+	paths := make([]string, 0, len(trustedCublasLibPaths)+3)
+	if override := os.Getenv(cublasLibPathOverrideEnv); override != "" {
+		if vetted, ok := cuda.VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+	}
+	paths = append(paths, trustedCublasLibPaths...)
+	paths = append(paths, "libcublas.so.12", "libcublas.so")
+	return paths
 }
 
 func loadCublas() (*cublasLib, error) {

--- a/internal/cublas/cublaslt_purego.go
+++ b/internal/cublas/cublaslt_purego.go
@@ -2,6 +2,7 @@ package cublas
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"unsafe"
 
@@ -110,10 +111,37 @@ var (
 	errLtLoad error
 )
 
-// cublasLt library paths to try.
-var cublasLtLibPaths = []string{
-	"libcublasLt.so.12",
-	"libcublasLt.so",
+// cublasLtLibPathOverrideEnv names an environment variable that, if set to
+// a vetted absolute path, is tried before trustedCublasLtLibPaths. See
+// cuda.VetAbsoluteLibPath for the safety checks applied.
+const cublasLtLibPathOverrideEnv = "ZERFOO_CUBLASLT_LIB_PATH"
+
+// trustedCublasLtLibPaths mirror the CUDA toolkit install location zerfoo's
+// own deployments use (docs/bench/manifests/*.yaml mount /usr/local/cuda
+// read-only and set LD_LIBRARY_PATH=/usr/local/cuda/lib64).
+var trustedCublasLtLibPaths = []string{
+	"/usr/local/cuda/lib64/libcublasLt.so.12",
+	"/usr/local/cuda/lib64/libcublasLt.so",
+}
+
+// cublasLt library paths to try, in order.
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): the trailing
+// bare-soname entries are a DOCUMENTED residual trust assumption -- see the
+// equivalent comment on cublasLibPaths above and on cudartPaths in
+// internal/cuda/purego.go for the full rationale.
+var cublasLtLibPaths = buildCublasLtLibPaths()
+
+func buildCublasLtLibPaths() []string {
+	paths := make([]string, 0, len(trustedCublasLtLibPaths)+3)
+	if override := os.Getenv(cublasLtLibPathOverrideEnv); override != "" {
+		if vetted, ok := cuda.VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+	}
+	paths = append(paths, trustedCublasLtLibPaths...)
+	paths = append(paths, "libcublasLt.so.12", "libcublasLt.so")
+	return paths
 }
 
 func loadCublasLt() (*cublasLtLib, error) {

--- a/internal/cublas/dlopen_security_test.go
+++ b/internal/cublas/dlopen_security_test.go
@@ -1,0 +1,82 @@
+package cublas
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCublasLibPathsPreferAbsolute is the CUDA-2 regression guard
+// (docs/deep-reviews/002-full-codebase.md): the trusted absolute CUDA
+// toolkit locations must always be tried before the documented bare-soname
+// fallback.
+func TestCublasLibPathsPreferAbsolute(t *testing.T) {
+	if len(cublasLibPaths) < len(trustedCublasLibPaths) {
+		t.Fatalf("expected at least %d candidates, got %v", len(trustedCublasLibPaths), cublasLibPaths)
+	}
+	for i, want := range trustedCublasLibPaths {
+		if cublasLibPaths[i] != want {
+			t.Fatalf("expected trusted absolute path %q at index %d, got %v", want, i, cublasLibPaths)
+		}
+	}
+	for _, p := range cublasLibPaths[len(trustedCublasLibPaths):] {
+		if p == "./libcublas.so" || p == "." {
+			t.Fatalf("cublasLibPaths fallback must not contain a CWD-relative entry: %q", p)
+		}
+	}
+}
+
+func TestBuildCublasLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libcublas.so.12")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(cublasLibPathOverrideEnv, path)
+	paths := buildCublasLibPaths()
+	if len(paths) == 0 || paths[0] != path {
+		t.Fatalf("expected override %q first, got %v", path, paths)
+	}
+}
+
+func TestBuildCublasLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(cublasLibPathOverrideEnv, "./libcublas.so")
+	paths := buildCublasLibPaths()
+	if len(paths) == 0 || paths[0] != trustedCublasLibPaths[0] {
+		t.Fatalf("expected invalid override to be dropped, got %v", paths)
+	}
+}
+
+// TestCublasLtLibPathsPreferAbsolute mirrors TestCublasLibPathsPreferAbsolute
+// for cublasLt.
+func TestCublasLtLibPathsPreferAbsolute(t *testing.T) {
+	if len(cublasLtLibPaths) < len(trustedCublasLtLibPaths) {
+		t.Fatalf("expected at least %d candidates, got %v", len(trustedCublasLtLibPaths), cublasLtLibPaths)
+	}
+	for i, want := range trustedCublasLtLibPaths {
+		if cublasLtLibPaths[i] != want {
+			t.Fatalf("expected trusted absolute path %q at index %d, got %v", want, i, cublasLtLibPaths)
+		}
+	}
+}
+
+func TestBuildCublasLtLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libcublasLt.so.12")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(cublasLtLibPathOverrideEnv, path)
+	paths := buildCublasLtLibPaths()
+	if len(paths) == 0 || paths[0] != path {
+		t.Fatalf("expected override %q first, got %v", path, paths)
+	}
+}
+
+func TestBuildCublasLtLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(cublasLtLibPathOverrideEnv, "./libcublasLt.so")
+	paths := buildCublasLtLibPaths()
+	if len(paths) == 0 || paths[0] != trustedCublasLtLibPaths[0] {
+		t.Fatalf("expected invalid override to be dropped, got %v", paths)
+	}
+}

--- a/internal/cuda/purego.go
+++ b/internal/cuda/purego.go
@@ -45,12 +45,53 @@ var (
 	errGlobal  error
 )
 
-// cudartPaths lists the shared library names to try, in order.
-// On Linux, libcudart.so is the standard name. The versioned
-// name (libcudart.so.12) is tried first for specificity.
-var cudartPaths = []string{
-	"libcudart.so.12",
-	"libcudart.so",
+// cudartLibPathOverrideEnv names an environment variable that, if set to a
+// vetted absolute path, is tried before trustedCudartLibPaths. See
+// VetAbsoluteLibPath for the safety checks applied.
+const cudartLibPathOverrideEnv = "ZERFOO_CUDART_LIB_PATH"
+
+// trustedCudartLibPaths are the CUDA toolkit install locations zerfoo's own
+// deployments use: docs/bench/manifests/*.yaml mount /usr/local/cuda
+// read-only and set LD_LIBRARY_PATH=/usr/local/cuda/lib64. Trying these
+// absolute paths first means dlopen never has to consult
+// LD_LIBRARY_PATH/RPATH at all on a host that matches this convention.
+var trustedCudartLibPaths = []string{
+	"/usr/local/cuda/lib64/libcudart.so.12",
+	"/usr/local/cuda/lib64/libcudart.so",
+}
+
+// cudartPaths lists the shared library candidates to try, in order.
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): the trailing
+// bare-soname entries are a residual, DOCUMENTED trust assumption, not an
+// oversight. Unlike libkernels.so (a zerfoo-built artifact with exactly one
+// vetted install location -- see kernelLibPaths and CUDA-1), the CUDA
+// toolkit is a third-party install whose location genuinely varies across
+// hosts (distro package managers, conda/pip environments, non-standard
+// prefixes), so there is no single absolute path we can force. We try the
+// trusted zerfoo-deployment path (and any vetted operator override) first,
+// eliminating the LD_LIBRARY_PATH/RPATH hijack window whenever the trusted
+// path resolves, and only fall back to a bare soname -- resolved via the
+// default dynamic-linker search path, hijackable via LD_LIBRARY_PATH -- when
+// no trusted absolute install is found. TestCudartPathsPreferAbsolute
+// enforces that the absolute candidates always precede the bare fallback.
+var cudartPaths = buildCudartPaths()
+
+// buildCudartPaths assembles the dlopen candidate list: an optional vetted
+// override, then the trusted absolute defaults, then the bare-soname
+// fallback documented above.
+func buildCudartPaths() []string {
+	paths := make([]string, 0, len(trustedCudartLibPaths)+3)
+	if override := os.Getenv(cudartLibPathOverrideEnv); override != "" {
+		if vetted, ok := VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+		// An invalid override is silently ignored (not fatal): we fall
+		// through to the trusted defaults rather than refusing to start.
+	}
+	paths = append(paths, trustedCudartLibPaths...)
+	paths = append(paths, "libcudart.so.12", "libcudart.so")
+	return paths
 }
 
 // Open loads libcudart via dlopen and resolves all CUDA runtime
@@ -203,13 +244,26 @@ func buildKernelLibPaths() []string {
 	return paths
 }
 
-// vetKernelLibOverride validates that path is safe to hand to dlopen: it
-// must be an absolute path (never CWD-relative or a bare soname), it must
-// exist, and it must not be world-writable -- a world-writable "trusted"
-// path is just as hijackable as a CWD-relative one, since any local user
-// could replace its contents with a malicious library whose ELF
-// constructors run on the next dlopen.
+// vetKernelLibOverride validates that path is safe to hand to dlopen for the
+// kernel library override. Kept as a thin, package-local alias of
+// VetAbsoluteLibPath so existing CUDA-1 regression tests keep working
+// unchanged.
 func vetKernelLibOverride(path string) (string, bool) {
+	return VetAbsoluteLibPath(path)
+}
+
+// VetAbsoluteLibPath validates that path is safe to hand to dlopen as an
+// operator-provided override for any native library candidate list in this
+// module (CUDA runtime, cuBLAS, cuDNN, HIP, rocBLAS, MIOpen, OpenCL,
+// TensorRT, and the zerfoo-built kernel shims -- see CUDA-2,
+// docs/deep-reviews/002-full-codebase.md). The path must be absolute (never
+// CWD-relative or a bare soname), it must exist, and it must not be
+// world-writable -- a world-writable "trusted" path is just as hijackable
+// as a CWD-relative one, since any local user could replace its contents
+// with a malicious library whose ELF constructors run on the next dlopen.
+// Exported so every internal/*/purego.go loader can share one vetting
+// implementation instead of re-deriving these checks.
+func VetAbsoluteLibPath(path string) (string, bool) {
 	if !filepath.IsAbs(path) {
 		return "", false
 	}

--- a/internal/cuda/purego_test.go
+++ b/internal/cuda/purego_test.go
@@ -197,6 +197,53 @@ func TestBuildKernelLibPathsUsesValidOverrideFirst(t *testing.T) {
 	}
 }
 
+// TestCudartPathsPreferAbsolute is the CUDA-2 regression guard
+// (docs/deep-reviews/002-full-codebase.md): the trusted absolute CUDA
+// toolkit locations must always be tried before the documented bare-soname
+// fallback, so that on any host matching zerfoo's deployment convention
+// dlopen never consults LD_LIBRARY_PATH/RPATH.
+func TestCudartPathsPreferAbsolute(t *testing.T) {
+	if len(cudartPaths) < len(trustedCudartLibPaths) {
+		t.Fatalf("expected at least %d candidates, got %v", len(trustedCudartLibPaths), cudartPaths)
+	}
+	for i, want := range trustedCudartLibPaths {
+		if cudartPaths[i] != want {
+			t.Fatalf("expected trusted absolute path %q at index %d, got %v", want, i, cudartPaths)
+		}
+	}
+	for _, p := range cudartPaths[len(trustedCudartLibPaths):] {
+		if filepath.IsAbs(p) {
+			continue
+		}
+		// Bare-soname fallback entries are expected here (documented CUDA-2
+		// residual trust assumption); just make sure none are CWD-relative.
+		if p == "." || (len(p) >= 2 && p[:2] == "./") {
+			t.Fatalf("cudartPaths fallback must not contain a CWD-relative entry: %q", p)
+		}
+	}
+}
+
+func TestBuildCudartPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libcudart.so.12")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(cudartLibPathOverrideEnv, path)
+	paths := buildCudartPaths()
+	if len(paths) == 0 || paths[0] != path {
+		t.Fatalf("expected override %q first, got %v", path, paths)
+	}
+}
+
+func TestBuildCudartPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(cudartLibPathOverrideEnv, "./libcudart.so.12")
+	paths := buildCudartPaths()
+	if len(paths) == 0 || paths[0] != trustedCudartLibPaths[0] {
+		t.Fatalf("expected invalid override to be dropped, got %v", paths)
+	}
+}
+
 func TestDlopenImplWithLibSystem(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("libSystem test only runs on macOS")

--- a/internal/cudnn/cudnn_purego.go
+++ b/internal/cudnn/cudnn_purego.go
@@ -2,6 +2,7 @@ package cudnn
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"unsafe"
 
@@ -278,11 +279,39 @@ var (
 	errCuDNN        error
 )
 
-// cudnnPaths lists the shared library names to try, in order.
-var cudnnPaths = []string{
-	"libcudnn.so.9",
-	"libcudnn.so.8",
-	"libcudnn.so",
+// cudnnLibPathOverrideEnv names an environment variable that, if set to a
+// vetted absolute path, is tried before trustedCudnnLibPaths. See
+// cuda.VetAbsoluteLibPath for the safety checks applied.
+const cudnnLibPathOverrideEnv = "ZERFOO_CUDNN_LIB_PATH"
+
+// trustedCudnnLibPaths mirror the CUDA toolkit install location zerfoo's
+// own deployments use (docs/bench/manifests/*.yaml mount /usr/local/cuda
+// read-only and set LD_LIBRARY_PATH=/usr/local/cuda/lib64).
+var trustedCudnnLibPaths = []string{
+	"/usr/local/cuda/lib64/libcudnn.so.9",
+	"/usr/local/cuda/lib64/libcudnn.so.8",
+	"/usr/local/cuda/lib64/libcudnn.so",
+}
+
+// cudnnPaths lists the shared library candidates to try, in order.
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): the trailing
+// bare-soname entries are a DOCUMENTED residual trust assumption -- see the
+// equivalent comment on cudartPaths in internal/cuda/purego.go for the full
+// rationale (cuDNN is a third-party CUDA toolkit component whose install
+// location genuinely varies across hosts).
+var cudnnPaths = buildCudnnLibPaths()
+
+func buildCudnnLibPaths() []string {
+	paths := make([]string, 0, len(trustedCudnnLibPaths)+4)
+	if override := os.Getenv(cudnnLibPathOverrideEnv); override != "" {
+		if vetted, ok := cuda.VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+	}
+	paths = append(paths, trustedCudnnLibPaths...)
+	paths = append(paths, "libcudnn.so.9", "libcudnn.so.8", "libcudnn.so")
+	return paths
 }
 
 // openCuDNN loads libcudnn via dlopen and resolves all function pointers.

--- a/internal/cudnn/dlopen_security_test.go
+++ b/internal/cudnn/dlopen_security_test.go
@@ -1,0 +1,48 @@
+package cudnn
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCudnnPathsPreferAbsolute is the CUDA-2 regression guard
+// (docs/deep-reviews/002-full-codebase.md): the trusted absolute CUDA
+// toolkit locations must always be tried before the documented bare-soname
+// fallback.
+func TestCudnnPathsPreferAbsolute(t *testing.T) {
+	if len(cudnnPaths) < len(trustedCudnnLibPaths) {
+		t.Fatalf("expected at least %d candidates, got %v", len(trustedCudnnLibPaths), cudnnPaths)
+	}
+	for i, want := range trustedCudnnLibPaths {
+		if cudnnPaths[i] != want {
+			t.Fatalf("expected trusted absolute path %q at index %d, got %v", want, i, cudnnPaths)
+		}
+	}
+	for _, p := range cudnnPaths[len(trustedCudnnLibPaths):] {
+		if p == "./libcudnn.so" || p == "." {
+			t.Fatalf("cudnnPaths fallback must not contain a CWD-relative entry: %q", p)
+		}
+	}
+}
+
+func TestBuildCudnnLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libcudnn.so.9")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(cudnnLibPathOverrideEnv, path)
+	paths := buildCudnnLibPaths()
+	if len(paths) == 0 || paths[0] != path {
+		t.Fatalf("expected override %q first, got %v", path, paths)
+	}
+}
+
+func TestBuildCudnnLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(cudnnLibPathOverrideEnv, "./libcudnn.so")
+	paths := buildCudnnLibPaths()
+	if len(paths) == 0 || paths[0] != trustedCudnnLibPaths[0] {
+		t.Fatalf("expected invalid override to be dropped, got %v", paths)
+	}
+}

--- a/internal/hip/dlopen_security_test.go
+++ b/internal/hip/dlopen_security_test.go
@@ -1,0 +1,48 @@
+package hip
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHipPathsPreferAbsolute is the CUDA-2 regression guard
+// (docs/deep-reviews/002-full-codebase.md): the trusted absolute ROCm
+// install locations must always be tried before the documented bare-soname
+// fallback.
+func TestHipPathsPreferAbsolute(t *testing.T) {
+	if len(hipPaths) < len(trustedHipLibPaths) {
+		t.Fatalf("expected at least %d candidates, got %v", len(trustedHipLibPaths), hipPaths)
+	}
+	for i, want := range trustedHipLibPaths {
+		if hipPaths[i] != want {
+			t.Fatalf("expected trusted absolute path %q at index %d, got %v", want, i, hipPaths)
+		}
+	}
+	for _, p := range hipPaths[len(trustedHipLibPaths):] {
+		if p == "./libamdhip64.so" || p == "." {
+			t.Fatalf("hipPaths fallback must not contain a CWD-relative entry: %q", p)
+		}
+	}
+}
+
+func TestBuildHipLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libamdhip64.so.6")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(hipLibPathOverrideEnv, path)
+	paths := buildHipLibPaths()
+	if len(paths) == 0 || paths[0] != path {
+		t.Fatalf("expected override %q first, got %v", path, paths)
+	}
+}
+
+func TestBuildHipLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(hipLibPathOverrideEnv, "./libamdhip64.so")
+	paths := buildHipLibPaths()
+	if len(paths) == 0 || paths[0] != trustedHipLibPaths[0] {
+		t.Fatalf("expected invalid override to be dropped, got %v", paths)
+	}
+}

--- a/internal/hip/kernels/dlopen_security_test.go
+++ b/internal/hip/kernels/dlopen_security_test.go
@@ -1,0 +1,57 @@
+package kernels
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHipKernelPathsAreAbsolute is the CUDA-2 regression guard
+// (docs/deep-reviews/002-full-codebase.md, mirroring CUDA-1's
+// TestKernelLibPathsAreAbsolute in internal/cuda/purego_test.go): the HIP
+// kernel shim is a zerfoo-built artifact with exactly one vetted install
+// location, like libkernels.so, so every dlopen candidate must be an
+// absolute path -- never a bare soname or CWD-relative entry.
+func TestHipKernelPathsAreAbsolute(t *testing.T) {
+	if len(hipKernelPaths) == 0 {
+		t.Fatal("expected hipKernelPaths to contain at least the trusted default")
+	}
+	for _, p := range hipKernelPaths {
+		if !filepath.IsAbs(p) {
+			t.Fatalf("hipKernelPaths contains a non-absolute (CWD-relative or bare-soname) entry: %q", p)
+		}
+	}
+}
+
+func TestHipKernelPathsContainsTrustedDefault(t *testing.T) {
+	found := false
+	for _, p := range hipKernelPaths {
+		if p == trustedHipKernelLibPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected hipKernelPaths to contain trusted default %q, got %v", trustedHipKernelLibPath, hipKernelPaths)
+	}
+}
+
+func TestBuildHipKernelLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(hipKernelLibPathOverrideEnv, "./libhipkernels.so")
+	paths := buildHipKernelLibPaths()
+	if len(paths) != 1 || paths[0] != trustedHipKernelLibPath {
+		t.Fatalf("expected invalid override to fall through to trusted default only, got %v", paths)
+	}
+}
+
+func TestBuildHipKernelLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libhipkernels.so")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(hipKernelLibPathOverrideEnv, path)
+	paths := buildHipKernelLibPaths()
+	if len(paths) != 2 || paths[0] != path || paths[1] != trustedHipKernelLibPath {
+		t.Fatalf("expected [override, trustedDefault], got %v", paths)
+	}
+}

--- a/internal/hip/kernels/purego.go
+++ b/internal/hip/kernels/purego.go
@@ -2,6 +2,7 @@ package kernels
 
 import (
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/zerfoo/zerfoo/internal/cuda"
@@ -30,9 +31,38 @@ type KernelLib struct {
 	launchFlashAttentionF32 uintptr
 }
 
-// hipKernelPaths lists the shared library names to try, in order.
-var hipKernelPaths = []string{
-	"libhipkernels.so",
+// trustedHipKernelLibPath is the vetted, absolute production location for
+// the custom HIP kernels shared library, mirroring the
+// /opt/zerfoo/lib/libkernels.so convention already established for CUDA
+// custom kernels (internal/cuda/purego.go, CUDA-1, T141.1) -- both are
+// zerfoo-compiled artifacts with one intended install location, not
+// third-party vendor libraries.
+const trustedHipKernelLibPath = "/opt/zerfoo/lib/libhipkernels.so"
+
+// hipKernelLibPathOverrideEnv names an environment variable that, if set to
+// a vetted absolute path, is tried before trustedHipKernelLibPath. See
+// cuda.VetAbsoluteLibPath for the safety checks applied.
+const hipKernelLibPathOverrideEnv = "ZERFOO_HIP_KERNEL_LIB_PATH"
+
+// hipKernelPaths lists paths to try for the custom HIP kernels shared
+// library.
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): every entry
+// here MUST be an absolute path -- see the identical rationale on
+// kernelLibPaths in internal/cuda/purego.go (CUDA-1). Do not reintroduce a
+// relative or bare-soname candidate; TestHipKernelPathsAreAbsolute enforces
+// this.
+var hipKernelPaths = buildHipKernelLibPaths()
+
+func buildHipKernelLibPaths() []string {
+	paths := make([]string, 0, 2)
+	if override := os.Getenv(hipKernelLibPathOverrideEnv); override != "" {
+		if vetted, ok := cuda.VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+	}
+	paths = append(paths, trustedHipKernelLibPath)
+	return paths
 }
 
 var (

--- a/internal/hip/purego.go
+++ b/internal/hip/purego.go
@@ -2,6 +2,7 @@ package hip
 
 import (
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/zerfoo/zerfoo/internal/cuda"
@@ -34,10 +35,42 @@ var (
 	errGlobal  error
 )
 
-// hipPaths lists the shared library names to try, in order.
-var hipPaths = []string{
-	"libamdhip64.so.6",
-	"libamdhip64.so",
+// hipLibPathOverrideEnv names an environment variable that, if set to a
+// vetted absolute path, is tried before trustedHipLibPaths. See
+// cuda.VetAbsoluteLibPath for the safety checks applied.
+const hipLibPathOverrideEnv = "ZERFOO_HIP_LIB_PATH"
+
+// trustedHipLibPaths use /opt/rocm/lib, AMD's standard ROCm install prefix
+// (documented ROCm convention, not zerfoo-specific -- no zerfoo deployment
+// mounts a ROCm host yet, see docs/adr/012-amd-rocm-backend.md: "GPU paths
+// untested without hardware"). Trying this absolute path first means dlopen
+// never has to consult LD_LIBRARY_PATH/RPATH at all on a standard ROCm
+// install.
+var trustedHipLibPaths = []string{
+	"/opt/rocm/lib/libamdhip64.so.6",
+	"/opt/rocm/lib/libamdhip64.so",
+}
+
+// hipPaths lists the shared library candidates to try, in order.
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): the trailing
+// bare-soname entries are a DOCUMENTED residual trust assumption -- see the
+// equivalent comment on cudartPaths in internal/cuda/purego.go for the full
+// rationale. ROCm packages sometimes install outside /opt/rocm (distro
+// packages, custom prefixes), so we keep the bare-soname fallback rather
+// than failing closed on hosts that don't match the standard convention.
+var hipPaths = buildHipLibPaths()
+
+func buildHipLibPaths() []string {
+	paths := make([]string, 0, len(trustedHipLibPaths)+3)
+	if override := os.Getenv(hipLibPathOverrideEnv); override != "" {
+		if vetted, ok := cuda.VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+	}
+	paths = append(paths, trustedHipLibPaths...)
+	paths = append(paths, "libamdhip64.so.6", "libamdhip64.so")
+	return paths
 }
 
 // Open loads libamdhip64 via dlopen and resolves all HIP runtime

--- a/internal/miopen/dlopen_security_test.go
+++ b/internal/miopen/dlopen_security_test.go
@@ -1,0 +1,48 @@
+package miopen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMiopenPathsPreferAbsolute is the CUDA-2 regression guard
+// (docs/deep-reviews/002-full-codebase.md): the trusted absolute ROCm
+// install locations must always be tried before the documented bare-soname
+// fallback.
+func TestMiopenPathsPreferAbsolute(t *testing.T) {
+	if len(miopenPaths) < len(trustedMiopenLibPaths) {
+		t.Fatalf("expected at least %d candidates, got %v", len(trustedMiopenLibPaths), miopenPaths)
+	}
+	for i, want := range trustedMiopenLibPaths {
+		if miopenPaths[i] != want {
+			t.Fatalf("expected trusted absolute path %q at index %d, got %v", want, i, miopenPaths)
+		}
+	}
+	for _, p := range miopenPaths[len(trustedMiopenLibPaths):] {
+		if p == "./libMIOpen.so" || p == "." {
+			t.Fatalf("miopenPaths fallback must not contain a CWD-relative entry: %q", p)
+		}
+	}
+}
+
+func TestBuildMiopenLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libMIOpen.so.1")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(miopenLibPathOverrideEnv, path)
+	paths := buildMiopenLibPaths()
+	if len(paths) == 0 || paths[0] != path {
+		t.Fatalf("expected override %q first, got %v", path, paths)
+	}
+}
+
+func TestBuildMiopenLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(miopenLibPathOverrideEnv, "./libMIOpen.so")
+	paths := buildMiopenLibPaths()
+	if len(paths) == 0 || paths[0] != trustedMiopenLibPaths[0] {
+		t.Fatalf("expected invalid override to be dropped, got %v", paths)
+	}
+}

--- a/internal/miopen/purego.go
+++ b/internal/miopen/purego.go
@@ -2,6 +2,7 @@ package miopen
 
 import (
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/zerfoo/zerfoo/internal/cuda"
@@ -54,9 +55,37 @@ var (
 	errGlobal  error
 )
 
-var miopenPaths = []string{
-	"libMIOpen.so.1",
-	"libMIOpen.so",
+// miopenLibPathOverrideEnv names an environment variable that, if set to a
+// vetted absolute path, is tried before trustedMiopenLibPaths. See
+// cuda.VetAbsoluteLibPath for the safety checks applied.
+const miopenLibPathOverrideEnv = "ZERFOO_MIOPEN_LIB_PATH"
+
+// trustedMiopenLibPaths use /opt/rocm/lib, AMD's standard ROCm install
+// prefix (see the identical rationale on trustedHipLibPaths in
+// internal/hip/purego.go).
+var trustedMiopenLibPaths = []string{
+	"/opt/rocm/lib/libMIOpen.so.1",
+	"/opt/rocm/lib/libMIOpen.so",
+}
+
+// miopenPaths lists the shared library candidates to try, in order.
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): the trailing
+// bare-soname entries are a DOCUMENTED residual trust assumption -- see the
+// equivalent comment on hipPaths in internal/hip/purego.go for the full
+// rationale.
+var miopenPaths = buildMiopenLibPaths()
+
+func buildMiopenLibPaths() []string {
+	paths := make([]string, 0, len(trustedMiopenLibPaths)+3)
+	if override := os.Getenv(miopenLibPathOverrideEnv); override != "" {
+		if vetted, ok := cuda.VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+	}
+	paths = append(paths, trustedMiopenLibPaths...)
+	paths = append(paths, "libMIOpen.so.1", "libMIOpen.so")
+	return paths
 }
 
 // Open loads libMIOpen via dlopen and resolves all function pointers.

--- a/internal/opencl/dlopen_security_test.go
+++ b/internal/opencl/dlopen_security_test.go
@@ -1,0 +1,51 @@
+package opencl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenclPathsNoCWDRelativeEntry is the CUDA-2 regression guard
+// (docs/deep-reviews/002-full-codebase.md). OpenCL has no trusted absolute
+// default -- see the SECURITY comment on openclPaths for why the ICD
+// design makes a bare soname the correct residual choice here -- but a
+// CWD-relative entry would still be an unambiguous regression, so this
+// guards against exactly that.
+func TestOpenclPathsNoCWDRelativeEntry(t *testing.T) {
+	if len(openclPaths) == 0 {
+		t.Fatal("expected openclPaths to contain at least the bare-soname fallback")
+	}
+	for _, p := range openclPaths {
+		if p == "./libOpenCL.so" || p == "." {
+			t.Fatalf("openclPaths must not contain a CWD-relative entry: %q", p)
+		}
+		if filepath.IsAbs(p) {
+			continue
+		}
+		if filepath.Dir(p) != "." {
+			t.Fatalf("openclPaths entry %q resolves outside the bare-soname search path", p)
+		}
+	}
+}
+
+func TestBuildOpenclLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libOpenCL.so.1")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(openclLibPathOverrideEnv, path)
+	paths := buildOpenclLibPaths()
+	if len(paths) == 0 || paths[0] != path {
+		t.Fatalf("expected override %q first, got %v", path, paths)
+	}
+}
+
+func TestBuildOpenclLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(openclLibPathOverrideEnv, "./libOpenCL.so")
+	paths := buildOpenclLibPaths()
+	if len(paths) == 0 || paths[0] != "libOpenCL.so.1" {
+		t.Fatalf("expected invalid override to be dropped, got %v", paths)
+	}
+}

--- a/internal/opencl/purego.go
+++ b/internal/opencl/purego.go
@@ -2,6 +2,7 @@ package opencl
 
 import (
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/zerfoo/zerfoo/internal/cuda"
@@ -44,10 +45,37 @@ var (
 	errGlobal  error
 )
 
-// openclPaths lists the shared library names to try, in order.
-var openclPaths = []string{
-	"libOpenCL.so.1",
-	"libOpenCL.so",
+// openclLibPathOverrideEnv names an environment variable that, if set to a
+// vetted absolute path, is tried before the bare-soname candidates below.
+// See cuda.VetAbsoluteLibPath for the safety checks applied.
+const openclLibPathOverrideEnv = "ZERFOO_OPENCL_LIB_PATH"
+
+// openclPaths lists the shared library candidates to try, in order.
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): unlike the
+// CUDA/ROCm loaders above, this list has NO trusted absolute default, and
+// that is a deliberate, documented decision rather than an oversight.
+// OpenCL is architected around the system ICD loader: libOpenCL.so is a
+// thin dispatcher that discovers vendor implementations at runtime via
+// /etc/OpenCL/vendors/*.icd (an NVIDIA driver package, ocl-icd, an
+// Intel/AMD vendor SDK, ...). There is no single "the OpenCL library" path
+// that is correct across hosts the way /usr/local/cuda or /opt/rocm are for
+// their ecosystems, so forcing an absolute path here would just be wrong on
+// most machines rather than more secure. We accept the residual
+// LD_LIBRARY_PATH/RPATH hijack exposure of the bare-soname resolution below
+// as inherent to the ICD design; an operator who wants to pin a specific,
+// vetted absolute build can still do so via openclLibPathOverrideEnv.
+var openclPaths = buildOpenclLibPaths()
+
+func buildOpenclLibPaths() []string {
+	paths := make([]string, 0, 3)
+	if override := os.Getenv(openclLibPathOverrideEnv); override != "" {
+		if vetted, ok := cuda.VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+	}
+	paths = append(paths, "libOpenCL.so.1", "libOpenCL.so")
+	return paths
 }
 
 // Open loads libOpenCL via dlopen and resolves all OpenCL runtime

--- a/internal/rocblas/dlopen_security_test.go
+++ b/internal/rocblas/dlopen_security_test.go
@@ -1,0 +1,48 @@
+package rocblas
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRocblasPathsPreferAbsolute is the CUDA-2 regression guard
+// (docs/deep-reviews/002-full-codebase.md): the trusted absolute ROCm
+// install locations must always be tried before the documented bare-soname
+// fallback.
+func TestRocblasPathsPreferAbsolute(t *testing.T) {
+	if len(rocblasPaths) < len(trustedRocblasLibPaths) {
+		t.Fatalf("expected at least %d candidates, got %v", len(trustedRocblasLibPaths), rocblasPaths)
+	}
+	for i, want := range trustedRocblasLibPaths {
+		if rocblasPaths[i] != want {
+			t.Fatalf("expected trusted absolute path %q at index %d, got %v", want, i, rocblasPaths)
+		}
+	}
+	for _, p := range rocblasPaths[len(trustedRocblasLibPaths):] {
+		if p == "./librocblas.so" || p == "." {
+			t.Fatalf("rocblasPaths fallback must not contain a CWD-relative entry: %q", p)
+		}
+	}
+}
+
+func TestBuildRocblasLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "librocblas.so.4")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(rocblasLibPathOverrideEnv, path)
+	paths := buildRocblasLibPaths()
+	if len(paths) == 0 || paths[0] != path {
+		t.Fatalf("expected override %q first, got %v", path, paths)
+	}
+}
+
+func TestBuildRocblasLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(rocblasLibPathOverrideEnv, "./librocblas.so")
+	paths := buildRocblasLibPaths()
+	if len(paths) == 0 || paths[0] != trustedRocblasLibPaths[0] {
+		t.Fatalf("expected invalid override to be dropped, got %v", paths)
+	}
+}

--- a/internal/rocblas/purego.go
+++ b/internal/rocblas/purego.go
@@ -2,6 +2,7 @@ package rocblas
 
 import (
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/zerfoo/zerfoo/internal/cuda"
@@ -27,10 +28,37 @@ var (
 	errGlobal  error
 )
 
-// rocblasPaths lists the shared library names to try, in order.
-var rocblasPaths = []string{
-	"librocblas.so.4",
-	"librocblas.so",
+// rocblasLibPathOverrideEnv names an environment variable that, if set to a
+// vetted absolute path, is tried before trustedRocblasLibPaths. See
+// cuda.VetAbsoluteLibPath for the safety checks applied.
+const rocblasLibPathOverrideEnv = "ZERFOO_ROCBLAS_LIB_PATH"
+
+// trustedRocblasLibPaths use /opt/rocm/lib, AMD's standard ROCm install
+// prefix (see the identical rationale on trustedHipLibPaths in
+// internal/hip/purego.go).
+var trustedRocblasLibPaths = []string{
+	"/opt/rocm/lib/librocblas.so.4",
+	"/opt/rocm/lib/librocblas.so",
+}
+
+// rocblasPaths lists the shared library candidates to try, in order.
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): the trailing
+// bare-soname entries are a DOCUMENTED residual trust assumption -- see the
+// equivalent comment on hipPaths in internal/hip/purego.go for the full
+// rationale.
+var rocblasPaths = buildRocblasLibPaths()
+
+func buildRocblasLibPaths() []string {
+	paths := make([]string, 0, len(trustedRocblasLibPaths)+3)
+	if override := os.Getenv(rocblasLibPathOverrideEnv); override != "" {
+		if vetted, ok := cuda.VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+	}
+	paths = append(paths, trustedRocblasLibPaths...)
+	paths = append(paths, "librocblas.so.4", "librocblas.so")
+	return paths
 }
 
 // Open loads librocblas via dlopen and resolves all rocBLAS function

--- a/internal/tensorrt/dlopen_security_test.go
+++ b/internal/tensorrt/dlopen_security_test.go
@@ -1,0 +1,57 @@
+package tensorrt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestTrtLibPathsAreAbsolute is the CUDA-2 regression guard
+// (docs/deep-reviews/002-full-codebase.md, mirroring CUDA-1's
+// TestKernelLibPathsAreAbsolute in internal/cuda/purego_test.go): the
+// TensorRT C shim is a zerfoo-built artifact with exactly one vetted
+// install location, like libkernels.so, so every dlopen candidate must be
+// an absolute path -- never a bare soname or CWD-relative entry.
+func TestTrtLibPathsAreAbsolute(t *testing.T) {
+	if len(trtLibPaths) == 0 {
+		t.Fatal("expected trtLibPaths to contain at least the trusted default")
+	}
+	for _, p := range trtLibPaths {
+		if !filepath.IsAbs(p) {
+			t.Fatalf("trtLibPaths contains a non-absolute (CWD-relative or bare-soname) entry: %q", p)
+		}
+	}
+}
+
+func TestTrtLibPathsContainsTrustedDefault(t *testing.T) {
+	found := false
+	for _, p := range trtLibPaths {
+		if p == trustedTrtCapiLibPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected trtLibPaths to contain trusted default %q, got %v", trustedTrtCapiLibPath, trtLibPaths)
+	}
+}
+
+func TestBuildTrtLibPathsFallsBackOnInvalidOverride(t *testing.T) {
+	t.Setenv(trtCapiLibPathOverrideEnv, "./libtrt_capi.so")
+	paths := buildTrtLibPaths()
+	if len(paths) != 1 || paths[0] != trustedTrtCapiLibPath {
+		t.Fatalf("expected invalid override to fall through to trusted default only, got %v", paths)
+	}
+}
+
+func TestBuildTrtLibPathsUsesValidOverrideFirst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "libtrt_capi.so")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write test fixture: %v", err)
+	}
+	t.Setenv(trtCapiLibPathOverrideEnv, path)
+	paths := buildTrtLibPaths()
+	if len(paths) != 2 || paths[0] != path || paths[1] != trustedTrtCapiLibPath {
+		t.Fatalf("expected [override, trustedDefault], got %v", paths)
+	}
+}

--- a/internal/tensorrt/tensorrt_purego.go
+++ b/internal/tensorrt/tensorrt_purego.go
@@ -2,6 +2,7 @@ package tensorrt
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"unsafe"
 
@@ -154,10 +155,45 @@ var (
 	errGlobalTrt  error
 )
 
+// trustedTrtCapiLibPath is the vetted, absolute production location for the
+// zerfoo-built TensorRT C shim shared library, mirroring the
+// /opt/zerfoo/lib/libkernels.so convention already established for CUDA
+// custom kernels (internal/cuda/purego.go, CUDA-1, T141.1) -- both are
+// zerfoo-compiled artifacts with one intended install location, not
+// third-party vendor libraries.
+const trustedTrtCapiLibPath = "/opt/zerfoo/lib/libtrt_capi.so"
+
+// trtCapiLibPathOverrideEnv names an environment variable that, if set to a
+// vetted absolute path, is tried before trustedTrtCapiLibPath. See
+// cuda.VetAbsoluteLibPath for the safety checks applied.
+const trtCapiLibPathOverrideEnv = "ZERFOO_TRT_CAPI_LIB_PATH"
+
 // Library paths to try for the TensorRT C shim shared library.
-var trtLibPaths = []string{
-	"libtrt_capi.so",
-	"./libtrt_capi.so",
+//
+// SECURITY (CUDA-2, docs/deep-reviews/002-full-codebase.md): every entry
+// here MUST be an absolute path. dlopen executes a shared object's ELF
+// constructors at load time, so a bare soname (resolved via the default
+// loader search path) or a CWD-relative entry lets an attacker who can
+// write into the process's working directory (or influence
+// LD_LIBRARY_PATH) achieve code execution the moment TensorRT initializes.
+// This list previously included "libtrt_capi.so" and "./libtrt_capi.so" --
+// exactly the CUDA-1 pattern (docs/adr/094-untrusted-boundary-security-hardening.md),
+// but for the TensorRT shim instead of the CUDA kernel library. Do not
+// reintroduce a relative or bare-soname candidate;
+// TestTrtLibPathsAreAbsolute enforces this.
+var trtLibPaths = buildTrtLibPaths()
+
+func buildTrtLibPaths() []string {
+	paths := make([]string, 0, 2)
+	if override := os.Getenv(trtCapiLibPathOverrideEnv); override != "" {
+		if vetted, ok := cuda.VetAbsoluteLibPath(override); ok {
+			paths = append(paths, vetted)
+		}
+		// An invalid override is silently ignored (not fatal): we fall
+		// through to the trusted default rather than refusing to start.
+	}
+	paths = append(paths, trustedTrtCapiLibPath)
+	return paths
 }
 
 func loadTrtLib() (*trtLib, error) {


### PR DESCRIPTION
## Summary

- Closes CUDA-2 (`docs/deep-reviews/002-full-codebase.md`): every native-lib dlopen candidate list in `internal/*/purego.go` loaded by bare soname only, resolved via the default dynamic-linker search path and therefore hijackable via `LD_LIBRARY_PATH`/RPATH given env control. This broadens T141.1/CUDA-1 (PR #943), which only fixed the custom kernel library.
- `cudartPaths`, `cublasLibPaths`, `cublasLtLibPaths`, `cudnnPaths`, `hipPaths`, `rocblasPaths`, `miopenPaths` now try an optional vetted absolute override, then a trusted vendor install location (`/usr/local/cuda/lib64` for the CUDA-toolkit family, matching `docs/bench/manifests/*.yaml`; `/opt/rocm/lib` for the ROCm family, AMD's standard convention), before falling back to the bare soname. The bare-soname fallback is kept and explicitly documented as a residual, deliberate trust assumption for these third-party installs (unlike zerfoo's own build artifacts, their location genuinely varies across hosts).
- Two zerfoo-built shim libraries get the stricter CUDA-1 treatment (trusted-absolute-only, no bare-soname fallback): `internal/hip/kernels`' `libhipkernels.so` -> `/opt/zerfoo/lib/libhipkernels.so`, and `internal/tensorrt`'s `libtrt_capi.so` -> `/opt/zerfoo/lib/libtrt_capi.so`. The TensorRT loader still carried a CWD-relative `./libtrt_capi.so` entry -- the exact CUDA-1 pattern -- found during this audit.
- OpenCL is left on bare-soname resolution with an explicit documented rationale instead of a forced absolute path: the OpenCL ICD loader is architected around runtime vendor discovery via `/etc/OpenCL/vendors/*.icd`, so there is no single correct "the OpenCL library" path the way there is for CUDA/ROCm.
- `internal/cuda`'s `vetKernelLibOverride` is now a thin alias of a newly exported `cuda.VetAbsoluteLibPath`, shared by every package above instead of re-deriving the same absolute/exists/non-world-writable checks.
- `docs/plan.md`: marks T141.2 / S141.2.1 done.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/cuda/... ./internal/cublas/... ./internal/cudnn/... ./internal/tensorrt/... ./internal/hip/... ./internal/rocblas/... ./internal/miopen/... ./internal/opencl/...` clean
- [x] `go test ./internal/...` green (darwin, no GPU)
- [x] New/extended tests per package assert absolute-path ordering ahead of the documented bare-soname fallback, override vetting (valid override wins, invalid override dropped), and CWD-relative-entry rejection for the two zerfoo-built shims: `TestCudartPathsPreferAbsolute`, `TestCublasLibPathsPreferAbsolute`, `TestCublasLtLibPathsPreferAbsolute`, `TestCudnnPathsPreferAbsolute`, `TestHipPathsPreferAbsolute`, `TestRocblasPathsPreferAbsolute`, `TestMiopenPathsPreferAbsolute`, `TestOpenclPathsNoCWDRelativeEntry`, `TestTrtLibPathsAreAbsolute`, `TestHipKernelPathsAreAbsolute` (+ override-vetting variants for each).