### PR TITLE
fix(serve): cap per-request image-fetch fan-out (SERVE-3b, T143.4)

### DIFF
--- a/serve/handlers.go
+++ b/serve/handlers.go
@@ -2,6 +2,7 @@
 package serve
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -98,12 +99,35 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		opts = append(opts, grammarOpt)
 	}
 
-	// Convert messages and fetch any images.
+	// Cap the total number of images referenced across all messages before
+	// fetching any of them (SERVE-3b): a small request body can otherwise
+	// enumerate thousands of image_url entries, each fetched sequentially.
+	totalImages := 0
+	for _, m := range req.Messages {
+		totalImages += len(m.ImageURLs)
+	}
+	if totalImages > maxImagesPerRequest {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("too many images: %d exceeds maximum of %d per request", totalImages, maxImagesPerRequest))
+		return
+	}
+
+	// Convert messages and fetch any images. All image fetches for this
+	// request share one byte budget and one wall-clock deadline derived
+	// from the request context, bounding total memory and total time spent
+	// on the fan-out regardless of how many images are requested.
+	imgCtx := r.Context()
+	if totalImages > 0 {
+		var cancel context.CancelFunc
+		imgCtx, cancel = context.WithTimeout(r.Context(), maxImageFetchWallClock)
+		defer cancel()
+	}
+	imgBudget := newImageFetchBudget(maxTotalImageBytes)
+
 	messages := make([]inference.Message, len(req.Messages))
 	for i, m := range req.Messages {
 		messages[i] = inference.Message{Role: m.Role, Content: m.Content}
 		if len(m.ImageURLs) > 0 {
-			images, err := fetchImages(r.Context(), m.ImageURLs)
+			images, err := fetchImages(imgCtx, m.ImageURLs, imgBudget)
 			if err != nil {
 				s.logger.Debug("image fetch error", "error", err.Error())
 				writeError(w, http.StatusBadRequest, "image fetch failed")

--- a/serve/vision.go
+++ b/serve/vision.go
@@ -240,33 +240,77 @@ func (m *ChatMessage) UnmarshalJSON(data []byte) error {
 // maxImageSize is the maximum allowed size for downloaded images (20 MB).
 const maxImageSize = 20 * 1024 * 1024
 
-// fetchImages downloads or decodes images from the given URLs.
+// maxImagesPerRequest caps the number of image_url entries a single
+// chat-completion request may reference across all messages. Without this
+// cap, a request well within the 10 MB body limit could still enumerate
+// thousands of image URLs, each fetched sequentially (SERVE-3b).
+const maxImagesPerRequest = 16
+
+// maxTotalImageBytes caps the cumulative decoded/downloaded size of all
+// images fetched for a single request, preventing memory exhaustion even
+// when every image individually stays under maxImageSize.
+const maxTotalImageBytes = 64 * 1024 * 1024
+
+// maxImageFetchWallClock bounds the total wall-clock time spent fetching
+// images for a single request, regardless of how many images are fetched
+// or how slow individual origins are. It is applied on top of (not instead
+// of) the caller's context deadline.
+const maxImageFetchWallClock = 60 * time.Second
+
+// imageFetchBudget tracks the remaining decoded-byte budget shared across
+// every image fetched for a single request. It is not safe for concurrent
+// use; fetchImages consumes it sequentially per request.
+type imageFetchBudget struct {
+	remaining int64
+}
+
+// newImageFetchBudget creates a budget with the given total byte allowance.
+func newImageFetchBudget(total int64) *imageFetchBudget {
+	return &imageFetchBudget{remaining: total}
+}
+
+// fetchImages downloads or decodes images from the given URLs, enforcing a
+// shared byte budget and the caller's context (which should carry an overall
+// wall-clock deadline for the whole request's image fan-out).
 // Supports both HTTP(S) URLs and base64 data URIs.
-func fetchImages(ctx context.Context, urls []ImageURL) ([][]byte, error) {
+func fetchImages(ctx context.Context, urls []ImageURL, budget *imageFetchBudget) ([][]byte, error) {
 	images := make([][]byte, len(urls))
 	for i, u := range urls {
-		data, err := fetchImageData(ctx, u.URL)
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("image %d: fetch deadline exceeded: %w", i, err)
+		}
+		if budget.remaining <= 0 {
+			return nil, fmt.Errorf("image %d: total decoded image bytes exceed request budget of %d bytes", i, maxTotalImageBytes)
+		}
+		limit := budget.remaining
+		if limit > maxImageSize {
+			limit = maxImageSize
+		}
+		data, err := fetchImageData(ctx, u.URL, limit)
 		if err != nil {
 			return nil, fmt.Errorf("image %d: %w", i, err)
 		}
+		budget.remaining -= int64(len(data))
 		images[i] = data
 	}
 	return images, nil
 }
 
-// fetchImageData retrieves raw image bytes from a URL or data URI.
-func fetchImageData(ctx context.Context, rawURL string) ([]byte, error) {
+// fetchImageData retrieves raw image bytes from a URL or data URI, never
+// returning more than limit bytes.
+func fetchImageData(ctx context.Context, rawURL string, limit int64) ([]byte, error) {
 	if strings.HasPrefix(rawURL, "data:") {
-		return decodeDataURI(rawURL)
+		return decodeDataURI(rawURL, limit)
 	}
 	if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
-		return downloadImage(ctx, rawURL)
+		return downloadImage(ctx, rawURL, limit)
 	}
 	return nil, fmt.Errorf("unsupported image URL scheme: %s", rawURL)
 }
 
-// decodeDataURI parses a data URI of the form data:<mediatype>;base64,<data>.
-func decodeDataURI(uri string) ([]byte, error) {
+// decodeDataURI parses a data URI of the form data:<mediatype>;base64,<data>,
+// rejecting decoded payloads larger than limit bytes.
+func decodeDataURI(uri string, limit int64) ([]byte, error) {
 	idx := strings.Index(uri, ",")
 	if idx < 0 {
 		return nil, fmt.Errorf("invalid data URI: missing comma separator")
@@ -276,13 +320,21 @@ func decodeDataURI(uri string) ([]byte, error) {
 		return nil, fmt.Errorf("unsupported data URI encoding (only base64 is supported)")
 	}
 	encoded := uri[idx+1:]
-	return base64.StdEncoding.DecodeString(encoded)
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("image exceeds remaining budget of %d bytes", limit)
+	}
+	return data, nil
 }
 
-// downloadImage fetches an image from an HTTP(S) URL.
+// downloadImage fetches an image from an HTTP(S) URL, never returning more
+// than limit bytes.
 // SSRF protection is enforced at connect time by ssrfSafeDialContext
 // in the HTTP transport, preventing DNS rebinding attacks.
-func downloadImage(ctx context.Context, url string) ([]byte, error) {
+func downloadImage(ctx context.Context, url string, limit int64) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
@@ -295,12 +347,12 @@ func downloadImage(ctx context.Context, url string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("download returned status %d", resp.StatusCode)
 	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImageSize+1))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
 	if err != nil {
 		return nil, fmt.Errorf("read body: %w", err)
 	}
-	if len(data) > maxImageSize {
-		return nil, fmt.Errorf("image exceeds maximum size of %d bytes", maxImageSize)
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("image exceeds maximum size of %d bytes", limit)
 	}
 	return data, nil
 }

--- a/serve/vision_test.go
+++ b/serve/vision_test.go
@@ -141,6 +141,148 @@ func TestAPIVisionInput_HTTPImage(t *testing.T) {
 	}
 }
 
+// TestAPIVisionInput_TooManyImages verifies that a chat-completion request
+// referencing more than maxImagesPerRequest image_url entries is rejected
+// with a 400 before any image is fetched (SERVE-3b). A naive fan-out would
+// otherwise sequentially fetch every entry (each up to maxImageSize, with a
+// 30s timeout) before failing, which is the resource-exhaustion DoS this
+// cap prevents.
+func TestAPIVisionInput_TooManyImages(t *testing.T) {
+	pngData := testPNG(t)
+
+	var fetchCount atomic.Int64
+	imgServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngData)
+	}))
+	defer imgServer.Close()
+
+	withBypassedSSRF(t)
+
+	mdl := buildTestModel(t)
+	srv := NewServer(mdl)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	var parts []string
+	parts = append(parts, `{"type": "text", "text": "describe these"}`)
+	for i := 0; i < maxImagesPerRequest+1; i++ {
+		parts = append(parts, `{"type": "image_url", "image_url": {"url": "`+imgServer.URL+`/test.png"}}`)
+	}
+	body := `{"messages": [{"role": "user", "content": [` + strings.Join(parts, ",") + `]}], "max_tokens": 5}`
+
+	resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusBadRequest, data)
+	}
+	if !containsAny(string(data), "too many images") {
+		t.Errorf("error body = %s, want mention of image count cap", data)
+	}
+	if got := fetchCount.Load(); got != 0 {
+		t.Errorf("fetchCount = %d, want 0 (request should be rejected before any fetch)", got)
+	}
+}
+
+// TestAPIVisionInput_TooManyImages_AcrossMessages verifies the image count
+// cap is enforced across the whole request (summed over every message),
+// not just within a single message.
+func TestAPIVisionInput_TooManyImages_AcrossMessages(t *testing.T) {
+	pngData := testPNG(t)
+
+	var fetchCount atomic.Int64
+	imgServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngData)
+	}))
+	defer imgServer.Close()
+
+	withBypassedSSRF(t)
+
+	mdl := buildTestModel(t)
+	srv := NewServer(mdl)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	imgPart := `{"type": "image_url", "image_url": {"url": "` + imgServer.URL + `/test.png"}}`
+	perMessage := maxImagesPerRequest/2 + 1 // two messages of this size exceed the cap
+	var imgParts []string
+	for i := 0; i < perMessage; i++ {
+		imgParts = append(imgParts, imgPart)
+	}
+	content := "[" + strings.Join(imgParts, ",") + "]"
+	body := `{"messages": [
+		{"role": "user", "content": ` + content + `},
+		{"role": "user", "content": ` + content + `}
+	], "max_tokens": 5}`
+
+	resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusBadRequest, data)
+	}
+	if got := fetchCount.Load(); got != 0 {
+		t.Errorf("fetchCount = %d, want 0 (request should be rejected before any fetch)", got)
+	}
+}
+
+// TestFetchImages_ByteBudgetExceeded verifies that fetchImages enforces the
+// shared byte budget across multiple images in a single call, rejecting a
+// fetch once the cumulative decoded size would exceed the remaining budget
+// -- even though each individual image stays under maxImageSize.
+func TestFetchImages_ByteBudgetExceeded(t *testing.T) {
+	mkDataURI := func(n int) string {
+		payload := bytes.Repeat([]byte{0x42}, n)
+		return "data:application/octet-stream;base64," + base64.StdEncoding.EncodeToString(payload)
+	}
+
+	urls := []ImageURL{
+		{URL: mkDataURI(100)},
+		{URL: mkDataURI(100)},
+	}
+
+	budget := newImageFetchBudget(150) // first image fits, second does not
+	_, err := fetchImages(context.Background(), urls, budget)
+	if err == nil {
+		t.Fatal("expected error when cumulative image bytes exceed budget, got nil")
+	}
+	if !containsAny(err.Error(), "budget") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestFetchImages_WithinByteBudget verifies that fetchImages succeeds and
+// correctly decrements the shared budget when total bytes stay within it.
+func TestFetchImages_WithinByteBudget(t *testing.T) {
+	mkDataURI := func(n int) string {
+		payload := bytes.Repeat([]byte{0x42}, n)
+		return "data:application/octet-stream;base64," + base64.StdEncoding.EncodeToString(payload)
+	}
+
+	urls := []ImageURL{
+		{URL: mkDataURI(100)},
+		{URL: mkDataURI(100)},
+	}
+
+	budget := newImageFetchBudget(1000)
+	images, err := fetchImages(context.Background(), urls, budget)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(images) != 2 || len(images[0]) != 100 || len(images[1]) != 100 {
+		t.Fatalf("unexpected image sizes: %v", images)
+	}
+	if budget.remaining != 800 {
+		t.Errorf("budget.remaining = %d, want 800", budget.remaining)
+	}
+}
+
 func TestAPIVisionInput_StringContent(t *testing.T) {
 	mdl := buildTestModel(t)
 	srv := NewServer(mdl)
@@ -214,7 +356,7 @@ func TestDecodeDataURI(t *testing.T) {
 	encoded := base64.StdEncoding.EncodeToString(original)
 	uri := "data:image/png;base64," + encoded
 
-	got, err := decodeDataURI(uri)
+	got, err := decodeDataURI(uri, maxImageSize)
 	if err != nil {
 		t.Fatalf("decodeDataURI error: %v", err)
 	}
@@ -224,7 +366,7 @@ func TestDecodeDataURI(t *testing.T) {
 }
 
 func TestDecodeDataURI_InvalidFormat(t *testing.T) {
-	_, err := decodeDataURI("data:image/png;base64")
+	_, err := decodeDataURI("data:image/png;base64", maxImageSize)
 	if err == nil {
 		t.Error("expected error for missing comma separator")
 	}
@@ -281,7 +423,7 @@ func TestChatMessageUnmarshal_EmptyString(t *testing.T) {
 
 func TestSSRF_BlockLoopback(t *testing.T) {
 	ctx := context.Background()
-	_, err := downloadImage(ctx, "http://127.0.0.1/secret")
+	_, err := downloadImage(ctx, "http://127.0.0.1/secret", maxImageSize)
 	if err == nil {
 		t.Fatal("expected error for loopback address, got nil")
 	}
@@ -292,7 +434,7 @@ func TestSSRF_BlockLoopback(t *testing.T) {
 
 func TestSSRF_BlockMetadataIP(t *testing.T) {
 	ctx := context.Background()
-	_, err := downloadImage(ctx, "http://169.254.169.254/latest/meta-data/")
+	_, err := downloadImage(ctx, "http://169.254.169.254/latest/meta-data/", maxImageSize)
 	if err == nil {
 		t.Fatal("expected error for metadata IP, got nil")
 	}
@@ -303,7 +445,7 @@ func TestSSRF_BlockMetadataIP(t *testing.T) {
 
 func TestSSRF_BlockMetadataHostname(t *testing.T) {
 	ctx := context.Background()
-	_, err := downloadImage(ctx, "http://metadata.google.internal/computeMetadata/v1/")
+	_, err := downloadImage(ctx, "http://metadata.google.internal/computeMetadata/v1/", maxImageSize)
 	if err == nil {
 		t.Fatal("expected error for metadata.google.internal, got nil")
 	}
@@ -314,7 +456,7 @@ func TestSSRF_BlockMetadataHostname(t *testing.T) {
 
 func TestSSRF_BlockPrivateAddress(t *testing.T) {
 	ctx := context.Background()
-	_, err := downloadImage(ctx, "http://10.0.0.1/internal")
+	_, err := downloadImage(ctx, "http://10.0.0.1/internal", maxImageSize)
 	if err == nil {
 		t.Fatal("expected error for private address, got nil")
 	}
@@ -335,7 +477,7 @@ func TestSSRF_AllowPublicURL(t *testing.T) {
 	withBypassedSSRF(t)
 
 	ctx := context.Background()
-	got, err := downloadImage(ctx, imgServer.URL+"/image.png")
+	got, err := downloadImage(ctx, imgServer.URL+"/image.png", maxImageSize)
 	if err != nil {
 		t.Fatalf("unexpected error downloading from mock server: %v", err)
 	}


### PR DESCRIPTION
## Summary

Fixes SERVE-3b from `docs/deep-reviews/002-full-codebase.md` [CWE-770]: a 10 MB chat-completion request body could enumerate thousands of `image_url` entries. Each was fetched sequentially in `serve/vision.go` (up to 20 MB, 30s timeout each) and accumulated fully in memory before any response, allowing a small request to trigger unbounded memory/time consumption on the server.

## Changes

- `serve/handlers.go`: sum `ImageURLs` across all messages in a request and reject with `400` (`too many images: N exceeds maximum of 16 per request`) *before* fetching anything if the total exceeds `maxImagesPerRequest` (16).
- `serve/vision.go`:
  - `maxImagesPerRequest = 16`
  - `maxTotalImageBytes = 64 MB` — a shared `imageFetchBudget` tracks cumulative decoded bytes across every image in the request; `fetchImages`/`downloadImage`/`decodeDataURI` now take an explicit per-call `limit` derived from the remaining budget, so a download is capped to what's left rather than always up to the old flat 20 MB.
  - `maxImageFetchWallClock = 60s` — the whole fan-out for a request runs under a `context.WithTimeout(r.Context(), ...)`, bounding total wall-clock time regardless of how many images or how slow the origins are.

## Test plan

- [x] `TestAPIVisionInput_TooManyImages` — 17 `image_url` entries in one message: request rejected `400` before any fetch (asserts fetch-server hit count stays 0).
- [x] `TestAPIVisionInput_TooManyImages_AcrossMessages` — count cap enforced as a sum across multiple messages, not per-message.
- [x] `TestFetchImages_ByteBudgetExceeded` — shared budget rejects a second image once cumulative bytes would exceed it, even though each image individually is within `maxImageSize`.
- [x] `TestFetchImages_WithinByteBudget` — budget correctly decremented on success.
- [x] Existing `TestAPIVisionInput` / `TestAPIVisionInput_HTTPImage` (normal small requests) still pass.
- [x] `gofmt -l` clean on changed files; `go vet ./serve/...` clean; `go test ./serve/...` green.