### PR TITLE
fix(serve): log escaped request path to prevent log injection (SERVE-6, T143.8)

### DIFF
--- a/serve/logging_test.go
+++ b/serve/logging_test.go
@@ -147,6 +147,44 @@ func TestLogging_NopLogger(t *testing.T) {
 	// No panic or error means Nop logger works correctly.
 }
 
+// TestLogging_EscapesControlCharsInPath guards against SERVE-6: logMiddleware
+// must log the percent-encoded request path (r.URL.EscapedPath()), not the
+// percent-decoded r.URL.Path, so a request path carrying CR/LF (or other
+// control characters) cannot forge or split log lines.
+func TestLogging_EscapesControlCharsInPath(t *testing.T) {
+	mdl := buildTestModel(t)
+	var buf bytes.Buffer
+	logger := log.New(&buf, log.LevelInfo, log.FormatText)
+	srv := NewServer(mdl, WithLogger(logger))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	const injected = "FAKE-INJECTED-LOG-LINE"
+	resp := doGet(t, ts.URL+"/v1/models%0D%0A"+injected)
+	_ = resp.Body.Close()
+
+	output := buf.String()
+
+	// The decoded form must never appear: a raw CR/LF immediately followed
+	// by attacker-controlled text would fabricate what looks like a second,
+	// independent log line.
+	if strings.Contains(output, "\r\n"+injected) {
+		t.Fatalf("raw control chars leaked into log output (log injection): %q", output)
+	}
+
+	// Exactly one log line should have been written; a raw CR/LF in the path
+	// would otherwise split it into two.
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly one log line, got %d: %q", len(lines), output)
+	}
+
+	// The escaped, percent-encoded form must be present in the path field.
+	if !strings.Contains(lines[0], "path=/v1/models%0D%0A"+injected) {
+		t.Errorf("expected escaped path in log line, got: %q", lines[0])
+	}
+}
+
 func TestLogging_StructuredFields(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/serve/server.go
+++ b/serve/server.go
@@ -388,7 +388,10 @@ func (s *Server) logMiddleware(next http.Handler) http.Handler {
 
 		fields := []string{
 			"method", r.Method,
-			"path", r.URL.Path,
+			// EscapedPath (not the percent-decoded Path) is logged here: an
+			// attacker-controlled path can otherwise embed control characters
+			// (e.g. CR/LF) that split or forge log lines (SERVE-6, CWE-117).
+			"path", r.URL.EscapedPath(),
 			"model", modelID,
 			"prompt_tokens", "0",
 			"completion_tokens", "0",


### PR DESCRIPTION
## Summary
- `logMiddleware` (serve/server.go) logged the percent-decoded `r.URL.Path`, allowing a request path with percent-encoded control characters (e.g. `%0D%0A`) to decode into raw CR/LF and forge or split log lines.
- Fixed by logging `r.URL.EscapedPath()`, which preserves percent-encoding of any control bytes so nothing raw reaches the log sink.
- Ref: deep-review 002 finding SERVE-6 (`docs/deep-reviews/002-full-codebase.md`), CWE-117.

## Test plan
- [x] Added `TestLogging_EscapesControlCharsInPath` (serve/logging_test.go): sends a request with `%0D%0A` + injected text in the path, captures log output via a buffer logger, and asserts (a) no raw `\r\n` + injected text leaks, (b) exactly one log line is produced, (c) the escaped form appears in the `path=` field.
- [x] Verified the test fails against the pre-fix code (reverting to `r.URL.Path` reproduces the raw CRLF injection) and passes against the fix.
- [x] `gofmt -l` clean, `go vet ./serve/...` clean.
- [x] `go test ./serve/...` green (all packages, including new test).