### PR TITLE
feat(cli): wire --rate-limit/--keystore serve flags (T145.1)

### DIFF
--- a/cmd/cli/serve.go
+++ b/cmd/cli/serve.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/zerfoo/zerfoo/inference"
 	"github.com/zerfoo/zerfoo/serve"
+	"github.com/zerfoo/zerfoo/serve/security"
 	"github.com/zerfoo/zerfoo/serve/shutdown"
 )
 
@@ -24,6 +26,11 @@ type ServeCommand struct {
 	shutdownCoord *shutdown.Coordinator
 	// loadFn allows injection of a custom model loader for testing.
 	loadFn func(modelID string, opts ...inference.Option) (*inference.Model, error)
+	// newServer constructs the server from its options. Defaults to
+	// serve.NewServer; overridable in tests so they can capture the
+	// constructed *serve.Server (and confirm which security options were
+	// actually applied) without standing up a real listening socket.
+	newServer func(m *inference.Model, opts ...serve.ServerOption) *serve.Server
 }
 
 // NewServeCommand creates a new ServeCommand.
@@ -32,6 +39,7 @@ func NewServeCommand(coord *shutdown.Coordinator, out io.Writer) *ServeCommand {
 		out:           out,
 		shutdownCoord: coord,
 		loadFn:        inference.Load,
+		newServer:     serve.NewServer,
 	}
 }
 
@@ -46,8 +54,10 @@ func (c *ServeCommand) Description() string {
 // Run implements Command.Run.
 func (c *ServeCommand) Run(ctx context.Context, args []string) error {
 	var modelID, cacheDir, port, gpusRaw, apiKey, tlsCert, tlsKey string
-	var pjrtPlugin string
+	var pjrtPlugin, keystorePath string
 	var allowNoAuth bool
+	var rateLimitRPS float64
+	var rateLimitBurst int
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -96,6 +106,32 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) error {
 			}
 			pjrtPlugin = args[i+1]
 			i++
+		case "--keystore":
+			if i+1 >= len(args) {
+				return errors.New("--keystore requires a value")
+			}
+			keystorePath = args[i+1]
+			i++
+		case "--rate-limit":
+			if i+1 >= len(args) {
+				return errors.New("--rate-limit requires a value")
+			}
+			v, perr := strconv.ParseFloat(args[i+1], 64)
+			if perr != nil || v <= 0 {
+				return fmt.Errorf("invalid --rate-limit value: %s", args[i+1])
+			}
+			rateLimitRPS = v
+			i++
+		case "--rate-limit-burst":
+			if i+1 >= len(args) {
+				return errors.New("--rate-limit-burst requires a value")
+			}
+			n, perr := strconv.Atoi(args[i+1])
+			if perr != nil || n <= 0 {
+				return fmt.Errorf("invalid --rate-limit-burst value: %s", args[i+1])
+			}
+			rateLimitBurst = n
+			i++
 		default:
 			if modelID != "" {
 				return fmt.Errorf("unexpected argument: %s", args[i])
@@ -119,6 +155,9 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) error {
 	if (tlsCert != "") != (tlsKey != "") {
 		return errors.New("both --tls-cert and --tls-key are required")
 	}
+	if rateLimitBurst > 0 && rateLimitRPS <= 0 {
+		return errors.New("--rate-limit-burst requires --rate-limit")
+	}
 
 	var loadOpts []inference.Option
 	if cacheDir != "" {
@@ -137,18 +176,36 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) error {
 		}
 	}
 
-	// Require explicit opt-in when no API key is configured.
-	if apiKey == "" && !allowNoAuth {
-		return errors.New("set --api-key, ZERFOO_API_KEY, or --allow-no-auth")
+	// Require explicit opt-in when no authentication (static API key or a
+	// scoped keystore) is configured.
+	authConfigured := apiKey != "" || keystorePath != ""
+	if !authConfigured && !allowNoAuth {
+		return errors.New("set --api-key, ZERFOO_API_KEY, or --allow-no-auth (or configure --keystore)")
 	}
-	if apiKey == "" && allowNoAuth {
+	if !authConfigured && allowNoAuth {
 		_, _ = fmt.Fprintf(c.out, "WARN: serve: no API key configured, all endpoints are public\n")
+	}
+
+	// Open the scoped keystore before loading the model so a bad --keystore
+	// path fails fast instead of after the (potentially slow) model load.
+	var keyStore *security.KeyStore
+	var keystoreBackend *security.BboltKeyStoreBackend
+	if keystorePath != "" {
+		var kerr error
+		keystoreBackend, kerr = security.NewBboltKeyStoreBackend(keystorePath)
+		if kerr != nil {
+			return fmt.Errorf("open --keystore: %w", kerr)
+		}
+		keyStore = security.NewKeyStore(security.WithBackend(keystoreBackend))
 	}
 
 	li := startLoading(c.out)
 	mdl, err := c.loadFn(modelID, loadOpts...)
 	li.stop()
 	if err != nil {
+		if keystoreBackend != nil {
+			_ = keystoreBackend.Close()
+		}
 		return fmt.Errorf("load model: %w", err)
 	}
 
@@ -159,13 +216,34 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) error {
 	if apiKey != "" {
 		serverOpts = append(serverOpts, serve.WithAPIKey(apiKey))
 	}
-	srv := serve.NewServer(mdl, serverOpts...)
+	if keyStore != nil {
+		serverOpts = append(serverOpts, serve.WithKeyStore(keyStore))
+	}
+	if rateLimitRPS > 0 {
+		burst := rateLimitBurst
+		if burst <= 0 {
+			burst = int(math.Ceil(rateLimitRPS))
+			if burst < 1 {
+				burst = 1
+			}
+		}
+		serverOpts = append(serverOpts, serve.WithRateLimiter(security.NewRateLimiter(rateLimitRPS, burst)))
+	}
+	srv := c.newServer(mdl, serverOpts...)
 	httpServer := &http.Server{
 		Addr:    net.JoinHostPort("", port),
 		Handler: srv.Handler(),
 	}
 
 	if c.shutdownCoord != nil {
+		// Registered before httpServer so reverse-order Shutdown closes the
+		// listener first (drain in-flight requests), then srv.Close (stops
+		// the rate limiter's cleanup goroutine and batch scheduler, per
+		// T142.3), then finally the keystore's bbolt handle.
+		if keystoreBackend != nil {
+			c.shutdownCoord.Register(bboltCloser{keystoreBackend})
+		}
+		c.shutdownCoord.Register(srv)
 		c.shutdownCoord.Register(shutdownAdapter{httpServer})
 	}
 
@@ -206,6 +284,16 @@ func (a shutdownAdapter) Close(ctx context.Context) error {
 	return a.srv.Shutdown(ctx)
 }
 
+// bboltCloser adapts *security.BboltKeyStoreBackend (whose Close takes no
+// context) to the shutdown.Closer interface.
+type bboltCloser struct {
+	backend *security.BboltKeyStoreBackend
+}
+
+func (b bboltCloser) Close(_ context.Context) error {
+	return b.backend.Close()
+}
+
 // parseGPUList parses a comma-separated list of GPU IDs (e.g. "0,1,2,3")
 // and returns them as a sorted, deduplicated slice of non-negative integers.
 func parseGPUList(raw string) ([]int, error) {
@@ -243,14 +331,26 @@ func (c *ServeCommand) Usage() string {
 Start an OpenAI-compatible HTTP inference server.
 
 OPTIONS:
-  --port <port>       Listen port (default: 8080)
-  --cache-dir <dir>   Override model cache directory
-  --gpus <ids>        Comma-separated GPU IDs to distribute model across (e.g. 0,1,2,3)
-  --api-key <key>     Require Bearer token auth (env: ZERFOO_API_KEY)
-  --allow-no-auth     Allow starting without an API key (public endpoints)
-  --tls-cert <path>   Path to TLS certificate file (requires --tls-key)
-  --tls-key <path>    Path to TLS private key file (requires --tls-cert)
-  --pjrt <path>       Path to PJRT plugin .so for accelerator backend
+  --port <port>            Listen port (default: 8080)
+  --cache-dir <dir>        Override model cache directory
+  --gpus <ids>             Comma-separated GPU IDs to distribute model across (e.g. 0,1,2,3)
+  --api-key <key>          Require Bearer token auth (env: ZERFOO_API_KEY)
+  --keystore <path>        Path to a bbolt-backed scoped API key store. Enables
+                           per-key scope enforcement (read_only/inference/
+                           training/admin) instead of a single static key.
+                           May be combined with --api-key; when both are set,
+                           keystore-backed scope checks take precedence.
+                           Counts as configured authentication for the
+                           no-auth-without-opt-in check below.
+  --allow-no-auth          Allow starting without an API key (public endpoints)
+  --tls-cert <path>        Path to TLS certificate file (requires --tls-key)
+  --tls-key <path>         Path to TLS private key file (requires --tls-cert)
+  --rate-limit <rps>       Enable per-IP token-bucket rate limiting at this
+                           requests/second rate. Requests beyond the limit
+                           receive 429 Too Many Requests.
+  --rate-limit-burst <n>   Burst capacity for --rate-limit (default: ceil(rps),
+                           minimum 1). Requires --rate-limit.
+  --pjrt <path>            Path to PJRT plugin .so for accelerator backend
 
 ENDPOINTS:
   POST /v1/chat/completions   Chat completion
@@ -265,6 +365,8 @@ func (c *ServeCommand) Examples() []string {
 		"serve google/gemma-3-1b --port 9090",
 		"serve google/gemma-3-1b --gpus 0,1,2,3",
 		"serve google/gemma-3-1b --pjrt /usr/lib/pjrt_cpu.so",
+		"serve google/gemma-3-1b --rate-limit 10 --rate-limit-burst 20",
+		"serve google/gemma-3-1b --keystore /var/lib/zerfoo/apikeys.db",
 	}
 }
 

--- a/cmd/cli/serve_test.go
+++ b/cmd/cli/serve_test.go
@@ -5,10 +5,15 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zerfoo/zerfoo/inference"
+	"github.com/zerfoo/zerfoo/serve"
+	"github.com/zerfoo/zerfoo/serve/security"
 	"github.com/zerfoo/zerfoo/serve/shutdown"
 )
 
@@ -354,6 +359,205 @@ func TestServeCommand_GPUsFlagValid(t *testing.T) {
 	cancel()
 	err := <-errCh
 	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+}
+
+// waitForServer blocks until a *serve.Server arrives on ch or the timeout
+// elapses. It exists so tests exercising cmd.newServer's DI hook don't hang
+// forever if Run fails to reach server construction.
+func waitForServer(t *testing.T, ch <-chan *serve.Server) *serve.Server {
+	t.Helper()
+	select {
+	case srv := <-ch:
+		return srv
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server construction")
+		return nil
+	}
+}
+
+func TestServeCommand_RateLimitFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"rate-limit missing value", []string{"--rate-limit"}, "--rate-limit requires a value"},
+		{"rate-limit non-numeric", []string{"--rate-limit", "abc", "test-model"}, "invalid --rate-limit value"},
+		{"rate-limit zero", []string{"--rate-limit", "0", "test-model"}, "invalid --rate-limit value"},
+		{"rate-limit negative", []string{"--rate-limit", "-5", "test-model"}, "invalid --rate-limit value"},
+		{"rate-limit-burst missing value", []string{"--rate-limit-burst"}, "--rate-limit-burst requires a value"},
+		{"rate-limit-burst non-numeric", []string{"--rate-limit-burst", "abc", "test-model"}, "invalid --rate-limit-burst value"},
+		{"rate-limit-burst zero", []string{"--rate-limit", "1", "--rate-limit-burst", "0", "test-model"}, "invalid --rate-limit-burst value"},
+		{"rate-limit-burst without rate-limit", []string{"--rate-limit-burst", "5", "test-model"}, "--rate-limit-burst requires --rate-limit"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			cmd := NewServeCommand(nil, &out)
+			cmd.loadFn = func(_ string, _ ...inference.Option) (*inference.Model, error) {
+				return nil, errors.New("should not be called")
+			}
+			err := cmd.Run(context.Background(), tc.args)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestServeCommand_KeystoreFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"keystore missing value", []string{"--keystore"}, "--keystore requires a value"},
+		{"keystore unopenable path", []string{"--keystore", "/nonexistent-dir-zf-t145/apikeys.db", "test-model"}, "open --keystore"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			cmd := NewServeCommand(nil, &out)
+			cmd.loadFn = func(_ string, _ ...inference.Option) (*inference.Model, error) {
+				return nil, errors.New("should not be called")
+			}
+			err := cmd.Run(context.Background(), tc.args)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestServeCommand_RateLimitWiring verifies that --rate-limit/--rate-limit-burst
+// actually construct a serve.Server with a functioning rate limiter (T145.1):
+// the server built by the CLI's newServer hook must reject the request that
+// exceeds the configured burst with 429, not just accept the flag silently.
+func TestServeCommand_RateLimitWiring(t *testing.T) {
+	mdl := buildCLITestModel(t)
+	var out bytes.Buffer
+	cmd := NewServeCommand(nil, &out)
+	cmd.loadFn = func(_ string, _ ...inference.Option) (*inference.Model, error) {
+		return mdl, nil
+	}
+
+	serverCh := make(chan *serve.Server, 1)
+	cmd.newServer = func(m *inference.Model, opts ...serve.ServerOption) *serve.Server {
+		s := serve.NewServer(m, opts...)
+		serverCh <- s
+		return s
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cmd.Run(ctx, []string{
+			"--port", "0", "--allow-no-auth",
+			"--rate-limit", "1", "--rate-limit-burst", "1",
+			"test-model",
+		})
+	}()
+
+	srv := waitForServer(t, serverCh)
+	handler := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.RemoteAddr = "10.0.0.5:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first request: got status %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req2.RemoteAddr = "10.0.0.5:1234"
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request: got status %d, want %d; body=%s", rec2.Code, http.StatusTooManyRequests, rec2.Body.String())
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+}
+
+// TestServeCommand_KeystoreWiring verifies that --keystore opens the given
+// bbolt file and wires it into the server's scope-based auth (T145.1): a
+// pre-provisioned read_only key must authenticate and authorize a GET
+// request, and a request without any credentials must be rejected.
+func TestServeCommand_KeystoreWiring(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "apikeys.db")
+
+	// Pre-populate the keystore, then close it -- bbolt takes an exclusive
+	// file lock, so the backend must be closed before the CLI opens the
+	// same path.
+	backend, err := security.NewBboltKeyStoreBackend(dbPath)
+	if err != nil {
+		t.Fatalf("NewBboltKeyStoreBackend: %v", err)
+	}
+	ks := security.NewKeyStore(security.WithBackend(backend))
+	rawKey, _, err := ks.Create("t145-test-key", []security.Scope{security.ScopeReadOnly}, time.Time{})
+	if err != nil {
+		t.Fatalf("Create key: %v", err)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("close backend: %v", err)
+	}
+
+	mdl := buildCLITestModel(t)
+	var out bytes.Buffer
+	cmd := NewServeCommand(nil, &out)
+	cmd.loadFn = func(_ string, _ ...inference.Option) (*inference.Model, error) {
+		return mdl, nil
+	}
+
+	serverCh := make(chan *serve.Server, 1)
+	cmd.newServer = func(m *inference.Model, opts ...serve.ServerOption) *serve.Server {
+		s := serve.NewServer(m, opts...)
+		serverCh <- s
+		return s
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		// Deliberately no --api-key/--allow-no-auth: --keystore alone must
+		// satisfy the "authentication configured" opt-in check.
+		errCh <- cmd.Run(ctx, []string{"--port", "0", "--keystore", dbPath, "test-model"})
+	}()
+
+	srv := waitForServer(t, serverCh)
+	handler := srv.Handler()
+
+	unauth := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, unauth)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("no credentials: got status %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+
+	authed := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	authed.Header.Set("Authorization", "Bearer "+rawKey)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, authed)
+	if rec2.Code != http.StatusOK {
+		t.Errorf("valid keystore key: got status %d, want %d; body=%s", rec2.Code, http.StatusOK, rec2.Body.String())
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
 		t.Fatalf("Run error: %v", err)
 	}
 }


### PR DESCRIPTION
Closes the Wave Sec-5 `T145.1` task: expose the already-written serve security defenses (rate limiter + bbolt API key store) through the `serve` CLI, per ADR-094 "ship the defense you write" and deep-review 002 SERVE findings (UC-H2-008/010).

## Flags added
- `--rate-limit <rps>` / `--rate-limit-burst <n>` -> `serve.WithRateLimiter(security.NewRateLimiter(rps, burst))`; burst defaults to `ceil(rps)`. Burst without a rate is rejected.
- `--keystore <path>` -> opens a scoped bbolt key store **before** model load (bad path fails fast) and installs `serve.WithKeyStore`; counts as configured auth alongside `--api-key`/`ZERFOO_API_KEY`.

## Shutdown ordering
Keystore `bboltCloser` is registered with the shutdown coordinator **before** the server, so reverse-order shutdown drains the listener -> stops the rate-limiter cleanup goroutine (T142.3) -> closes the bbolt handle last.

## Verification
`go build ./...`, `go vet ./cmd/cli/... ./serve/...`, and `go test ./cmd/cli/... ./serve/...` all green (cmd/cli 2.5s). New `serve_test.go` cases cover flag parsing, validation errors, and mutual-requirement guards.

Unblocks **T145.2** (deep-review 002 closeout).