### PR TITLE
fix(serve): validate max_tokens/temperature bounds (SERVE-5, T143.6)

### DIFF
--- a/serve/handlers.go
+++ b/serve/handlers.go
@@ -45,6 +45,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if err := validateMaxTokens(req.MaxTokens); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	// Validate tools and tool_choice.
 	if len(req.Tools) > 0 {
@@ -199,6 +203,10 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 
 	// Validate sampling parameters.
 	if err := validateSamplingParams(req.Temperature, req.TopP, req.TopK); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validateMaxTokens(req.MaxTokens); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/serve/server_test.go
+++ b/serve/server_test.go
@@ -1901,6 +1901,140 @@ func TestMaxTokensClamp(t *testing.T) {
 	})
 }
 
+func TestMaxTokensNonPositiveRejected(t *testing.T) {
+	mdl := buildTestModel(t)
+
+	t.Run("negative_rejected_chat", func(t *testing.T) {
+		srv := NewServer(mdl)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body := `{"model":"test-model","messages":[{"role":"user","content":"hello"}],"max_tokens":-1}`
+		resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 400; body = %s", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("zero_rejected_chat", func(t *testing.T) {
+		srv := NewServer(mdl)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body := `{"model":"test-model","messages":[{"role":"user","content":"hello"}],"max_tokens":0}`
+		resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 400; body = %s", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("negative_rejected_completions", func(t *testing.T) {
+		srv := NewServer(mdl)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body := `{"model":"test-model","prompt":"hello","max_tokens":-5}`
+		resp := doPost(t, ts.URL+"/v1/completions", "application/json", body)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 400; body = %s", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("zero_rejected_completions", func(t *testing.T) {
+		srv := NewServer(mdl)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body := `{"model":"test-model","prompt":"hello","max_tokens":0}`
+		resp := doPost(t, ts.URL+"/v1/completions", "application/json", body)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 400; body = %s", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("positive_still_works", func(t *testing.T) {
+		srv := NewServer(mdl)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body := `{"model":"test-model","messages":[{"role":"user","content":"hello"}],"max_tokens":5}`
+		resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, b)
+		}
+	})
+}
+
+func TestTemperatureUpperBoundClamp(t *testing.T) {
+	mdl := buildTestModel(t)
+
+	t.Run("out_of_range_clamped_not_rejected_chat", func(t *testing.T) {
+		srv := NewServer(mdl)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body := `{"model":"test-model","messages":[{"role":"user","content":"hello"}],"temperature":10,"max_tokens":5}`
+		resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("out_of_range_clamped_not_rejected_completions", func(t *testing.T) {
+		srv := NewServer(mdl)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body := `{"model":"test-model","prompt":"hello","temperature":10,"max_tokens":5}`
+		resp := doPost(t, ts.URL+"/v1/completions", "application/json", body)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("negative_still_rejected", func(t *testing.T) {
+		srv := NewServer(mdl)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body := `{"model":"test-model","messages":[{"role":"user","content":"hello"}],"temperature":-1,"max_tokens":5}`
+		resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 400; body = %s", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("valid_temperature_still_works", func(t *testing.T) {
+		srv := NewServer(mdl)
+		ts := httptest.NewServer(srv.Handler())
+		defer ts.Close()
+
+		body := `{"model":"test-model","messages":[{"role":"user","content":"hello"}],"temperature":0.7,"max_tokens":5}`
+		resp := doPost(t, ts.URL+"/v1/chat/completions", "application/json", body)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, b)
+		}
+	})
+}
+
 func TestRateLimitMiddleware(t *testing.T) {
 	m := buildTestModel(t)
 
@@ -2088,7 +2222,57 @@ func TestValidateSamplingParams(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("temperature clamped high", func(t *testing.T) {
+		temp := 5.0
+		if err := validateSamplingParams(&temp, nil, nil); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if temp != maxTemperature {
+			t.Errorf("temperature = %g, want %g", temp, maxTemperature)
+		}
+	})
+
+	t.Run("temperature at upper bound allowed", func(t *testing.T) {
+		temp := maxTemperature
+		if err := validateSamplingParams(&temp, nil, nil); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if temp != maxTemperature {
+			t.Errorf("temperature = %g, want %g", temp, maxTemperature)
+		}
+	})
 }
+
+func TestValidateMaxTokens(t *testing.T) {
+	t.Run("nil allowed", func(t *testing.T) {
+		if err := validateMaxTokens(nil); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("positive allowed", func(t *testing.T) {
+		n := 100
+		if err := validateMaxTokens(&n); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("zero rejected", func(t *testing.T) {
+		n := 0
+		if err := validateMaxTokens(&n); err == nil {
+			t.Error("expected error for zero max_tokens")
+		}
+	})
+
+	t.Run("negative rejected", func(t *testing.T) {
+		n := -5
+		if err := validateMaxTokens(&n); err == nil {
+			t.Error("expected error for negative max_tokens")
+		}
+	})
+}
+
 func TestHandleHealthz(t *testing.T) {
 	mdl := buildTestModel(t)
 	srv := NewServer(mdl)

--- a/serve/types.go
+++ b/serve/types.go
@@ -161,12 +161,23 @@ type ModelDeleteResponse struct {
 
 // --- Validation and helper functions ---
 
+// maxTemperature is the server-side upper bound for the temperature sampling
+// parameter. Values above this are clamped rather than rejected, matching the
+// clamp convention already used for max_tokens' upper bound and top_p.
+const maxTemperature = 2.0
+
 // validateSamplingParams checks temperature, top_p, and top_k values.
-// Temperature must be >= 0 (rejected otherwise). TopP is clamped to [0, 1].
+// Temperature must be >= 0 (rejected otherwise) and is clamped to
+// maxTemperature on the high end. TopP is clamped to [0, 1].
 // TopK must be >= 0 (rejected otherwise).
 func validateSamplingParams(temperature *float64, topP *float64, topK *int) error {
-	if temperature != nil && *temperature < 0 {
-		return fmt.Errorf("temperature must be >= 0, got %g", *temperature)
+	if temperature != nil {
+		if *temperature < 0 {
+			return fmt.Errorf("temperature must be >= 0, got %g", *temperature)
+		}
+		if *temperature > maxTemperature {
+			*temperature = maxTemperature
+		}
 	}
 	if topP != nil {
 		if *topP < 0 {
@@ -177,6 +188,15 @@ func validateSamplingParams(temperature *float64, topP *float64, topK *int) erro
 	}
 	if topK != nil && *topK < 0 {
 		return fmt.Errorf("top_k must be >= 0, got %d", *topK)
+	}
+	return nil
+}
+
+// validateMaxTokens rejects non-positive max_tokens values. The upper bound is
+// enforced separately by clamping to the server's configured maximum.
+func validateMaxTokens(maxTokens *int) error {
+	if maxTokens != nil && *maxTokens <= 0 {
+		return fmt.Errorf("max_tokens must be > 0, got %d", *maxTokens)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `max_tokens` in `/v1/chat/completions` and `/v1/completions` only had its upper bound enforced (clamped to the server's configured limit). A negative or zero value passed through unvalidated and reached `buildGenerationOptions`/generation. Now rejected with 400 via a new `validateMaxTokens` check in `serve/types.go`, called from both handlers in `serve/handlers.go`.
- `temperature` had no upper bound at all. Added a `maxTemperature` constant (2.0) and clamp it in `validateSamplingParams`, matching the existing clamp convention already used for `max_tokens`' upper bound and `top_p` (rather than rejecting, to stay consistent with that convention).

Addresses SERVE-5 from `docs/deep-reviews/002-full-codebase.md`.

## Test plan
- [x] `TestValidateMaxTokens` (new, `serve/server_test.go`): nil/positive allowed, zero/negative rejected.
- [x] `TestValidateSamplingParams` (extended): temperature clamped at `maxTemperature` on the high end, values at the bound allowed.
- [x] `TestMaxTokensNonPositiveRejected` (new, API-level): negative/zero `max_tokens` -> 400 on both `/v1/chat/completions` and `/v1/completions`; a valid positive value still returns 200.
- [x] `TestTemperatureUpperBoundClamp` (new, API-level): out-of-range temperature is clamped (200, not rejected) on both endpoints; negative temperature still rejected (400); valid temperature still works (200).
- [x] `gofmt -l` clean, `go vet ./serve/...` clean, `go test ./serve/...` green.