### PR TITLE
fix(registry): support out-of-band expected hash for HF pulls (HF-1, T143.10)

### DIFF
--- a/model/registry/pull.go
+++ b/model/registry/pull.go
@@ -38,6 +38,17 @@ type HFPullOptions struct {
 	OnProgress ProgressFunc
 	// Client overrides the HTTP client used for downloads.
 	Client *http.Client
+	// ExpectedHashes optionally pins the expected SHA-256 checksum (lowercase
+	// hex) for specific files, keyed by the repository-relative filename
+	// (e.g. "model-Q4_K_M.gguf"). When a filename has an entry here, it is
+	// verified against this out-of-band value INSTEAD of any hash derived
+	// from the download response's own ETag/X-Linked-Etag/Content-Sha256
+	// headers -- trusting the serving origin's own headers as the "expected"
+	// hash provides no integrity guarantee against a compromised or MITM'd
+	// server (HF-1). A mismatch is a hard error. Files not present in this
+	// map fall back to the prior trust-on-first-download ETag behavior for
+	// backward compatibility.
+	ExpectedHashes map[string]string
 }
 
 // HFSibling represents a file entry in a HuggingFace model listing.
@@ -211,8 +222,20 @@ func downloadFile(ctx context.Context, opts HFPullOptions, modelID, filename, ta
 		return 0, err
 	}
 
-	// Extract expected SHA-256 from response headers if available.
-	expectedHash := extractSHA256(resp)
+	// Determine the expected SHA-256. An out-of-band pin (opts.ExpectedHashes)
+	// takes precedence over anything derived from the response headers, since
+	// the headers originate from the same server the content was just
+	// fetched from and offer no protection against a compromised or MITM'd
+	// origin (HF-1). Absent a pin, fall back to the prior ETag-derived trust
+	// behavior for backward compatibility.
+	var expectedHash string
+	pinned := false
+	if h, ok := opts.ExpectedHashes[filename]; ok && h != "" {
+		expectedHash = strings.ToLower(h)
+		pinned = true
+	} else {
+		expectedHash = extractSHA256(resp)
+	}
 
 	// Atomic write: download to a temp file, then rename on success.
 	tmpPath := cleaned + ".tmp"
@@ -249,13 +272,19 @@ func downloadFile(ctx context.Context, opts HFPullOptions, modelID, filename, ta
 		return 0, err
 	}
 
-	// Verify checksum if the server provided one.
+	// Verify checksum. A pinned hash is always enforced. Otherwise, verify
+	// against the ETag-derived hash if the server provided one.
 	gotHash := hex.EncodeToString(hasher.Sum(nil))
-	if expectedHash != "" {
+	switch {
+	case pinned:
+		if gotHash != expectedHash {
+			return 0, fmt.Errorf("checksum mismatch for %s: expected %s (pinned), got %s", filename, expectedHash, gotHash)
+		}
+	case expectedHash != "":
 		if gotHash != expectedHash {
 			return 0, fmt.Errorf("checksum mismatch for %s: expected %s, got %s", filename, expectedHash, gotHash)
 		}
-	} else {
+	default:
 		slog.Warn("no SHA-256 checksum available from server, skipping verification", "file", filename)
 	}
 

--- a/model/registry/pull_test.go
+++ b/model/registry/pull_test.go
@@ -528,6 +528,157 @@ func TestDownloadFile_InterruptedDownload_NoPartialFile(t *testing.T) {
 	}
 }
 
+func TestDownloadFile_PinnedHashOverridesETag_Match(t *testing.T) {
+	content := []byte("out-of-band pinned content")
+	hash := sha256.Sum256(content)
+	hexHash := hex.EncodeToString(hash[:])
+
+	// Server ETag intentionally does NOT match the real content hash. If the
+	// pinned hash correctly takes precedence, the download must still
+	// succeed because the pin matches the content -- the (wrong) ETag must
+	// be ignored entirely.
+	wrongETag := strings.Repeat("cd", 32)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/models/org/model", func(w http.ResponseWriter, _ *http.Request) {
+		info := HFModelInfo{ID: "org/model", Siblings: []HFSibling{{Filename: "config.json"}}}
+		json.NewEncoder(w).Encode(info) //nolint:errcheck
+	})
+	mux.HandleFunc("/org/model/resolve/main/config.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", fmt.Sprintf("%q", wrongETag))
+		w.Write(content) //nolint:errcheck
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	dir := t.TempDir()
+	pullFn := NewHFPullFunc(HFPullOptions{
+		APIURL: server.URL + "/api/models",
+		CDNURL: server.URL,
+		Client: server.Client(),
+		ExpectedHashes: map[string]string{
+			"config.json": hexHash,
+		},
+	})
+
+	_, err := pullFn(context.Background(), "org/model", dir)
+	if err != nil {
+		t.Fatalf("Pull should succeed when pinned hash matches content, regardless of ETag: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(content) {
+		t.Errorf("file content = %q, want %q", data, content)
+	}
+}
+
+func TestDownloadFile_PinnedHashMismatch_Rejected(t *testing.T) {
+	content := []byte("some content that will not match the pin")
+	hash := sha256.Sum256(content)
+	realHexHash := hex.EncodeToString(hash[:])
+	wrongPin := strings.Repeat("ef", 32)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/models/org/model", func(w http.ResponseWriter, _ *http.Request) {
+		info := HFModelInfo{ID: "org/model", Siblings: []HFSibling{{Filename: "config.json"}}}
+		json.NewEncoder(w).Encode(info) //nolint:errcheck
+	})
+	mux.HandleFunc("/org/model/resolve/main/config.json", func(w http.ResponseWriter, _ *http.Request) {
+		// Server's ETag correctly matches the content (i.e. it is NOT the
+		// cause of the failure) -- only the caller-supplied pin is wrong.
+		w.Header().Set("ETag", fmt.Sprintf("%q", realHexHash))
+		w.Write(content) //nolint:errcheck
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	dir := t.TempDir()
+	pullFn := NewHFPullFunc(HFPullOptions{
+		APIURL: server.URL + "/api/models",
+		CDNURL: server.URL,
+		Client: server.Client(),
+		ExpectedHashes: map[string]string{
+			"config.json": wrongPin,
+		},
+	})
+
+	_, err := pullFn(context.Background(), "org/model", dir)
+	if err == nil {
+		t.Fatal("Pull should fail when pinned hash does not match downloaded content")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("error should mention checksum mismatch, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pinned") {
+		t.Errorf("error should indicate the mismatch came from a pinned hash, got: %v", err)
+	}
+
+	finalPath := filepath.Join(dir, "config.json")
+	if _, err := os.Stat(finalPath); !os.IsNotExist(err) {
+		t.Error("final file should not exist after pinned checksum mismatch")
+	}
+	tmpPath := filepath.Join(dir, "config.json.tmp")
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Error("temp file should not exist after pinned checksum mismatch")
+	}
+}
+
+func TestDownloadFile_NoPin_FallsBackToETagBehavior(t *testing.T) {
+	// With no ExpectedHashes entry for the file, behavior must be unchanged
+	// from before: a correct ETag is verified and accepted, matching
+	// TestDownloadFile_ChecksumMatch's expectations exactly, but this time
+	// with a (nil) ExpectedHashes map explicitly passed to exercise the
+	// "no out-of-band hash provided" path end-to-end.
+	content := []byte("etag fallback content")
+	hash := sha256.Sum256(content)
+	hexHash := hex.EncodeToString(hash[:])
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/models/org/model", func(w http.ResponseWriter, _ *http.Request) {
+		info := HFModelInfo{ID: "org/model", Siblings: []HFSibling{{Filename: "config.json"}, {Filename: "tokenizer.json"}}}
+		json.NewEncoder(w).Encode(info) //nolint:errcheck
+	})
+	mux.HandleFunc("/org/model/resolve/main/config.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", fmt.Sprintf("%q", hexHash))
+		w.Write(content) //nolint:errcheck
+	})
+	mux.HandleFunc("/org/model/resolve/main/tokenizer.json", func(w http.ResponseWriter, _ *http.Request) {
+		// No ETag at all: should warn-and-accept exactly as before.
+		w.Write([]byte(`{"ok": true}`)) //nolint:errcheck
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	dir := t.TempDir()
+	pullFn := NewHFPullFunc(HFPullOptions{
+		APIURL: server.URL + "/api/models",
+		CDNURL: server.URL,
+		Client: server.Client(),
+		// ExpectedHashes only pins a different, unrelated file -- config.json
+		// and tokenizer.json must both fall back to ETag-based behavior.
+		ExpectedHashes: map[string]string{
+			"some-other-file.gguf": strings.Repeat("11", 32),
+		},
+	})
+
+	_, err := pullFn(context.Background(), "org/model", dir)
+	if err != nil {
+		t.Fatalf("Pull should succeed via unchanged ETag fallback behavior: %v", err)
+	}
+
+	for _, name := range []string{"config.json", "tokenizer.json"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); os.IsNotExist(err) {
+			t.Errorf("expected file %s to exist", name)
+		}
+	}
+}
+
 func TestExtractSHA256(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary
- HF-1 (deep-review 002): HuggingFace pull integrity was trust-on-first-download -- the expected SHA-256 came from the same server's ETag/X-Linked-Etag/Content-Sha256 headers, so a compromised or MITM'd origin could serve tampered content with a self-consistent "expected" hash.
- Adds `HFPullOptions.ExpectedHashes map[string]string` (repository-relative filename -> pinned lowercase-hex SHA-256). When a file has a pin, it is verified against that out-of-band value instead of any header-derived hash, and a mismatch is a hard error.
- Files without a pin are unaffected: they keep the prior ETag-based trust behavior for backward compatibility.

## Test plan
- [x] `TestDownloadFile_PinnedHashOverridesETag_Match` -- correct pin accepted even when the server's ETag is wrong/different
- [x] `TestDownloadFile_PinnedHashMismatch_Rejected` -- wrong pin rejected with a "checksum mismatch ... pinned" error, no temp/final file left behind
- [x] `TestDownloadFile_NoPin_FallsBackToETagBehavior` -- no pin for the file -> existing ETag accept/warn behavior unchanged
- [x] `gofmt -l` clean, `go vet ./model/registry/...` clean
- [x] `go test ./model/registry/...` green