### PR TITLE
build(deploy): add .dockerignore to trim build context (CICD-5, T144.5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Docker build context root is the repo root (see deploy/aws/README.md:
+# `docker build -f deploy/aws/Dockerfile .`). The build stage only runs
+# `go mod download` and `go build ./cmd/zerfoo` — never `go test` — so test
+# sources, fixtures, docs, and unrelated tooling artifacts are safe to drop
+# from the context sent to the daemon.
+#
+# Do NOT exclude go.mod or go.sum: the Dockerfile COPYs them explicitly
+# before the full `COPY . .`.
+
+# Version control
+.git
+.github
+
+# Claude Code session state, worktrees, and checkpoint scratch files
+.claude
+.claude-checkpoint*.md
+
+# Documentation -- not needed to build the binary
+docs
+*.md
+
+# Test sources and fixtures -- never compiled into `go build` output
+**/*_test.go
+**/testdata
+
+# Pre-built debug binaries checked into the repo (unrelated to the serve image)
+/debug-infer
+/gguf-info
+/ts_train
+/bin
+
+# Editor / OS scratch
+*.swp
+.DS_Store


### PR DESCRIPTION
## Summary

- CICD-5 (docs/deep-reviews/002-full-codebase.md): `deploy/aws/Dockerfile` does `COPY . .` (line 10) with no `.dockerignore`, so the entire repo -- `.git`, docs, checked-in debug binaries, test fixtures, local scratch -- gets sent to the Docker daemon as build context.
- The image is built with `docker build -t zerfoo:latest -f deploy/aws/Dockerfile .` (see `deploy/aws/README.md:45`), so the build context root is the repo root -- that's where `.dockerignore` must live.
- Added `.dockerignore` at the repo root excluding: `.git`, `.github`, `.claude` (session state/worktrees) and `.claude-checkpoint*.md`, `docs/`, `*.md`, all `**/*_test.go` and `**/testdata`, the pre-built debug binaries tracked in git (`debug-infer`, `gguf-info`, `ts_train`, `bin/`), and editor/OS scratch (`*.swp`, `.DS_Store`).
- Confirmed nothing excluded is needed: the Dockerfile's build stage only runs `go mod download` (needs `go.mod`/`go.sum`, copied explicitly and untouched by the ignore rules) and `go build ./cmd/zerfoo` (never `go test`, so `_test.go`/`testdata` are safe to drop). `go list -deps ./cmd/zerfoo` confirms the actual package set needed (`cmd`, `distributed`, `generate`, `inference`, `internal`, `layers`, `model`, `serve`, `tabular`, `timeseries`, `training`) -- none of those directories are touched by the exclusions.
- Verified by copying the tree with the same exclusions applied and running `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /tmp/zerfoo-verify ./cmd/zerfoo` -- build succeeded.

## Test plan

- [x] `go list -deps ./cmd/zerfoo` reviewed to confirm the excluded top-level paths are not part of the binary's dependency graph
- [x] Simulated the `.dockerignore`-filtered build context and ran the Dockerfile's exact build command (`go build ./cmd/zerfoo`) against it -- succeeded
- [ ] Optional: run `docker build -f deploy/aws/Dockerfile .` directly in an environment with Docker available, to confirm end-to-end