### PR TITLE
fix(serve): block unspecified + CGNAT addresses in SSRF guard (SSRF-1, T143.7)

### DIFF
--- a/serve/vision.go
+++ b/serve/vision.go
@@ -31,13 +31,28 @@ var blockedSSRFIPs = map[string]bool{
 // when downloading an image.
 const maxImageRedirects = 3
 
+// cgnatBlock is the shared address space reserved for carrier-grade NAT
+// (RFC 6598). Requests into this range can reach infrastructure that is not
+// meant to be internet-reachable, so it is treated the same as RFC 1918
+// private space for SSRF purposes.
+var cgnatBlock = func() *net.IPNet {
+	_, block, err := net.ParseCIDR("100.64.0.0/10")
+	if err != nil {
+		panic(fmt.Sprintf("invalid CGNAT CIDR: %v", err))
+	}
+	return block
+}()
+
 // isBlockedIP checks whether an IP address should be blocked for SSRF protection.
-// It returns a non-nil error if the IP is loopback, private, link-local, or a
-// known cloud metadata address.
+// It returns a non-nil error if the IP is loopback, private, link-local,
+// unspecified, CGNAT (RFC 6598), or a known cloud metadata address.
 func isBlockedIP(ip net.IP) error {
 	ipStr := ip.String()
 	if blockedSSRFIPs[ipStr] {
 		return fmt.Errorf("blocked SSRF target: %s", ipStr)
+	}
+	if ip.IsUnspecified() {
+		return fmt.Errorf("blocked SSRF target: unspecified address %s", ipStr)
 	}
 	if ip.IsLoopback() {
 		return fmt.Errorf("blocked SSRF target: loopback address %s", ipStr)
@@ -50,6 +65,9 @@ func isBlockedIP(ip net.IP) error {
 	}
 	if ip.IsLinkLocalMulticast() {
 		return fmt.Errorf("blocked SSRF target: link-local multicast address %s", ipStr)
+	}
+	if cgnatBlock.Contains(ip) {
+		return fmt.Errorf("blocked SSRF target: CGNAT address %s", ipStr)
 	}
 	return nil
 }

--- a/serve/vision_test.go
+++ b/serve/vision_test.go
@@ -490,6 +490,10 @@ func TestIsBlockedIP(t *testing.T) {
 		{"private_192", "192.168.1.1", "private"},
 		{"link_local", "169.254.1.1", "link-local"},
 		{"metadata_ip", "169.254.169.254", "blocked SSRF"},
+		{"unspecified_v4", "0.0.0.0", "unspecified"},
+		{"unspecified_v6", "::", "unspecified"},
+		{"cgnat_low", "100.64.0.1", "CGNAT"},
+		{"cgnat_high", "100.127.255.254", "CGNAT"},
 		{"public", "93.184.216.34", ""},
 	}
 


### PR DESCRIPTION
## Summary
- `isBlockedIP` in `serve/vision.go` omitted `net.IP.IsUnspecified()` (`0.0.0.0` / `::`) and the CGNAT `100.64.0.0/10` reserved range from the SSRF blocklist. On Linux, `http://0.0.0.0:<port>/` can reach loopback-bound services, and CGNAT space can reach carrier infrastructure not meant to be internet-reachable.
- Adds both checks to `isBlockedIP` alongside the existing loopback/private/link-local/metadata blocks. No other logic in the connect-time SSRF defense was touched.

Ref: `docs/deep-reviews/002-full-codebase.md` SSRF-1.

## Test plan
- [x] `TestIsBlockedIP` extended with `unspecified_v4` (`0.0.0.0`), `unspecified_v6` (`::`), `cgnat_low` (`100.64.0.1`), `cgnat_high` (`100.127.255.254`) — all blocked; existing loopback/private/link-local/metadata/public cases still pass.
- [x] `gofmt -l` clean, `go vet ./serve/...` clean.
- [x] `go test ./serve/... -count=1` green.