### PR TITLE
fix(ci): scope benchmark PR-comment write token to the commenting job (CICD-3, T144.3)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,13 +8,16 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-  pull-requests: write
 concurrency:
   group: benchmark-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   bench:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      regressed: ${{ steps.regression.outputs.regressed }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
@@ -51,15 +54,20 @@ jobs:
       - name: Build comparison tool
         run: go build -o bench-compare ./cmd/bench-compare/
       - name: Check for regressions
+        id: regression
         if: steps.prev.outcome == 'success'
         run: |
+          REGRESSED=false
           ./bench-compare prev/bench-results.json bench-results.json > regression-report.md || REGRESSED=true
           cat regression-report.md
-          if [ "$REGRESSED" = "true" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
-            gh pr comment ${{ github.event.pull_request.number }} --body-file regression-report.md
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
+          echo "regressed=${REGRESSED}" >> "$GITHUB_OUTPUT"
+      - name: Upload regression report
+        if: steps.regression.outputs.regressed == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: regression-report-${{ github.sha }}
+          path: regression-report.md
+          retention-days: 7
       - name: Save as previous baseline
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -68,9 +76,27 @@ jobs:
           path: bench-results.json
           overwrite: true
           retention-days: 90
+  comment:
+    needs: bench
+    if: needs.bench.outputs.regressed == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download regression report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: regression-report-${{ github.sha }}
+      - name: Post regression comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr comment ${{ github.event.pull_request.number }} --body-file regression-report.md
   bench-gpu:
     runs-on: [self-hosted, dgx-spark]
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Run GPU benchmarks


### PR DESCRIPTION
## Summary
- CICD-3 (docs/deep-reviews/002-full-codebase.md): `.github/workflows/benchmark.yml` granted `pull-requests: write` at the workflow level, so the `bench` job -- which checks out and runs PR code end to end -- carried a write-scoped token even though only the regression-comment step needed it.
- Split the comment-posting logic into a new `comment` job that depends on `bench`, downloads the `regression-report` artifact, and posts it via `gh pr comment`. Only this job has `pull-requests: write`.
- `bench` and `bench-gpu` now run with `contents: read` only (job-level `permissions:` override), matching least privilege.
- Benchmarking behavior is unchanged: same steps, same regression-comparison logic, same conditions (`steps.prev.outcome == 'success'`, comment only posted when a regression is detected on a `pull_request` event).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/benchmark.yml'))"` parses cleanly.
- [x] `actionlint .github/workflows/benchmark.yml` -- only pre-existing unrelated warning (unknown self-hosted runner label `dgx-spark`, not introduced by this change).
- [ ] Workflow behavior itself can only be confirmed by a live PR/push run (not exercised here).