### PR TITLE
fix(registry): reject non-https registry URLs unless explicitly opted in (OCI-2, T139.5)

### DIFF
--- a/model/registry/oci.go
+++ b/model/registry/oci.go
@@ -18,10 +18,11 @@ var maxBlobSize = 20 << 30
 // Registry is an OCI distribution spec client for pushing and pulling
 // GGUF models as OCI artifacts.
 type Registry struct {
-	url      string
-	username string
-	password string
-	client   *http.Client
+	url          string
+	username     string
+	password     string
+	client       *http.Client
+	insecureHTTP bool
 }
 
 // Option configures a Registry.
@@ -42,16 +43,50 @@ func WithHTTPClient(client *http.Client) Option {
 	}
 }
 
-// NewRegistry creates a new OCI registry client.
-func NewRegistry(url string, opts ...Option) *Registry {
+// WithInsecureHTTP allows the registry client to talk to a plain http://
+// endpoint instead of https://. By default NewRegistry rejects non-https
+// registry URLs: an http registry lets a network attacker read
+// credentials and blob contents, or tamper with manifests/blobs in
+// transit (CWE-319). Only opt in for local development or test servers
+// that cannot serve TLS (e.g. httptest.Server).
+func WithInsecureHTTP() Option {
+	return func(r *Registry) {
+		r.insecureHTTP = true
+	}
+}
+
+// NewRegistry creates a new OCI registry client for the given base URL.
+//
+// The URL must use the https:// scheme. Plain http:// is rejected unless
+// WithInsecureHTTP is passed, since an insecure connection lets a
+// network attacker observe credentials and model bytes, or tamper with
+// them in transit. Use WithInsecureHTTP() to opt in for localhost
+// development or test servers that do not serve TLS.
+func NewRegistry(rawURL string, opts ...Option) (*Registry, error) {
 	r := &Registry{
-		url:    strings.TrimRight(url, "/"),
+		url:    strings.TrimRight(rawURL, "/"),
 		client: http.DefaultClient,
 	}
 	for _, opt := range opts {
 		opt(r)
 	}
-	return r
+
+	scheme, _, ok := strings.Cut(r.url, "://")
+	if !ok {
+		return nil, fmt.Errorf("oci: registry URL %q must include a scheme (https:// or http://)", rawURL)
+	}
+	switch strings.ToLower(scheme) {
+	case "https":
+		// Always allowed.
+	case "http":
+		if !r.insecureHTTP {
+			return nil, fmt.Errorf("oci: registry URL %q uses http://; refusing to connect insecurely, use WithInsecureHTTP() to opt in", rawURL)
+		}
+	default:
+		return nil, fmt.Errorf("oci: registry URL %q has unsupported scheme %q; only https:// is allowed (or http:// with WithInsecureHTTP)", rawURL, scheme)
+	}
+
+	return r, nil
 }
 
 // Reference holds a parsed OCI reference (registry/repo:tag or registry/repo@digest).

--- a/model/registry/oci_test.go
+++ b/model/registry/oci_test.go
@@ -160,12 +160,71 @@ func readBody(r *http.Request) ([]byte, error) {
 	return data, nil
 }
 
+// TestNewRegistry_RejectsHTTPByDefault verifies that a plain http://
+// registry URL is rejected unless the caller explicitly opts in via
+// WithInsecureHTTP (OCI-2).
+func TestNewRegistry_RejectsHTTPByDefault(t *testing.T) {
+	reg, err := NewRegistry("http://registry.example.com")
+	if err == nil {
+		t.Fatal("NewRegistry should reject a plain http:// URL by default")
+	}
+	if reg != nil {
+		t.Error("NewRegistry should return a nil Registry on error")
+	}
+	if !strings.Contains(err.Error(), "http://") {
+		t.Errorf("error should mention http://, got: %v", err)
+	}
+}
+
+// TestNewRegistry_AllowsHTTPWithInsecureOptIn verifies that WithInsecureHTTP
+// re-allows a plain http:// registry URL, so local dev servers and
+// httptest-based tests can still opt in explicitly.
+func TestNewRegistry_AllowsHTTPWithInsecureOptIn(t *testing.T) {
+	reg, err := NewRegistry("http://registry.example.com", WithInsecureHTTP())
+	if err != nil {
+		t.Fatalf("NewRegistry with WithInsecureHTTP should accept http://, got error: %v", err)
+	}
+	if reg == nil {
+		t.Fatal("NewRegistry should return a non-nil Registry")
+	}
+}
+
+// TestNewRegistry_AllowsHTTPS verifies that https:// registry URLs are
+// always accepted, with or without the insecure opt-in.
+func TestNewRegistry_AllowsHTTPS(t *testing.T) {
+	if _, err := NewRegistry("https://registry.example.com"); err != nil {
+		t.Errorf("NewRegistry should accept https:// by default, got error: %v", err)
+	}
+	if _, err := NewRegistry("https://registry.example.com", WithInsecureHTTP()); err != nil {
+		t.Errorf("NewRegistry should accept https:// with WithInsecureHTTP too, got error: %v", err)
+	}
+}
+
+// TestNewRegistry_RejectsUnsupportedScheme verifies that schemes other than
+// http/https (e.g. ftp://) are rejected outright.
+func TestNewRegistry_RejectsUnsupportedScheme(t *testing.T) {
+	if _, err := NewRegistry("ftp://registry.example.com"); err == nil {
+		t.Fatal("NewRegistry should reject non-http(s) schemes")
+	}
+}
+
+// TestNewRegistry_RejectsMissingScheme verifies that a URL with no scheme
+// at all is rejected rather than silently treated as insecure.
+func TestNewRegistry_RejectsMissingScheme(t *testing.T) {
+	if _, err := NewRegistry("registry.example.com"); err == nil {
+		t.Fatal("NewRegistry should reject a URL with no scheme")
+	}
+}
+
 func TestRegistry_Push(t *testing.T) {
 	mock := newMockOCIRegistry()
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
 	// Create a fake GGUF model file.
 	dir := t.TempDir()
@@ -175,7 +234,7 @@ func TestRegistry_Push(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := reg.Push(context.Background(), "registry.example.com/myrepo:v1.0", modelPath)
+	err = reg.Push(context.Background(), "registry.example.com/myrepo:v1.0", modelPath)
 	if err != nil {
 		t.Fatalf("Push error: %v", err)
 	}
@@ -230,7 +289,10 @@ func TestRegistry_Pull(t *testing.T) {
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
 	// First push a model.
 	dir := t.TempDir()
@@ -268,7 +330,10 @@ func TestRegistry_Pull_DigestMismatch(t *testing.T) {
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
 	repo := "models/evil"
 	tag := "v1"
@@ -328,7 +393,10 @@ func TestRegistry_Tags(t *testing.T) {
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
 	// Push two versions.
 	dir := t.TempDir()
@@ -367,7 +435,10 @@ func TestRegistry_Resolve(t *testing.T) {
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
 	dir := t.TempDir()
 	modelPath := filepath.Join(dir, "model.gguf")
@@ -397,16 +468,22 @@ func TestRegistry_Resolve(t *testing.T) {
 }
 
 func TestRegistry_Push_FileNotFound(t *testing.T) {
-	reg := NewRegistry("http://localhost:0")
-	err := reg.Push(context.Background(), "registry.example.com/repo:v1", "/nonexistent/model.gguf")
+	reg, err := NewRegistry("http://localhost:0", WithInsecureHTTP())
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
+	err = reg.Push(context.Background(), "registry.example.com/repo:v1", "/nonexistent/model.gguf")
 	if err == nil {
 		t.Error("Push should fail for nonexistent file")
 	}
 }
 
 func TestRegistry_Push_InvalidRef(t *testing.T) {
-	reg := NewRegistry("http://localhost:0")
-	err := reg.Push(context.Background(), "invalidref", "/nonexistent/model.gguf")
+	reg, err := NewRegistry("http://localhost:0", WithInsecureHTTP())
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
+	err = reg.Push(context.Background(), "invalidref", "/nonexistent/model.gguf")
 	if err == nil {
 		t.Error("Push should fail for invalid reference")
 	}
@@ -417,9 +494,12 @@ func TestRegistry_Pull_ManifestNotFound(t *testing.T) {
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
-	err := reg.Pull(context.Background(), "registry.example.com/repo:nonexistent", "/tmp/out.gguf")
+	err = reg.Pull(context.Background(), "registry.example.com/repo:nonexistent", "/tmp/out.gguf")
 	if err == nil {
 		t.Error("Pull should fail for nonexistent manifest")
 	}
@@ -430,7 +510,10 @@ func TestRegistry_Tags_EmptyRepo(t *testing.T) {
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
 	tags, err := reg.Tags(context.Background(), "empty/repo")
 	if err != nil {
@@ -449,12 +532,16 @@ func TestRegistry_WithCredentials(t *testing.T) {
 	}))
 	defer server.Close()
 
-	reg := NewRegistry(server.URL,
+	reg, err := NewRegistry(server.URL,
+		WithInsecureHTTP(),
 		WithCredentials("myuser", "mypass"),
 		WithHTTPClient(server.Client()),
 	)
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
-	_, err := reg.Tags(context.Background(), "repo")
+	_, err = reg.Tags(context.Background(), "repo")
 	if err != nil {
 		t.Fatalf("Tags error: %v", err)
 	}
@@ -472,7 +559,10 @@ func TestRegistry_DefaultTag(t *testing.T) {
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
 	dir := t.TempDir()
 	modelPath := filepath.Join(dir, "model.gguf")
@@ -486,7 +576,7 @@ func TestRegistry_DefaultTag(t *testing.T) {
 	}
 
 	// Resolve using explicit "latest".
-	_, err := reg.Resolve(context.Background(), "registry.example.com/repo:latest")
+	_, err = reg.Resolve(context.Background(), "registry.example.com/repo:latest")
 	if err != nil {
 		t.Fatalf("Resolve(latest) error: %v", err)
 	}
@@ -497,7 +587,10 @@ func TestRegistry_DigestReference(t *testing.T) {
 	server := httptest.NewServer(mock.handler())
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
 	dir := t.TempDir()
 	modelPath := filepath.Join(dir, "model.gguf")
@@ -606,9 +699,12 @@ func TestRegistry_GetBlob_OversizedResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	reg := NewRegistry(server.URL, WithHTTPClient(server.Client()))
+	reg, err := NewRegistry(server.URL, WithInsecureHTTP(), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewRegistry error: %v", err)
+	}
 
-	_, err := reg.getBlob(context.Background(), "repo", "sha256:fake")
+	_, err = reg.getBlob(context.Background(), "repo", "sha256:fake")
 	if err == nil {
 		t.Fatal("getBlob should reject oversized blob")
 	}


### PR DESCRIPTION
## Summary

- Fixes OCI-2 (deep-review 002, CWE-319): `model/registry/oci.go`'s `NewRegistry` accepted plain `http://` registry URLs, letting a network attacker read credentials/model bytes or tamper with manifests and blobs in transit.
- `NewRegistry` now validates the URL scheme: `https://` is always allowed; `http://` is rejected unless the new `WithInsecureHTTP()` option is passed; any other scheme (or a missing scheme) is rejected outright.
- Signature changes from `NewRegistry(url string, opts ...Option) *Registry` to `NewRegistry(url string, opts ...Option) (*Registry, error)` to surface the rejection. `NewRegistry` has no callers outside `model/registry` (verified via repo-wide grep), so this is a self-contained change.
- Existing httptest-based tests (which spin up plain-http test servers) now pass `WithInsecureHTTP()` alongside the existing `WithHTTPClient()` option, so they keep exercising real request/response flows without weakening the production default.

## Test plan

- [x] `TestNewRegistry_RejectsHTTPByDefault` — `http://` rejected without the opt-in
- [x] `TestNewRegistry_AllowsHTTPWithInsecureOptIn` — `http://` accepted with `WithInsecureHTTP()`
- [x] `TestNewRegistry_AllowsHTTPS` — `https://` accepted with or without the opt-in
- [x] `TestNewRegistry_RejectsUnsupportedScheme` / `TestNewRegistry_RejectsMissingScheme` — non-http(s) and scheme-less URLs rejected
- [x] All pre-existing `model/registry` tests updated and passing (`go test ./model/registry/...`)
- [x] `gofmt -l model/registry/` clean, `go vet ./...` clean, `go build ./...` clean