### PR TITLE
fix(serve): bound GuardianMiddleware body read, skip SSE buffering (SERVE-4, T143.5)

### DIFF
--- a/serve/guardian_middleware.go
+++ b/serve/guardian_middleware.go
@@ -5,9 +5,15 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/zerfoo/zerfoo/inference/guardian"
 )
+
+// guardianMaxRequestBodyBytes caps the request body GuardianMiddleware will
+// buffer for parsing. Matches the 10 MB cap used elsewhere in serve/ (see
+// handlers.go, classify.go, guard.go).
+const guardianMaxRequestBodyBytes = 10 << 20 // 10 MB
 
 // GuardianMiddlewareConfig controls how the Guardian safety middleware
 // intercepts chat completion requests.
@@ -21,7 +27,7 @@ type GuardianMiddlewareConfig struct {
 
 // guardianFlaggedResponse is returned when content is flagged and BlockOnFlag is true.
 type guardianFlaggedResponse struct {
-	Error    string       `json:"error"`
+	Error    string        `json:"error"`
 	Verdicts []VerdictData `json:"verdicts"`
 }
 
@@ -38,10 +44,16 @@ func GuardianMiddleware(evaluator GuardEvaluator, config GuardianMiddlewareConfi
 			}
 
 			// Read and buffer the request body so we can parse it and
-			// still forward it to the inner handler.
+			// still forward it to the inner handler. Bound the read so an
+			// attacker can't force unbounded memory growth (SERVE-4).
+			r.Body = http.MaxBytesReader(w, r.Body, guardianMaxRequestBodyBytes)
 			body, err := io.ReadAll(r.Body)
 			r.Body.Close()
 			if err != nil {
+				if isMaxBytesError(err) {
+					writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+					return
+				}
 				writeError(w, http.StatusBadRequest, "failed to read request body")
 				return
 			}
@@ -91,9 +103,21 @@ func GuardianMiddleware(evaluator GuardEvaluator, config GuardianMiddlewareConfi
 				return
 			}
 
-			// Capture the inner handler's response for output checking.
-			rec := &responseBuffer{header: make(http.Header)}
+			// Capture the inner handler's response for output checking. If
+			// the handler turns out to be streaming a Server-Sent Events
+			// response, the buffer switches to passing bytes straight
+			// through to the real ResponseWriter (flushing as it goes)
+			// instead of accumulating the whole response in memory, since
+			// SSE streams can be unbounded/long-lived and output scanning
+			// requires a complete response body (SERVE-4).
+			rec := &responseBuffer{header: make(http.Header), underlying: w}
 			next.ServeHTTP(rec, r)
+
+			if rec.passthrough {
+				// Response was already streamed directly to the client;
+				// there is nothing left to check or forward.
+				return
+			}
 
 			// --- Output check ---
 			assistantMsg := extractAssistantContent(rec.body.Bytes())
@@ -128,22 +152,62 @@ func GuardianMiddleware(evaluator GuardEvaluator, config GuardianMiddlewareConfi
 	}
 }
 
-// responseBuffer captures an HTTP response in memory.
+// responseBuffer captures an HTTP response in memory so GuardianMiddleware
+// can inspect it before forwarding to the client. If the response turns out
+// to be a Server-Sent Events stream (Content-Type: text/event-stream), it
+// switches to passthrough mode: bytes are written directly to the
+// underlying ResponseWriter (and flushed) instead of being buffered, so
+// streaming responses are neither delayed nor unboundedly accumulated in
+// memory.
 type responseBuffer struct {
-	header http.Header
-	body   bytes.Buffer
-	status int
+	underlying    http.ResponseWriter
+	header        http.Header
+	body          bytes.Buffer
+	status        int
+	headerWritten bool
+	passthrough   bool
 }
 
 func (rb *responseBuffer) Header() http.Header { return rb.header }
 
-func (rb *responseBuffer) WriteHeader(code int) { rb.status = code }
+func (rb *responseBuffer) WriteHeader(code int) {
+	if rb.headerWritten {
+		return
+	}
+	rb.commit(code)
+}
 
 func (rb *responseBuffer) Write(b []byte) (int, error) {
-	if rb.status == 0 {
-		rb.status = http.StatusOK
+	if !rb.headerWritten {
+		rb.commit(http.StatusOK)
+	}
+	if rb.passthrough {
+		n, err := rb.underlying.Write(b)
+		if f, ok := rb.underlying.(http.Flusher); ok {
+			f.Flush()
+		}
+		return n, err
 	}
 	return rb.body.Write(b)
+}
+
+// commit finalizes the response status/headers on first WriteHeader/Write
+// and decides whether to switch into SSE passthrough mode.
+func (rb *responseBuffer) commit(code int) {
+	rb.status = code
+	rb.headerWritten = true
+	if isEventStream(rb.header) {
+		rb.passthrough = true
+		copyHeader(rb.underlying.Header(), rb.header)
+		rb.underlying.WriteHeader(code)
+	}
+}
+
+// isEventStream reports whether the given response header declares an SSE
+// (text/event-stream) body.
+func isEventStream(h http.Header) bool {
+	ct := h.Get("Content-Type")
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(ct)), "text/event-stream")
 }
 
 // lastUserMessage returns the content of the last message with role "user".

--- a/serve/guardian_middleware_test.go
+++ b/serve/guardian_middleware_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/zerfoo/zerfoo/inference/guardian"
@@ -216,6 +218,159 @@ func TestGuardianMiddleware_NilEvaluatorPassesThrough(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 (nil evaluator), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestGuardianMiddleware_OverCapRequestBodyRejected verifies SERVE-4: the
+// middleware bounds its request body read with http.MaxBytesReader instead
+// of doing an unbounded io.ReadAll, so an oversized request is rejected
+// rather than buffered into memory.
+func TestGuardianMiddleware_OverCapRequestBodyRejected(t *testing.T) {
+	eval := &mockGuardEvaluator{}
+	mw := GuardianMiddleware(eval, GuardianMiddlewareConfig{
+		CheckInput:  true,
+		BlockOnFlag: true,
+	})
+
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := mw(inner)
+
+	// Pad well past the 10 MB cap shared with the rest of serve/.
+	bigValue := strings.Repeat("x", guardianMaxRequestBodyBytes+(1<<20))
+	oversized := `{"model":"test-model","messages":[{"role":"user","content":"` + bigValue + `"}]}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(oversized))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected %d, got %d: %s", http.StatusRequestEntityTooLarge, rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Fatal("inner handler should not run for an over-cap request body")
+	}
+}
+
+// trackingFlushWriter is a minimal http.ResponseWriter + http.Flusher that
+// records every Write/Flush as it happens, so tests can observe whether
+// bytes reached the "client" before a streaming handler finished -- i.e.
+// that GuardianMiddleware isn't buffering the whole response first.
+type trackingFlushWriter struct {
+	mu      sync.Mutex
+	header  http.Header
+	buf     bytes.Buffer
+	status  int
+	flushes int
+}
+
+func newTrackingFlushWriter() *trackingFlushWriter {
+	return &trackingFlushWriter{header: make(http.Header)}
+}
+
+func (w *trackingFlushWriter) Header() http.Header { return w.header }
+
+func (w *trackingFlushWriter) WriteHeader(code int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.status = code
+}
+
+func (w *trackingFlushWriter) Write(b []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(b)
+}
+
+func (w *trackingFlushWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.flushes++
+}
+
+func (w *trackingFlushWriter) snapshot() (string, int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String(), w.flushes
+}
+
+// TestGuardianMiddleware_SSEStreamsThroughWithoutBuffering verifies SERVE-4:
+// when the inner handler emits a text/event-stream response, the middleware
+// must not swallow/delay it by buffering the entire response before
+// forwarding -- each chunk must reach the client (and be flushed) as soon as
+// the inner handler writes it.
+func TestGuardianMiddleware_SSEStreamsThroughWithoutBuffering(t *testing.T) {
+	firstChunkWritten := make(chan struct{})
+	proceed := make(chan struct{})
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		if _, err := w.Write([]byte("data: chunk1\n\n")); err != nil {
+			t.Errorf("write chunk1: %v", err)
+		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		close(firstChunkWritten)
+
+		<-proceed
+
+		if _, err := w.Write([]byte("data: chunk2\n\n")); err != nil {
+			t.Errorf("write chunk2: %v", err)
+		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	})
+
+	eval := &mockGuardEvaluator{}
+	mw := GuardianMiddleware(eval, GuardianMiddlewareConfig{
+		CheckInput:  true,
+		CheckOutput: true,
+		BlockOnFlag: true,
+	})
+	handler := mw(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", chatBody(t, "hi"))
+	rw := newTrackingFlushWriter()
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rw, req)
+		close(done)
+	}()
+
+	select {
+	case <-firstChunkWritten:
+	case <-done:
+		t.Fatal("handler returned before writing the first SSE chunk")
+	}
+
+	// The first chunk (and a flush) must already be visible on the real
+	// ResponseWriter even though the handler hasn't returned yet -- proof
+	// the middleware is not buffering the whole response.
+	got, flushes := rw.snapshot()
+	if !strings.Contains(got, "chunk1") {
+		t.Fatalf("expected first SSE chunk to stream through immediately, got %q", got)
+	}
+	if strings.Contains(got, "chunk2") {
+		t.Fatalf("second chunk should not have been written yet, got %q", got)
+	}
+	if flushes == 0 {
+		t.Fatal("expected the flush to propagate to the underlying ResponseWriter")
+	}
+
+	close(proceed)
+	<-done
+
+	final, _ := rw.snapshot()
+	if !strings.Contains(final, "chunk1") || !strings.Contains(final, "chunk2") {
+		t.Fatalf("expected both SSE chunks in the final output, got %q", final)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `GuardianMiddleware` read the request body via unbounded `io.ReadAll`; now wraps it in `http.MaxBytesReader` at 10 MB, matching the cap used elsewhere in `serve/` (`handlers.go`, `classify.go`, `guard.go`). Over-cap requests get `413 request body too large` instead of unbounded memory growth.
- The output-check response buffer (`responseBuffer`) fully buffered the inner handler's response before forwarding it, which delays/breaks SSE. It now detects `Content-Type: text/event-stream` on first write and switches to a passthrough mode that writes (and flushes) directly to the real `ResponseWriter` as bytes arrive, skipping output scanning for streamed responses.
- Middleware is latent (not wired into `NewServer` yet) per deep-review 002, SERVE-4.

## Test plan
- [x] `TestGuardianMiddleware_OverCapRequestBodyRejected` — an oversized (~11 MB) chat-completions body is rejected with 413 and the inner handler is never invoked.
- [x] `TestGuardianMiddleware_SSEStreamsThroughWithoutBuffering` — an SSE response streams its first chunk (and a flush) to the client before the inner handler returns, proving the middleware isn't buffering/delaying it.
- [x] `go test ./serve/...` green.
- [x] `gofmt -l`, `go vet ./serve/...` clean.