### PR TITLE
fix(serve): remove dead SSRF validation code (SERVE-7, T143.9)

### DIFF
--- a/serve/vision.go
+++ b/serve/vision.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -119,55 +118,6 @@ var imageHTTPClient = &http.Client{
 		}
 		return nil
 	},
-}
-
-// ssrfValidator is kept for test compatibility. It defaults to a no-op
-// because SSRF protection is now enforced at connect time via
-// ssrfSafeDialContext in the HTTP transport.
-var ssrfValidator = func(ctx context.Context, rawURL string) error { return nil }
-
-// validateImageURL checks the given URL for SSRF attacks by resolving
-// the hostname and blocking requests to loopback, private, link-local,
-// and cloud metadata addresses. It additionally blocks known dangerous
-// hostnames (e.g. metadata.google.internal).
-//
-// Note: This function performs a pre-flight check. The primary SSRF
-// protection is the connect-time validation in ssrfSafeDialContext.
-func validateImageURL(ctx context.Context, rawURL string) error {
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return fmt.Errorf("parse URL: %w", err)
-	}
-
-	hostname := parsed.Hostname()
-
-	// Block known dangerous hostnames.
-	if blockedSSRFHosts[hostname] {
-		return fmt.Errorf("blocked SSRF target: %s", hostname)
-	}
-
-	// Block known dangerous IPs before DNS resolution.
-	if blockedSSRFIPs[hostname] {
-		return fmt.Errorf("blocked SSRF target: %s", hostname)
-	}
-
-	// Resolve hostname to IPs and check each one.
-	ips, err := net.DefaultResolver.LookupHost(ctx, hostname)
-	if err != nil {
-		return fmt.Errorf("resolve hostname %q: %w", hostname, err)
-	}
-
-	for _, ipStr := range ips {
-		ip := net.ParseIP(ipStr)
-		if ip == nil {
-			continue
-		}
-		if err := isBlockedIP(ip); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // ContentPart represents a single element in a multi-part content array.


### PR DESCRIPTION
## Summary

- Removes `validateImageURL` and `ssrfValidator` from `serve/vision.go` (deep-review 002, SERVE-7): both were dead code with zero callers anywhere in the repo, giving a false impression that URL-level SSRF validation runs. Real SSRF protection is unchanged and lives in `ssrfSafeDialContext`, which validates every resolved IP at connect time (including on redirect targets), so removing this code has no security regression.
- Dropped the now-unused `net/url` import.
- Evaluated the other half of SERVE-7 -- gating `/metrics` behind auth even in keystore mode (`server.go:262`) -- and decided **not** to change it in this PR. `serve/scope_auth_test.go` already has a test explicitly asserting unauthenticated `/metrics` access ("metrics skips auth with keystore"), meaning this is documented, intentional behavior, not an oversight. Prometheus deployments commonly rely on unauthenticated `/metrics` behind network-level access controls rather than app-level bearer auth, so gating it risks breaking scraping conventions for existing operators. This is left as tracked tech debt for a follow-up issue rather than bundled into a dead-code cleanup PR.

## Verification

- `grep -rn "validateImageURL\|ssrfValidator" --include="*.go" .` -> zero matches outside `serve/vision.go`'s own definitions (before removal); confirmed no test file, string-based dispatch, or reflection reference exists.
- `gofmt -l serve/vision.go` -> clean
- `go vet ./serve/...` -> clean
- `go build ./...` -> clean
- `go test ./serve/...` -> all packages pass

## Test plan

- [x] Confirmed `go test ./serve/...` green after removal
- [x] Confirmed `go build ./...` green (no orphaned imports)
- [ ] Reviewer: confirm agreement on deferring `/metrics` auth gating as tech debt vs. filing a follow-up issue