### PR TITLE
fix(deploy): digest-pin Dockerfile base images (CICD-4, T144.4)

### DIFF
--- a/deploy/aws/Dockerfile
+++ b/deploy/aws/Dockerfile
@@ -1,5 +1,7 @@
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM golang:1.26-bookworm AS build
+# Digest-pinned to the current golang:1.26-bookworm multi-arch manifest list
+# (resolved via the Docker Hub v2 repository API, 2026-07-10).
+FROM golang:1.26-bookworm@sha256:18aedc16aa19b3fd7ded7245fc14b109e054d65d22ed53c355c899582bbb2113 AS build
 
 WORKDIR /src
 
@@ -17,7 +19,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 # Distroless nonroot provides a minimal, secure runtime without a shell.
-FROM gcr.io/distroless/static-debian12:nonroot
+# Digest-pinned to the linux/amd64 manifest of static-debian12:nonroot (matching
+# this stage's GOARCH=amd64 build output), resolved via the gcr.io v2 manifest
+# API, 2026-07-10.
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:2edc6a6bd378e3cd0571e796acd60b5179aa73bdaadd40a53a42a33cf45678f6
 
 # GPU shared libraries are loaded at runtime by purego/dlopen from a host-mounted
 # path or an optional CUDA layer image; they are not baked into this image.


### PR DESCRIPTION
## Summary
- Digest-pin both `deploy/aws/Dockerfile` base images so `FROM` resolves to an immutable image instead of a mutable tag (CICD-4, deep-review 002).
- `golang:1.26-bookworm` pinned to its current multi-arch manifest-list digest (`sha256:18aedc16aa19b3fd7ded7245fc14b109e054d65d22ed53c355c899582bbb2113`), resolved via the Docker Hub v2 repository API.
- `gcr.io/distroless/static-debian12:nonroot` pinned to its current `linux/amd64` manifest digest (`sha256:2edc6a6bd378e3cd0571e796acd60b5179aa73bdaadd40a53a42a33cf45678f6`, matching this stage's `GOARCH=amd64` build output), resolved via the gcr.io v2 manifest API (no Docker Hub mirror exists for distroless).
- Tag kept alongside the digest (`image:tag@sha256:...`) for human readability, per standard practice.
- Grepped the repo for other Dockerfiles: `deploy/aws/Dockerfile` is the only one present, so no other files needed the same fix.

## Test plan
- [x] `grep -oE '@sha256:[0-9a-f]{64}' deploy/aws/Dockerfile` confirms both `FROM` lines carry well-formed 64-hex digests.
- [ ] CI build of the image (no local docker/crane/skopeo available in this environment to build/pull directly).